### PR TITLE
 change standalone.yml

### DIFF
--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -1,7 +1,6 @@
 version: "3"
 services:
   mysql:
-    platform: linux/x86_64
     image: mysql:5.7
     networks:
       - net


### PR DESCRIPTION
That platform is not really need,
I get an error if I run with this:
ERROR: The Compose file './docker-compose.standalone.yml' is invalid because:
Unsupported config option for services.mysql: 'platform'
So I think need remove that