### PR TITLE
fix: service ports are consistent with deployment

### DIFF
--- a/data/helm/clickvisual/templates/service.yaml
+++ b/data/helm/clickvisual/templates/service.yaml
@@ -7,9 +7,13 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
+    - name: server
+      port: { { .Values.service.port } }
       protocol: TCP
-      name: http
+      targetPort: server
+    - name: governor
+      port: 19011
+      protocol: TCP
+      targetPort: governor
   selector:
     {{- include "clickvisual.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
**Q:** endpoints is always none

Maybe this is caused by the service port... `not found targetPort: http`

test out yaml: `helm template clickvisual data/helm/clickvisual --set image.tag=latest`
```yaml
---
# Source: clickvisual/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: clickvisual
data:
    default.toml: |-
---
# Source: clickvisual/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: clickvisual
  labels:
    helm.sh/chart: clickvisual-0.0.1
    app.kubernetes.io/name: clickvisual
    app.kubernetes.io/instance: clickvisual
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  ports:
    - name: server
      port: 19001
      protocol: TCP
      targetPort: server
    - name: governor
      port: 19011
      protocol: TCP
      targetPort: governor
  selector:
    app.kubernetes.io/name: clickvisual
    app.kubernetes.io/instance: clickvisual
---
# Source: clickvisual/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: clickvisual
  labels:
    helm.sh/chart: clickvisual-0.0.1
    app.kubernetes.io/name: clickvisual
    app.kubernetes.io/instance: clickvisual
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: clickvisual
      app.kubernetes.io/instance: clickvisual
  template:
    metadata:
      labels:
        app.kubernetes.io/name: clickvisual
        app.kubernetes.io/instance: clickvisual
    spec:
      securityContext:
        {}
      containers:
        - name: clickvisual
          env:
            - name: EGO_DEBUG
              value: "true"
            - name: EGO_CONFIG_PATH
              value: "config/default.toml"
            - name: EGO_LOG_WRITER
              value: "stderr"
          securityContext:
            {}
          image: "clickvisual/clickvisual:latest"
          imagePullPolicy: IfNotPresent
          command:
            - /bin/sh
            - -c
            - ./bin/clickvisual
          ports:
            - name: server
              containerPort: 19001
              protocol: TCP
            - name: governor
              containerPort: 19011
              protocol: TCP
          resources:
            limits:
              cpu: 1000m
              memory: 512Mi
            requests:
              cpu: 500m
              memory: 256Mi
          volumeMounts:
            - mountPath: /clickvisual/configs
              name: config-volume-clickvisual
      volumes:
      - name: config-volume-clickvisual
        projected:
          defaultMode: 420
          sources:
            - configMap:
                name: clickvisual
---
# Source: clickvisual/templates/tests/test-connection.yaml
apiVersion: v1
kind: Pod
metadata:
  name: "clickvisual-test-connection"
  labels:
    helm.sh/chart: clickvisual-0.0.1
    app.kubernetes.io/name: clickvisual
    app.kubernetes.io/instance: clickvisual
    app.kubernetes.io/managed-by: Helm
  annotations:
    "helm.sh/hook": test
spec:
  containers:
    - name: wget
      image: busybox
      command: ['wget']
      args: ['clickvisual:19001']
  restartPolicy: Never
```