### PR TITLE
fix: service yaml parse error on helm template

### DIFF
--- a/data/helm/clickvisual/templates/service.yaml
+++ b/data/helm/clickvisual/templates/service.yaml
@@ -8,7 +8,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - name: server
-      port: { { .Values.service.port } }
+      port: {{ .Values.service.port }}
       protocol: TCP
       targetPort: server
     - name: governor


### PR DESCRIPTION
`$ helm template clickvisual data/helm/clickvisual --set image.tag=latest > clickvisual.yaml`

---

```bash
Error: YAML parse error on clickvisual/templates/service.yaml: error converting YAML to JSON: yaml: invalid map key: map[interface {}]interface {}{".Values.service.port":interface {}(nil)}

Use --debug flag to render out invalid YAML
```