### PR TITLE
feat: One-click log expansion currently applies only to the first-layer structure

### DIFF
--- a/ui/src/components/JsonView/JsonArray/index.tsx
+++ b/ui/src/components/JsonView/JsonArray/index.tsx
@@ -5,13 +5,15 @@ import JsonValue from "@/components/JsonView/JsonValue";
 import { useState } from "react";
 type JsonArrayProps = {
   data: Array<any>;
+  hierarchy: number;
 };
-const JsonArray = ({ data, ...restProps }: JsonArrayProps) => {
+const JsonArray = ({ data, hierarchy, ...restProps }: JsonArrayProps) => {
   const [isShowJson, setIsShowJson] = useState<boolean>(false);
 
   const indentStyle = {
     paddingLeft: "20px",
   };
+
   return (
     <div className={classNames(jsonViewStyles.jsonView)}>
       {data.length > 0 &&
@@ -39,7 +41,12 @@ const JsonArray = ({ data, ...restProps }: JsonArrayProps) => {
               className={classNames(jsonViewStyles.jsonViewArrayItem)}
               key={idx}
             >
-              <JsonValue jsonKey={item} val={item} {...restProps} />
+              <JsonValue
+                jsonKey={item}
+                val={item}
+                hierarchy={hierarchy + 1}
+                {...restProps}
+              />
               {isLast ? "" : ","}
             </div>
           );

--- a/ui/src/components/JsonView/JsonData/index.tsx
+++ b/ui/src/components/JsonView/JsonData/index.tsx
@@ -12,8 +12,9 @@ import JsonArray from "@/components/JsonView/JsonArray";
  */
 type JsonDataProps = {
   data: object;
+  hierarchy: number;
 } & _CommonProps;
-const JsonData = ({ data, ...restProps }: JsonDataProps) => {
+const JsonData = ({ data, hierarchy, ...restProps }: JsonDataProps) => {
   const [isShowJson, setIsShowJson] = useState<boolean>(false);
   const { secondaryIndexKeys, onClickValue, foldingChecked } = restProps;
 
@@ -29,7 +30,9 @@ const JsonData = ({ data, ...restProps }: JsonDataProps) => {
   }, []);
 
   useEffect(() => {
-    setIsShowJson(!foldingChecked);
+    if (hierarchy == 1) {
+      setIsShowJson(!foldingChecked);
+    }
   }, [foldingChecked]);
 
   /**
@@ -69,6 +72,7 @@ const JsonData = ({ data, ...restProps }: JsonDataProps) => {
           val={val}
           isIndex={isIndex()}
           indexField={indexKey}
+          hierarchy={hierarchy + 1}
           {...restProps}
           onClickValue={onClickValue}
         />
@@ -78,14 +82,8 @@ const JsonData = ({ data, ...restProps }: JsonDataProps) => {
 
   if (!data) return <div style={indentStyle} />;
 
-  if (data instanceof Array) return <JsonArray data={data} />;
-  // todo: 此处应该仅渲染 object
-  // let newData: object;
-  // if (typeof data == "string") {
-  //   newData = JSON.parse(data);
-  // } else {
-  //   newData = data;
-  // }
+  if (data instanceof Array)
+    return <JsonArray data={data} hierarchy={hierarchy + 1} />;
   let keys = Object.keys(data);
   let kvList: JSX.Element[] = [];
   keys.forEach((k, idx) => {

--- a/ui/src/components/JsonView/JsonValue/index.tsx
+++ b/ui/src/components/JsonView/JsonValue/index.tsx
@@ -2,9 +2,50 @@ import jsonViewStyles from "@/components/JsonView/index.less";
 import JsonData from "@/components/JsonView/JsonData";
 import classNames from "classnames";
 import JsonStringValue from "@/components/JsonView/JsonStringValue";
-import { useMemo, useState } from "react";
+import { Key, useMemo, useState } from "react";
 import { CaretDownOutlined, CaretRightOutlined } from "@ant-design/icons";
 import ClickMenu from "@/pages/DataLogs/components/QueryResult/Content/RawLog/ClickMenu";
+
+const indentStyle = {
+  paddingLeft: "20px",
+};
+
+const JsonArr = (props: {
+  jsonKey: any;
+  restProps: any;
+  hierarchy: number;
+  val: any;
+  isShowArr: boolean;
+}) => {
+  const { jsonKey, restProps, hierarchy, val, isShowArr } = props;
+
+  return (
+    <>
+      {val.length > 0 &&
+        isShowArr &&
+        val.map((item: any, idx: Key | null | undefined) => {
+          let isLast = idx === val.length - 1;
+          return (
+            <div
+              style={indentStyle}
+              className={classNames(jsonViewStyles.jsonViewArrayItem)}
+              key={idx}
+            >
+              <JsonValue
+                jsonKey={jsonKey}
+                val={item}
+                {...restProps}
+                isIndex={false}
+                indexField={undefined}
+                hierarchy={hierarchy + 1}
+              />
+              {isLast ? "" : ","}
+            </div>
+          );
+        })}
+    </>
+  );
+};
 
 /**
  * 渲染字段
@@ -33,11 +74,8 @@ const JsonValue = ({
     indexField,
     onInsertExclusion,
   } = restProps;
-  const [isShowArr, setIsShowArr] = useState<boolean>(true);
+  const [isShowArr, setIsShowArr] = useState<boolean>(false);
 
-  const indentStyle = {
-    paddingLeft: "20px",
-  };
   let dom: JSX.Element = <></>;
   const highLightFlag = useMemo(() => {
     if (!highLightValue || ["object", "string"].includes(typeof val))
@@ -81,7 +119,16 @@ const JsonValue = ({
                 </div>
               ))}
             <span>[</span>
-            {val.length > 0 &&
+            {
+              <JsonArr
+                val={val}
+                jsonKey={jsonKey}
+                restProps={restProps}
+                hierarchy={hierarchy + 1}
+                isShowArr={isShowArr}
+              />
+            }
+            {/* {val.length > 0 &&
               isShowArr &&
               val.map((item, idx) => {
                 let isLast = idx === val.length - 1;
@@ -102,7 +149,7 @@ const JsonValue = ({
                     {isLast ? "" : ","}
                   </div>
                 );
-              })}
+              })} */}
             <span>]</span>
           </span>
         );

--- a/ui/src/components/JsonView/JsonValue/index.tsx
+++ b/ui/src/components/JsonView/JsonValue/index.tsx
@@ -17,9 +17,15 @@ type JsonValueProps = {
   val: any;
   isIndex?: boolean;
   indexField?: string;
+  hierarchy: number;
 } & _CommonProps;
 
-const JsonValue = ({ jsonKey, val, ...restProps }: JsonValueProps) => {
+const JsonValue = ({
+  jsonKey,
+  val,
+  hierarchy,
+  ...restProps
+}: JsonValueProps) => {
   const {
     onClickValue,
     highLightValue,
@@ -91,6 +97,7 @@ const JsonValue = ({ jsonKey, val, ...restProps }: JsonValueProps) => {
                       {...restProps}
                       isIndex={false}
                       indexField={undefined}
+                      hierarchy={hierarchy + 1}
                     />
                     {isLast ? "" : ","}
                   </div>
@@ -106,7 +113,7 @@ const JsonValue = ({ jsonKey, val, ...restProps }: JsonValueProps) => {
       } else {
         dom = (
           <span className={classNames(jsonViewStyles.jsonViewValue)}>
-            <JsonData data={val} {...restProps} />
+            <JsonData data={val} {...restProps} hierarchy={hierarchy + 1} />
           </span>
         );
       }

--- a/ui/src/components/JsonView/index.tsx
+++ b/ui/src/components/JsonView/index.tsx
@@ -3,6 +3,7 @@ import JsonData from "@/components/JsonView/JsonData";
 
 type JsonViewProps = {
   data: any;
+  hierarchy: number;
 } & _CommonProps;
 
 const JsonView = (props: JsonViewProps) => {

--- a/ui/src/locales/en-US.ts
+++ b/ui/src/locales/en-US.ts
@@ -291,7 +291,7 @@ export default {
   "datasource.logLibrary.from.rule.tableName":
     "Please enter lowercase letters, uppercase letters, or underscores",
   "datasource.logLibrary.from.type": "_time_ Field Type",
-  "datasource.logLibrary.from.timeField": "timestamp field",
+  "datasource.logLibrary.from.timeField": "Specify the time field Key name",
   "datasource.logLibrary.from.rawLogField": "rawLog field",
   "datasource.logLibrary.from.days": "Log Retention Days",
   "datasource.logLibrary.from.brokers": "Brokers",
@@ -327,6 +327,7 @@ export default {
 
   "datasource.logLibrary.placeholder.tableName":
     "Please enter the name of the data table in upper or lower case English or underscore",
+  "datasource.logLibrary.usingSystemTime": "Using system time",
   "datasource.logLibrary.placeholder.type": "Please select a table type",
   "datasource.logLibrary.placeholder.days": "Please enter the log to save days",
   "datasource.logLibrary.placeholder.brokers": "kafka:9092",

--- a/ui/src/locales/zh-CN.ts
+++ b/ui/src/locales/zh-CN.ts
@@ -283,8 +283,8 @@ export default {
   "datasource.logLibrary.from.tableName": "数据表名称",
   "datasource.logLibrary.from.rule.tableName":
     "请输入小写字母、大写字母，或下划线",
-  "datasource.logLibrary.from.type": "采集时间类型",
-  "datasource.logLibrary.from.timeField": "采集时间",
+  "datasource.logLibrary.from.type": "时间字段类型",
+  "datasource.logLibrary.from.timeField": "指定时间字段Key名称",
   "datasource.logLibrary.from.rawLogField": "业务日志内容",
   "datasource.logLibrary.from.days": "日志保存天数",
   "datasource.logLibrary.from.brokers": "Brokers",
@@ -314,6 +314,7 @@ export default {
 
   "datasource.logLibrary.placeholder.tableName":
     "请输入数据表名称，支持小写字母、大写字母，或下划线",
+  "datasource.logLibrary.usingSystemTime": "使用系统时间",
   "datasource.logLibrary.placeholder.type": "请选择数据表类型",
   "datasource.logLibrary.placeholder.days": "请输入日志保存天数",
   "datasource.logLibrary.placeholder.brokers": "kafka:9092",
@@ -415,8 +416,7 @@ export default {
   "log.index.empty": "暂未创建字段",
   "log.index.item.empty": "暂无数据",
   "log.index.manage": "字段管理",
-  "log.index.manage.desc":
-    "字段管理",
+  "log.index.manage.desc": "字段管理",
   "log.index.help":
     "橙色背景色的字段是系统字段或用户字段，灰色背景色的字段是未设置字段，统计只对配置的字段生效",
   "log.index.manage.table.header.indexName": "字段名称",

--- a/ui/src/models/datalogs/types.ts
+++ b/ui/src/models/datalogs/types.ts
@@ -37,7 +37,6 @@ export type PaneType = {
   mode?: number;
   rawLogsIndexeList?: IndexInfoType[];
   isTrace: number;
-  linkLogs: any;
 };
 
 export enum hashType {

--- a/ui/src/pages/DataLogs/components/DataSourceMenu/LogLibraryList/DatabaseItem/index.tsx
+++ b/ui/src/pages/DataLogs/components/DataSourceMenu/LogLibraryList/DatabaseItem/index.tsx
@@ -12,6 +12,7 @@ const DatabaseItem = (props: { databasesItem: any; onGetList: any }) => {
     onChangeLogLibraryCreatedModalVisible,
     onChangeAddLogToDatabase,
     onChangeIsEditDatabase,
+    resizeMenuWidth,
     onChangeCurrentEditDatabase,
   } = useModel("dataLogs");
   const { deletedDatabase } = useModel("database");
@@ -138,7 +139,14 @@ const DatabaseItem = (props: { databasesItem: any; onGetList: any }) => {
         overlayClassName={logLibraryListStyles.logLibraryToolTip}
         overlayInnerStyle={{ width: 300 }}
       >
-        <div style={{ width: "100%" }}>
+        <div
+          style={{
+            width: resizeMenuWidth - 62 + "px",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
           <IconFont type="icon-database" style={{ marginRight: "4px" }} />
           {databasesItem.databaseName}
         </div>

--- a/ui/src/pages/DataLogs/components/DataSourceMenu/LogLibraryList/InstanceItem/index.tsx
+++ b/ui/src/pages/DataLogs/components/DataSourceMenu/LogLibraryList/InstanceItem/index.tsx
@@ -13,6 +13,7 @@ const InstanceItem = (props: { instanceItem: any }) => {
     onChangeIsAccessLogLibrary,
     onChangeLogLibraryCreatedModalVisible,
     onChangeIsLogLibraryAllDatabase,
+    resizeMenuWidth,
   } = useModel("dataLogs");
   const { instanceItem } = props;
   const i18n = useIntl();
@@ -68,7 +69,14 @@ const InstanceItem = (props: { instanceItem: any }) => {
         overlayClassName={logLibraryListStyles.logLibraryToolTip}
         overlayInnerStyle={{ width: 300 }}
       >
-        <div style={{ width: "100%" }}>
+        <div
+          style={{
+            width: resizeMenuWidth - 45 + "px",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
           <IconFont type="icon-instance" style={{ marginRight: "4px" }} />
           {instanceItem.instanceName}
         </div>

--- a/ui/src/pages/DataLogs/components/DataSourceMenu/LogLibraryList/LogLibraryItem/index.tsx
+++ b/ui/src/pages/DataLogs/components/DataSourceMenu/LogLibraryList/LogLibraryItem/index.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import logLibraryListStyles from "@/pages/DataLogs/components/DataSourceMenu/LogLibraryList/index.less";
-import {Dropdown, Menu, message, Tooltip} from "antd";
+import { Dropdown, Menu, message, Tooltip } from "antd";
 import {
   ApartmentOutlined,
   CalendarOutlined,
@@ -17,19 +17,19 @@ import {
   MINUTES_UNIT_TIME,
   PAGE_SIZE,
 } from "@/config/config";
-import {useModel} from "@@/plugin-model/useModel";
-import {useIntl} from "umi";
+import { useModel } from "@@/plugin-model/useModel";
+import { useIntl } from "umi";
 import lodash from "lodash";
 import moment from "moment";
-import {currentTimeStamp} from "@/utils/momentUtils";
+import { currentTimeStamp } from "@/utils/momentUtils";
 import deletedModal from "@/components/DeletedModal";
-import {IndexInfoType, TablesResponse} from "@/services/dataLogs";
+import { IndexInfoType, TablesResponse } from "@/services/dataLogs";
 import useTimeOptions from "@/pages/DataLogs/hooks/useTimeOptions";
-import {DefaultPane} from "@/models/datalogs/useLogPanes";
-import {RestUrlStates} from "@/pages/DataLogs/hooks/useLogUrlParams";
+import { DefaultPane } from "@/models/datalogs/useLogPanes";
+import { RestUrlStates } from "@/pages/DataLogs/hooks/useLogUrlParams";
 import useUrlState from "@ahooksjs/use-url-state";
-import {PaneType} from "@/models/datalogs/types";
-import {useEffect, useMemo, useRef} from "react";
+import { PaneType } from "@/models/datalogs/types";
+import { useEffect, useMemo, useRef } from "react";
 
 type LogLibraryItemProps = {
   logLibrary: TablesResponse;

--- a/ui/src/pages/DataLogs/components/DataSourceMenu/ModalCreatedLogLibrary/NewTable/JsonAsString/index.less
+++ b/ui/src/pages/DataLogs/components/DataSourceMenu/ModalCreatedLogLibrary/NewTable/JsonAsString/index.less
@@ -1,0 +1,53 @@
+.flexBox {
+  display: flex;
+  flex-wrap: wrap;
+  border: 1px solid #ccc;
+
+  .lableBox {
+    display: flex;
+    width: 100%;
+    div {
+      flex: 1;
+      padding-left: 10px;
+      line-height: 40px;
+      text-align: left;
+      background-color: #eee;
+      border-bottom: 1px solid #ccc;
+    }
+    :nth-child(1) {
+      border-right: 1px solid #ccc;
+    }
+  }
+
+  .itemBox {
+    display: flex;
+    width: 100%;
+
+    .timeField {
+      display: flex;
+      flex: 1;
+      align-items: center;
+      justify-content: center;
+      line-height: 50px;
+
+      :global .ant-form-item {
+        width: 90%;
+        margin: 0;
+        padding: 10px 0;
+      }
+    }
+    .timeFieldType {
+      display: flex;
+      flex: 1;
+      align-items: center;
+      justify-content: center;
+      line-height: 50px;
+
+      :global .ant-form-item {
+        width: 90%;
+        margin: 0;
+        padding: 10px 0;
+      }
+    }
+  }
+}

--- a/ui/src/pages/DataLogs/components/DataSourceMenu/ModalCreatedLogLibrary/NewTable/JsonAsString/index.tsx
+++ b/ui/src/pages/DataLogs/components/DataSourceMenu/ModalCreatedLogLibrary/NewTable/JsonAsString/index.tsx
@@ -1,4 +1,5 @@
-import { Form, Input, Select } from "antd";
+import { Form, Input, Select, Switch } from "antd";
+import styles from "./index.less";
 import { logLibraryTypes } from "@/pages/DataLogs/components/DataSourceMenu/ModalCreatedLogLibrary";
 import { useIntl } from "umi";
 
@@ -10,19 +11,13 @@ const JsonAsString = () => {
   return (
     <>
       <Form.Item
-        label="使用kafka采集时间作为时间轴"
+        label={i18n.formatMessage({
+          id: "datasource.logLibrary.usingSystemTime",
+        })}
         name="isKafkaTimestamp"
-        required
-        initialValue={1}
+        initialValue={true}
       >
-        <Select
-          placeholder={`${i18n.formatMessage({
-            id: "datasource.logLibrary.placeholder.type",
-          })}`}
-        >
-          <Option value={1}>yes</Option>
-          <Option value={0}>no</Option>
-        </Select>
+        <Switch defaultChecked />
       </Form.Item>
       <Form.Item
         noStyle
@@ -32,36 +27,46 @@ const JsonAsString = () => {
       >
         {({ getFieldValue }) => {
           const isKafkaTimestamp = getFieldValue("isKafkaTimestamp");
-          if (isKafkaTimestamp == 1) return <></>;
+          if (Number(isKafkaTimestamp) == 1) return <></>;
           return (
-            <>
-              <Form.Item
-                label={i18n.formatMessage({
-                  id: "datasource.logLibrary.from.timeField",
-                })}
-                name={"timeField"}
-              >
-                <Input />
-              </Form.Item>
-              <Form.Item
-                label={i18n.formatMessage({
-                  id: "datasource.logLibrary.from.type",
-                })}
-                name={"timeFieldType"}
-              >
-                <Select
-                  placeholder={`${i18n.formatMessage({
-                    id: "datasource.logLibrary.placeholder.type",
-                  })}`}
-                >
-                  {logLibraryTypes.map((item) => (
-                    <Option key={item.value} value={item.value}>
-                      {item.type}
-                    </Option>
-                  ))}
-                </Select>
-              </Form.Item>
-            </>
+            <Form.Item label=" " colon={false}>
+              <div className={styles.flexBox}>
+                <div className={styles.lableBox}>
+                  <div>
+                    {i18n.formatMessage({
+                      id: "datasource.logLibrary.from.timeField",
+                    })}
+                  </div>
+                  <div>
+                    {i18n.formatMessage({
+                      id: "datasource.logLibrary.from.type",
+                    })}
+                  </div>
+                </div>
+                <div className={styles.itemBox}>
+                  <div className={styles.timeField}>
+                    <Form.Item name={"timeField"}>
+                      <Input placeholder="timestamp" />
+                    </Form.Item>
+                  </div>
+                  <div className={styles.timeFieldType}>
+                    <Form.Item name={"timeFieldType"}>
+                      <Select
+                        placeholder={`${i18n.formatMessage({
+                          id: "datasource.logLibrary.placeholder.type",
+                        })}`}
+                      >
+                        {logLibraryTypes.map((item) => (
+                          <Option key={item.value} value={item.value}>
+                            {item.type}
+                          </Option>
+                        ))}
+                      </Select>
+                    </Form.Item>
+                  </div>
+                </div>
+              </div>
+            </Form.Item>
           );
         }}
       </Form.Item>

--- a/ui/src/pages/DataLogs/components/DataSourceMenu/ModalCreatedLogLibrary/NewTable/index.tsx
+++ b/ui/src/pages/DataLogs/components/DataSourceMenu/ModalCreatedLogLibrary/NewTable/index.tsx
@@ -41,7 +41,7 @@ const NewTable = (props: {
         />
       </Form.Item>
 
-      {/* ? V3 : V2 */}
+      {/* flag ? V3 : V2 */}
       {mode == 2 ? (
         <JsonAsString />
       ) : (

--- a/ui/src/pages/DataLogs/components/DataSourceMenu/ModalCreatedLogLibrary/index.tsx
+++ b/ui/src/pages/DataLogs/components/DataSourceMenu/ModalCreatedLogLibrary/index.tsx
@@ -40,6 +40,7 @@ const ModalCreatedLogLibrary = (props: { onGetList: any }) => {
   const onSubmitHandle = useDebounceFn(
     (field: any) => {
       // delete field.source;
+      field.isKafkaTimestamp = Number(field.isKafkaTimestamp);
       const response =
         field.mode === 1
           ? doCreatedLocalLogLibraryBatch.run(field.instance, {

--- a/ui/src/pages/DataLogs/components/QueryResult/Content/RawLog/RawLogList/LogItem/LogContentParse/index.tsx
+++ b/ui/src/pages/DataLogs/components/QueryResult/Content/RawLog/RawLogList/LogItem/LogContentParse/index.tsx
@@ -31,7 +31,6 @@ const LogContentParse = ({
   const isNullList = ["\n", "\r\n", "", " "];
 
   let content;
-  // todo: 这里不应该判断是否可以转json，此时应该是已经有了确定的数据结构
   if (typeof logContent !== "object") {
     if (isNullList.includes(logContent)) {
       content = "";
@@ -58,6 +57,7 @@ const LogContentParse = ({
           quickInsertLikeExclusion={quickInsertLikeExclusion}
           highLightValue={highlightKeywords}
           foldingChecked={foldingChecked}
+          hierarchy={1}
         />
       </>
     );


### PR DESCRIPTION
feat: One-click log expansion currently applies only to the first-layer structure
fix: The array in the object is expanded by default
fix: The overflow of the tree log library displays ellipses
feat: Optimize and update the interface for creating log libraries