### PR TITLE
feat: other(tcp) dsn format to clickhouse dsn, password support includes clickhouse allowed unicode

### DIFF
--- a/api/internal/service/instance_test.go
+++ b/api/internal/service/instance_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"net/url"
 	"os"
 	"reflect"
@@ -20,6 +21,11 @@ func TestMain(m *testing.M) {
 }
 
 func Test_clickHouseLink(t *testing.T) {
+	// The username may contain Latin letters, numbers, hyphens, and underscores, but must begin with a letter or an underscore.
+	user := "root-_123"
+	// The password must be between 8 and 128 characters.
+	passwd := url.QueryEscape("shimo*!@#")
+
 	type args struct {
 		dsn string
 	}
@@ -33,24 +39,47 @@ func Test_clickHouseLink(t *testing.T) {
 		{
 			name: "use http scheme",
 			args: args{
-				dsn: "http://127.0.0.1:8123?username=root&password=shimo",
+				dsn: fmt.Sprintf("http://127.0.0.1:8123?username=%s&password=%s", user, passwd),
 			},
 		},
 		{
 			name: "use https scheme", // localhost server no tls
 			args: args{
-				dsn: "https://127.0.0.1:8123?username=root&password=shimo&secure=true",
+				dsn: fmt.Sprintf("https://127.0.0.1:8123?username=%s&password=%s&secure=true", user, passwd),
 			},
 			wantErr: &url.Error{
 				Op:  "Post",
-				URL: "https://root:***@127.0.0.1:8123?database=default&default_format=Native",
+				URL: fmt.Sprintf("https://%s:***@127.0.0.1:8123?database=default&default_format=Native", user),
+				Err: errors.New("http: server gave HTTP response to HTTPS client"),
+			},
+		},
+		{
+			name: "use basic auth http scheme",
+			args: args{
+				dsn: fmt.Sprintf("http://%s:%s@127.0.0.1:8123", user, passwd),
+			},
+		},
+		{
+			name: "use basic auth https scheme", // localhost server no tls
+			args: args{
+				dsn: fmt.Sprintf("https://%s:%s@127.0.0.1:8123?secure=true", user, passwd),
+			},
+			wantErr: &url.Error{
+				Op:  "Post",
+				URL: fmt.Sprintf("https://%s:***@127.0.0.1:8123?database=default&default_format=Native", user),
 				Err: errors.New("http: server gave HTTP response to HTTPS client"),
 			},
 		},
 		{
 			name: "use tcp scheme",
 			args: args{
-				dsn: "tcp://127.0.0.1:9000?username=root&password=shimo",
+				dsn: fmt.Sprintf("tcp://127.0.0.1:9000?username=%s&password=%s", user, passwd),
+			},
+		},
+		{
+			name: "use clickhouse scheme",
+			args: args{
+				dsn: fmt.Sprintf("clickhouse://%s:%s@127.0.0.1:9000", user, passwd),
 			},
 		},
 	}

--- a/api/pkg/utils/clickhouse.go
+++ b/api/pkg/utils/clickhouse.go
@@ -17,6 +17,7 @@ func ClickhouseDsnConvert(req string) (res string) {
 		invoker.Logger.Error("clickhouseDsnConvert", elog.Any("error", err))
 		return req
 	}
+
 	query := u.Query()
 	query.Del("write_timeout")
 	if strings.HasPrefix(req, "clickhouse://") ||
@@ -30,9 +31,15 @@ func ClickhouseDsnConvert(req string) (res string) {
 	if database == "" {
 		database = "default"
 	}
-	res = fmt.Sprintf("clickhouse://%s:%s@%s/%s", query.Get("username"), query.Get("password"), u.Host, database)
-	query.Del("username")
+
+	password := query.Get("password")
+	if password != "" {
+		password = url.QueryEscape(query.Get("password")) // 处理特殊字符
+	}
+
+	res = fmt.Sprintf("clickhouse://%s:%s@%s/%s", query.Get("username"), password, u.Host, database)
 	query.Del("password")
+	query.Del("username")
 	query.Del("database")
 
 	queryValAssembly(query, "read_timeout", "ms")

--- a/api/pkg/utils/clickhouse_test.go
+++ b/api/pkg/utils/clickhouse_test.go
@@ -1,10 +1,17 @@
 package utils
 
 import (
+	"fmt"
+	"net/url"
 	"testing"
 )
 
 func TestClickhouseDsnConvert(t *testing.T) {
+	// The username may contain Latin letters, numbers, hyphens, and underscores, but must begin with a letter or an underscore.
+	user := "root-_123"
+	// The password must be between 8 and 128 characters.
+	passwd := url.QueryEscape("shimo*!@#")
+
 	type args struct {
 		req string
 	}
@@ -16,37 +23,51 @@ func TestClickhouseDsnConvert(t *testing.T) {
 		{
 			"tcp to clickhouse",
 			args{
-				"tcp://127.0.0.1:9000?username=clickvisual&password=clickvisual&read_timeout=10&debug=true",
+				fmt.Sprintf("tcp://127.0.0.1:9000?username=%s&password=%s&read_timeout=10&debug=true", user, passwd),
 			},
-			"clickhouse://clickvisual:clickvisual@127.0.0.1:9000/default?debug=true&read_timeout=10ms",
+			fmt.Sprintf("clickhouse://%s:%s@127.0.0.1:9000/default?debug=true&read_timeout=10ms", user, passwd),
 		},
 		{
 			"remove unknown write_timeout on tcp",
 			args{
-				"tcp://127.0.0.1:9000?username=clickvisual&password=clickvisual&debug=true&read_timeout=10&write_timeout=20ms",
+				fmt.Sprintf("tcp://127.0.0.1:9000?username=%s&password=%s&debug=true&read_timeout=10&write_timeout=20ms", user, passwd),
 			},
-			"clickhouse://clickvisual:clickvisual@127.0.0.1:9000/default?debug=true&read_timeout=10ms",
+			fmt.Sprintf("clickhouse://%s:%s@127.0.0.1:9000/default?debug=true&read_timeout=10ms", user, passwd),
 		},
 		{
 			"remove unknown write_timeout on clickhouse",
 			args{
-				"clickhouse://clickvisual:clickvisual@127.0.0.1:9000/default?debug=true&read_timeout=10ms&write_timeout=20ms",
+				fmt.Sprintf("clickhouse://%s:%s@127.0.0.1:9000/default?debug=true&read_timeout=10ms&write_timeout=20ms", user, passwd),
 			},
-			"clickhouse://clickvisual:clickvisual@127.0.0.1:9000/default?debug=true&read_timeout=10ms",
+			fmt.Sprintf("clickhouse://%s:%s@127.0.0.1:9000/default?debug=true&read_timeout=10ms", user, passwd),
 		},
 		{
 			"remove unknown write_timeout on http",
 			args{
-				"http://clickvisual:clickvisual@127.0.0.1:9000/default?debug=true&read_timeout=10ms&write_timeout=20ms",
+				fmt.Sprintf("http://127.0.0.1:9000/default?debug=true&password=%s&read_timeout=10ms&write_timeout=20ms&username=%s", user, passwd),
 			},
-			"http://clickvisual:clickvisual@127.0.0.1:9000/default?debug=true&read_timeout=10ms",
+			fmt.Sprintf("http://127.0.0.1:9000/default?debug=true&password=%s&read_timeout=10ms&username=%s", user, passwd),
 		},
 		{
 			"remove unknown write_timeout on https",
 			args{
-				"http://clickvisual:clickvisual@127.0.0.1:9000/default?debug=true&read_timeout=10ms&write_timeout=20ms",
+				fmt.Sprintf("https://127.0.0.1:9000/default?debug=true&password=%s&read_timeout=10ms&write_timeout=20ms&secure=true&username=%s", user, passwd),
 			},
-			"http://clickvisual:clickvisual@127.0.0.1:9000/default?debug=true&read_timeout=10ms",
+			fmt.Sprintf("https://127.0.0.1:9000/default?debug=true&password=%s&read_timeout=10ms&secure=true&username=%s", user, passwd),
+		},
+		{
+			"remove unknown write_timeout on http basic auth",
+			args{
+				fmt.Sprintf("http://%s:%s@127.0.0.1:9000/default?debug=true&read_timeout=10ms&write_timeout=20ms", user, passwd),
+			},
+			fmt.Sprintf("http://%s:%s@127.0.0.1:9000/default?debug=true&read_timeout=10ms", user, passwd),
+		},
+		{
+			"remove unknown write_timeout on https basic auth",
+			args{
+				fmt.Sprintf("https://%s:%s@127.0.0.1:9000/default?debug=true&read_timeout=10ms&write_timeout=20ms&secure=true", user, passwd),
+			},
+			fmt.Sprintf("https://%s:%s@127.0.0.1:9000/default?debug=true&read_timeout=10ms&secure=true", user, passwd),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**问题:** 当 tcp dsn 转 clickhouse dsn 时，如果 password 包含一些 clickhouse 允许使用的特殊字符 url encode 之后其实是可以使用的，但由于下方的转换代码中 query 会 url decode，所以直接 fmt %s 到 clickhouse dsn 中会密码错误

**解决:** fmt 前对 password 进行 url encode