### PR TITLE
fix: trim suffix /api/v2/alerts for alertmanager url

### DIFF
--- a/api/internal/service/alert/alertcomponent/prometheus.go
+++ b/api/internal/service/alert/alertcomponent/prometheus.go
@@ -200,7 +200,7 @@ func (p *Prometheus) alertmanagerURLs() ([]string, error) {
 
 	urls := make([]string, len(res.Data.ActiveAlertmanagers))
 	for i := range res.Data.ActiveAlertmanagers {
-		urls[i] = res.Data.ActiveAlertmanagers[i].URL
+		urls[i] = strings.TrimSuffix(res.Data.ActiveAlertmanagers[i].URL, "/api/v2/alerts")
 	}
 
 	return urls, nil


### PR DESCRIPTION
fix #807