### PR TITLE
Keep the default MySQL password the same as the one in the docker-compose.devops.yml file

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -41,7 +41,7 @@ password = "**"
 [mysql]
 debug = true
 # database DSN
-dsn = "root:root@tcp(127.0.0.1:13306)/clickvisual?charset=utf8mb4&collation=utf8mb4_general_ci&parseTime=True&loc=Local&readTimeout=1s&timeout=1s&writeTimeout=3s"
+dsn = "root:shimo@tcp(127.0.0.1:13306)/clickvisual?charset=utf8mb4&collation=utf8mb4_general_ci&parseTime=True&loc=Local&readTimeout=1s&timeout=1s&writeTimeout=3s"
 # log level
 level = "debug"
 # maximum number of connections in the idle connection pool for database


### PR DESCRIPTION
https://github.com/clickvisual/clickvisual/pull/878  After this pr, the default MySQL password does not match the one in docker-compose.devops.yml. Changing it to be consistent will optimize the development environment build