### PR TITLE
Update the Clickhouse port in docker-compose.devops.yml to expose it to the local host

### DIFF
--- a/docker-compose.devops.yml
+++ b/docker-compose.devops.yml
@@ -110,7 +110,8 @@ services:
     expose:
       - 9000
     ports:
-      - "8123:8123"
+      - "18123:8123"
+      - "19000:9000"
     volumes:
       - ./data/all-in-one/clickhouse/database:/var/lib/clickhouse
       - ./data/all-in-one/clickhouse/logs:/var/log

--- a/docs/docs/en/clickvisual/06join/env.md
+++ b/docs/docs/en/clickvisual/06join/env.md
@@ -31,7 +31,7 @@ fork 代码后，在项目根目录可以看到 `docker-compose.devops.yml`
 
 ### 新增日志库
 创建实例 
-> clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60
+> clickhouse://root:shimo@127.0.0.1:19000?dial_timeout=200ms&max_execution_time=60
 
 ![img_3.png](../../../images/env-3.png)
 

--- a/docs/docs/zh/clickvisual/06join/env.md
+++ b/docs/docs/zh/clickvisual/06join/env.md
@@ -31,7 +31,7 @@ fork 代码后，在项目根目录可以看到 `docker-compose.devops.yml`
 
 ### 新增日志库
 创建实例 
-> clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60
+> clickhouse://root:shimo@127.0.0.1:19000?dial_timeout=200ms&max_execution_time=60
 
 ![img_3.png](../../../images/env-3.png)
 


### PR DESCRIPTION
-   Fixed an issue where Clickhouse exposed the local port as closed, which prevented the development environment from linking。
- Also updated the documentation to make the development environment smoother

Associated pr

-  https://github.com/clickvisual/clickvisual/pull/878