### PR TITLE
fix: update datasource invalid parameter

### DIFF
--- a/ui/src/pages/DataLogs/components/DataSourceMenu/EditDatabaseModel/index.tsx
+++ b/ui/src/pages/DataLogs/components/DataSourceMenu/EditDatabaseModel/index.tsx
@@ -128,7 +128,7 @@ const EditDatabaseModel = (props: {
         </Form.Item>
         <Form.Item
           label={i18n.formatMessage({ id: "database.form.label.name" })}
-          name={"name"}
+          name={"databaseName"}
         >
           <Input disabled />
         </Form.Item>


### PR DESCRIPTION
更新数据库的时候传参与后端接收值不符合导致400报错

具体接口: /api/v1/databases/:id

```
{
  "code": 1,
  "msg": "invalid parameter: Name为必填字段",
  "data": null
}

```

