### PR TITLE
fix: ensure the clickvisual UI port matches the doc

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,7 +170,7 @@ services:
     expose:
       - 9201
     ports:
-      - "18001:19001"
+      - "19001:19001"
       - "19006:19006"
     depends_on:
       - mysql


### PR DESCRIPTION
Fixed #1083

https://github.com/clickvisual/clickvisual/blob/03eb41fb61766a59ebebbc94e59d33bf84d7f3e4/docker-compose.yml#L173

https://github.com/clickvisual/clickvisual/blob/03eb41fb61766a59ebebbc94e59d33bf84d7f3e4/docs/docs/zh/clickvisual/01quickstart/experience-clickvisual-with-docker-compose.md?plain=1#L8