### PR TITLE
Fix: Missing i18n prefix in install-introduce.md

### DIFF
--- a/docs/docs/en/clickvisual/02install/install-introduce.md
+++ b/docs/docs/en/clickvisual/02install/install-introduce.md
@@ -2,7 +2,7 @@
 
 This section discusses the environment preparation required to install ClickVisual and the process of installing ClickVisual on different environments. It contains the following topics:
 
-- [Install require](https://clickvisual.net/clickvisual/02install/install-require.html)
-- [Binary installation](https://clickvisual.net/clickvisual/02install/binary-installation.html)
-- [Docker installation](https://clickvisual.net/clickvisual/02install/docker-installation.html)
-- [Kubernetes Cluster installation](https://clickvisual.net/clickvisual/02install/k8s-installation.html)
+- [Install require](https://clickvisual.net/en/clickvisual/02install/install-require.html)
+- [Binary installation](https://clickvisual.net/en/clickvisual/02install/binary-installation.html)
+- [Docker installation](https://clickvisual.net/en/clickvisual/02install/docker-installation.html)
+- [Kubernetes Cluster installation](https://clickvisual.net/en/clickvisual/02install/k8s-installation.html)

--- a/docs/docs/zh/clickvisual/02install/install-introduce.md
+++ b/docs/docs/zh/clickvisual/02install/install-introduce.md
@@ -2,7 +2,7 @@
 
 本节讨论安装 clickvisual 所需环境准备以及在不同环境上安装 clickvisual 的过程。本节包含以下主题：
 
-- [安装基本要求](https://clickvisual.net/clickvisual/02install/install-require.html)
-- [二进制安装](https://clickvisual.net/clickvisual/02install/binary-installation.html)
-- [Docker 安装](https://clickvisual.net/clickvisual/02install/docker-installation.html)
-- [Kubernetes 集群安装](https://clickvisual.net/clickvisual/02install/k8s-installation.html)
+- [安装基本要求](https://clickvisual.net/zh/clickvisual/02install/install-require.html)
+- [二进制安装](https://clickvisual.net/zh/clickvisual/02install/binary-installation.html)
+- [Docker 安装](https://clickvisual.net/zh/clickvisual/02install/docker-installation.html)
+- [Kubernetes 集群安装](https://clickvisual.net/zh/clickvisual/02install/k8s-installation.html)


### PR DESCRIPTION
Missing i18n prefix in `install-introduce.md`:

```markdown
- [xxx](https://clickvisual.net/clickvisual/02install/install-require.html)
- [xxx](https://clickvisual.net/clickvisual/02install/binary-installation.html)
- [xxx](https://clickvisual.net/clickvisual/02install/docker-installation.html)
- [xxx](https://clickvisual.net/clickvisual/02install/k8s-installation.html)
```