### PR TITLE
Support DateTime64(6) and DateTime64(9)

### DIFF
--- a/api/internal/pkg/model/db/base_table.go
+++ b/api/internal/pkg/model/db/base_table.go
@@ -13,6 +13,8 @@ const (
 	TimeFieldTypeSecond = 1
 	TimeFieldTypeTsMs   = 2 // unix ms
 	TimeFieldTypeDT3    = 3 // DataTime64(3)
+	TimeFieldTypeDT6    = 4 // DataTime64(6)
+	TimeFieldTypeDT9    = 5 // DataTime64(9)
 )
 
 type BaseTable struct {

--- a/api/internal/pkg/utils/string.go
+++ b/api/internal/pkg/utils/string.go
@@ -1,6 +1,10 @@
 package utils
 
-import "math/rand"
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
 
 const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
@@ -58,4 +62,33 @@ func SundaySearch(s, p string, keys map[uint8]int) int {
 		}
 	}
 	return -1
+}
+
+// TimeToPrecisionString formats a time to a string with specified precision
+// precision:
+//
+//	"milli" -> milliseconds (10^-3)
+//	"micro" -> microseconds (10^-6)
+//	"nano"  -> nanoseconds  (10^-9)
+func TimeToPrecisionString(t time.Time, precision string) string {
+	switch precision {
+	case "milli":
+		return formatWithPrecision(t.UnixMilli(), 1e3, 3)
+	case "micro":
+		return formatWithPrecision(t.UnixMicro(), 1e6, 6)
+	case "nano":
+		return formatWithPrecision(t.UnixNano(), 1e9, 9)
+	default:
+		return ""
+	}
+}
+
+// formatWithPrecision formats timestamp with given precision
+// timestamp: Unix timestamp with specific precision
+// divisor: divisor to get seconds part
+// width: number of digits for decimal part
+func formatWithPrecision(timestamp int64, divisor int64, width int) string {
+	seconds := timestamp / divisor
+	fraction := timestamp % divisor
+	return fmt.Sprintf("%d.%0*d", seconds, width, fraction)
 }

--- a/api/internal/service/inquiry/clickhouse/clickhouse.go
+++ b/api/internal/service/inquiry/clickhouse/clickhouse.go
@@ -740,7 +740,9 @@ func (c *ClickHouseX) GetLogs(param view.ReqQuery, tid int) (res view.RespQuery,
 					res.Logs[k][db.TimeFieldSecond] = res.Logs[k][param.TimeField].(int64) / 1000
 					res.Logs[k][db.TimeFieldNanoseconds] = res.Logs[k][param.TimeField].(int64)
 				}
-			} else if param.TimeFieldType == db.TimeFieldTypeDT3 {
+			} else if param.TimeFieldType == db.TimeFieldTypeDT3 ||
+				param.TimeFieldType == db.TimeFieldTypeDT6 ||
+				param.TimeFieldType == db.TimeFieldTypeDT9 {
 				res.Logs[k][db.TimeFieldNanoseconds] = res.Logs[k][param.TimeField]
 			} else {
 				res.Logs[k][db.TimeFieldSecond] = res.Logs[k][param.TimeField]

--- a/api/internal/service/inquiry/clickhouse/clickhouseutils.go
+++ b/api/internal/service/inquiry/clickhouse/clickhouseutils.go
@@ -15,6 +15,7 @@ import (
 	constx2 "github.com/clickvisual/clickvisual/api/internal/pkg/constx"
 	db2 "github.com/clickvisual/clickvisual/api/internal/pkg/model/db"
 	view2 "github.com/clickvisual/clickvisual/api/internal/pkg/model/view"
+	"github.com/clickvisual/clickvisual/api/internal/pkg/utils"
 	"github.com/clickvisual/clickvisual/api/internal/service/inquiry/factory"
 )
 
@@ -96,6 +97,10 @@ func genTimeCondition(param view2.ReqQuery) string {
 		return fmt.Sprintf("%s >= toDateTime(%s) AND %s < toDateTime(%s)", param.TimeField, "%d", param.TimeField, "%d")
 	case db2.TimeFieldTypeDT3:
 		return fmt.Sprintf("%s >= toDateTime64(%s, 3) AND %s < toDateTime64(%s, 3)", param.TimeField, "%d", param.TimeField, "%d")
+	case db2.TimeFieldTypeDT6:
+		return fmt.Sprintf("%s >= toDateTime64(%s, 6) AND %s < toDateTime64(%s, 6)", param.TimeField, "%d", param.TimeField, "%d")
+	case db2.TimeFieldTypeDT9:
+		return fmt.Sprintf("%s >= toDateTime64(%s, 9) AND %s < toDateTime64(%s, 9)", param.TimeField, "%d", param.TimeField, "%d")
 	case db2.TimeFieldTypeTsMs:
 		return fmt.Sprintf("intDiv(%s,1000) >= %s AND intDiv(%s,1000) < %s", param.TimeField, "%d", param.TimeField, "%d")
 	}
@@ -107,6 +112,8 @@ func TransferGroupTimeField(timeField string, timeFieldTyp int) string {
 	case db2.TimeFieldTypeDT:
 		return timeField
 	case db2.TimeFieldTypeDT3:
+	case db2.TimeFieldTypeDT6:
+	case db2.TimeFieldTypeDT9:
 		return timeField
 	case db2.TimeFieldTypeTsMs:
 		return fmt.Sprintf("toDateTime(intDiv(%s,1000))", timeField)
@@ -121,7 +128,11 @@ func genTimeConditionEqual(param view2.ReqQuery, t time.Time) string {
 	case db2.TimeFieldTypeDT:
 		return fmt.Sprintf("toUnixTimestamp(%s) = %d", param.TimeField, t.Unix())
 	case db2.TimeFieldTypeDT3:
-		return fmt.Sprintf("%s = toDateTime64(%f, 3)", param.TimeField, float64(t.UnixMilli())/1000.0)
+		return fmt.Sprintf("%s = toDateTime64('%s', 3)", param.TimeField, utils.TimeToPrecisionString(t, "milli"))
+	case db2.TimeFieldTypeDT6:
+		return fmt.Sprintf("%s = toDateTime64('%s', 6)", param.TimeField, utils.TimeToPrecisionString(t, "micro"))
+	case db2.TimeFieldTypeDT9:
+		return fmt.Sprintf("%s = toDateTime64('%s', 9)", param.TimeField, utils.TimeToPrecisionString(t, "nano"))
 	case db2.TimeFieldTypeTsMs:
 		return fmt.Sprintf("%s = %d", param.TimeField, t.UnixMilli())
 	}

--- a/ui/src/pages/DataLogs/components/DataSourceMenu/ModalCreatedLogLibrary/LocalTable/index.tsx
+++ b/ui/src/pages/DataLogs/components/DataSourceMenu/ModalCreatedLogLibrary/LocalTable/index.tsx
@@ -338,6 +338,8 @@ const LocalTable = ({
                                       >
                                         <Radio.Group>
                                           <Radio value={3}>DateTime64(3)</Radio>
+                                          <Radio value={4}>DateTime64(6)</Radio>
+                                          <Radio value={5}>DateTime64(9)</Radio>
                                         </Radio.Group>
                                       </Form.Item>
                                     );


### PR DESCRIPTION
# 背景

在接入 OpenTelemetry Collector 的时候，ClickHouse 日志表的 `Timestamp` 字段类型是 `DateTime64(9)`。

```sql
Timestamp DateTime64(9) CODEC(Delta(8), ZSTD(1))
```

如果直接在后台选择 `DateTime64(3)` 类型，会因为以下的 SQL 优化导致日志详情不显示（但上方的日志统计显示，因为没有使用优化）。另外 `/api/v1/tables/1/logs` 接口返回的 `query` 字段是 `defaultSQL`，不一定是实际执行的 SQL。下面这两个问题应该都是这个原因引起的 #1021、#1192 。

```go
defaultSQL, optimizeSQL, originalWhere = c.logsSQL(param, tid)
```

因此希望能支持多种精度的 DateTime64

* DateTime64(6)
* DateTime64(9)



# 修改内容

* 添加了一个专门把时间转为字符串的函数 `utils.TimeToPrecisionString`
* `toDateTime64('%s', 3)` 里面的 `%s` 必须用引号括起来，不然转换会丢失精度。

```go
case db2.TimeFieldTypeDT3:
    return fmt.Sprintf("%s = toDateTime64('%s', 3)", param.TimeField, utils.TimeToPrecisionString(t, "milli"))
case db2.TimeFieldTypeDT6:
    return fmt.Sprintf("%s = toDateTime64('%s', 6)", param.TimeField, utils.TimeToPrecisionString(t, "micro"))
case db2.TimeFieldTypeDT9:
    return fmt.Sprintf("%s = toDateTime64('%s', 9)", param.TimeField, utils.TimeToPrecisionString(t, "nano"))
```

* `api/internal/service/inquiry/databend/databendutils.go` 中去除了重复的 import `db2`。

```go
"github.com/clickvisual/clickvisual/api/internal/pkg/model/db"
db2 "github.com/clickvisual/clickvisual/api/internal/pkg/model/db"
```

* 后台添加了两个 `DateTime64` 的选项。

```html
<Radio value={4}>DateTime64(6)</Radio>
<Radio value={5}>DateTime64(9)</Radio>
```

# 测试

* [x] ClickHouse
* [ ] Datebend