### PR TITLE
fix(query): support uppercase AS aliases

### DIFF
--- a/api/internal/pkg/utils/sql.go
+++ b/api/internal/pkg/utils/sql.go
@@ -7,17 +7,54 @@ import (
 
 var regSelectFields = regexp.MustCompile(`^(SELECT|select)([\S\s]+)(FROM|from)`)
 
+func isSQLSpace(char byte) bool {
+	return char == ' ' || char == '\t' || char == '\n' || char == '\r'
+}
+
+func topLevelAliasEnd(field string) int {
+	depth := 0
+	var quote byte
+	aliasEnd := -1
+	for i := 0; i < len(field); i++ {
+		char := field[i]
+		if quote != 0 {
+			if char == quote {
+				if i+1 < len(field) && field[i+1] == quote {
+					i++
+					continue
+				}
+				quote = 0
+			}
+			continue
+		}
+		switch char {
+		case '\'', '"', '`':
+			quote = char
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		default:
+			if depth == 0 && i > 0 && i+2 < len(field) &&
+				strings.EqualFold(field[i:i+2], "as") &&
+				isSQLSpace(field[i-1]) && isSQLSpace(field[i+2]) {
+				aliasEnd = i + 3
+				i++
+			}
+		}
+	}
+	return aliasEnd
+}
+
 func GenerateFieldOrderRules(sql string) ([]string, bool) {
 	regRes := regSelectFields.FindStringSubmatch(sql)
 	if len(regRes) == 4 {
 		res := make([]string, 0)
 		for _, tmp := range strings.Split(strings.TrimSpace(regRes[2]), ",") {
-			if strings.Contains(tmp, " as ") {
-				asArr := strings.Split(tmp, " as ")
-				if len(asArr) != 2 {
-					return nil, false
-				}
-				res = append(res, strings.TrimSpace(asArr[1]))
+			if aliasEnd := topLevelAliasEnd(tmp); aliasEnd >= 0 {
+				res = append(res, strings.TrimSpace(tmp[aliasEnd:]))
 			} else {
 				res = append(res, strings.TrimSpace(tmp))
 			}

--- a/api/internal/pkg/utils/sql_test.go
+++ b/api/internal/pkg/utils/sql_test.go
@@ -38,7 +38,29 @@ OFFSET
 			want1: true,
 		},
 		{
-			name: "test-2",
+			name: "uppercase AS alias",
+			args: args{
+				sql: `SELECT
+  count(*) AS total,name,tags,ts
+FROM
+  metrics.samples`,
+			},
+			want:  []string{"total", "name", "tags", "ts"},
+			want1: true,
+		},
+		{
+			name: "uppercase AS inside expression is not an alias",
+			args: args{
+				sql: `SELECT
+  CAST(ts AS String),name
+FROM
+  metrics.samples`,
+			},
+			want:  []string{"CAST(ts AS String)", "name"},
+			want1: true,
+		},
+		{
+			name: "test-3",
 			args: args{
 				sql: `SELECT
   val as key,name,tags,ts


### PR DESCRIPTION
## Summary

- recognize uppercase and mixed-case `AS` aliases when ordering query result fields
- ignore `AS` tokens nested inside expressions or quoted values
- add regression coverage for uppercase aliases and unaliased `CAST(... AS ...)` expressions

Closes #1167

## Verification

- `go test ./api/internal/pkg/utils -run ^'TestGenerateFieldOrderRules$' -count=1`\n- `make build.api`\n- `git diff --check origin/feature/v2...HEAD`\n\n## Known baseline failures\n\n- the full `api/internal/pkg/utils` suite still has pre-existing failures in `Test_Index` and `Test_MidIndex` from `agent_test.go`; the focused SQL parser test passes.