### PR TITLE
docs: fix release download commands

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -60,10 +60,10 @@ docker-compose up
 latest=$(curl -sL https://api.github.com/repos/clickvisual/clickvisual/releases/latest | grep  ".tag_name" | sed -E 's/.*"([^"]+)".*/\1/')
 
 # MacOs 下下载
-wget "https://github.com/clickvisual/clickvisual/releases/download/${latest}/clickvisual-${latest}-darwin-amd64.tar.gz" -O clickvisual-${latest}.tar.gz 
+wget "https://github.com/clickvisual/clickvisual/releases/download/${latest}/clickvisual-${latest}-darwin-amd64.tar.gz" -O clickvisual-${latest}.tar.gz
 
 # Linux 下下载
-wget "https://github.com/clickvisual/clickvisual/releases/download/${latest}/clickvisual-${latest}-linux-amd64.tar.gz" -O clickvisual-$(latest).tar.gz  
+wget "https://github.com/clickvisual/clickvisual/releases/download/${latest}/clickvisual-${latest}-linux-amd64.tar.gz" -O clickvisual-${latest}.tar.gz
 
 # 解压 tar.gz 包到 ./clickvisual 目录
 mkdir -p ./clickvisual-${latest} && tar -zxvf clickvisual-${latest}.tar.gz -C ./clickvisual-${latest}

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ docker-compose up
 latest=$(curl -sL https://api.github.com/repos/clickvisual/clickvisual/releases/latest | grep  ".tag_name" | sed -E 's/.*"([^"]+)".*/\1/')
 
 # for MacOS amd64.
-wget "https://github.com/clickvisual/clickvisual/releases/download/${latest}/clickvisual-${latest}-darwin-amd64.tar.gz" -O clickvisual-${latest}.tar.gz 
+wget "https://github.com/clickvisual/clickvisual/releases/download/${latest}/clickvisual-${latest}-darwin-amd64.tar.gz" -O clickvisual-${latest}.tar.gz
 
 # for Linux amd64.
-wget "https://github.com/clickvisual/clickvisual/releases/download/${latest}/clickvisual-${latest}-linux-amd64.tar.gz" -O clickvisual-$(latest).tar.gz  
+wget "https://github.com/clickvisual/clickvisual/releases/download/${latest}/clickvisual-${latest}-linux-amd64.tar.gz" -O clickvisual-${latest}.tar.gz
 
 # extract zip file to current directory.
 mkdir -p ./clickvisual-${latest} && tar -zxvf clickvisual-${latest}.tar.gz -C ./clickvisual-${latest}
@@ -148,4 +148,3 @@ Thanks for these wonderful people:
 ## Friends
 
 - [DBM - An awesome database management tool specified for ClickHouse](https://github.com/EdurtIO/dbm)
-

--- a/docs/docs/en/clickvisual/02install/binary-installation.md
+++ b/docs/docs/en/clickvisual/02install/binary-installation.md
@@ -29,7 +29,7 @@ wget "https://github.com/clickvisual/clickvisual/releases/download/${latest}/cli
 latest=$(curl -sL https://api.github.com/repos/clickvisual/clickvisual/releases/latest | grep  ".tag_name" | sed -E 's/.*"([^"]+)".*/\1/')
 
 # Mac arm64 system
-wget "https://github.com/clickvisual/clickvisual/releases/download/${latest}/clickvisual-${latest}-mac-arm64.tar.gz" -O clickvisual-${latest}.tar.gz
+wget "https://github.com/clickvisual/clickvisual/releases/download/${latest}/clickvisual-${latest}-darwin-arm64.tar.gz" -O clickvisual-${latest}.tar.gz
 ```
 
 ## Linux ARM64 Architecture

--- a/docs/docs/zh/clickvisual/02install/binary-installation.md
+++ b/docs/docs/zh/clickvisual/02install/binary-installation.md
@@ -29,7 +29,7 @@ wget "https://github.com/clickvisual/clickvisual/releases/download/${latest}/cli
 latest=$(curl -sL https://api.github.com/repos/clickvisual/clickvisual/releases/latest | grep  ".tag_name" | sed -E 's/.*"([^"]+)".*/\1/')
 
 # Mac arm64系统
-wget "https://github.com/clickvisual/clickvisual/releases/download/${latest}/clickvisual-${latest}-mac-arm64.tar.gz" -O clickvisual-${latest}.tar.gz
+wget "https://github.com/clickvisual/clickvisual/releases/download/${latest}/clickvisual-${latest}-darwin-arm64.tar.gz" -O clickvisual-${latest}.tar.gz
 ```
 
 ## Linux ARM64 架构


### PR DESCRIPTION
## Summary
- fix the Linux README download output variable
- use the GoReleaser `darwin-arm64` asset name in English and Chinese installation docs
- keep README and public binary-installation docs aligned

## Verification
- `git diff --check`
- confirmed all documented archive names against the v1.0.6 GitHub release assets

Closes #1152