### PR TITLE
fix: correct SQL select field parsing for function expressions

### DIFF
--- a/api/internal/pkg/utils/sql.go
+++ b/api/internal/pkg/utils/sql.go
@@ -6,23 +6,100 @@ import (
 )
 
 var regSelectFields = regexp.MustCompile(`^(SELECT|select)([\S\s]+)(FROM|from)`)
+var regAlias = regexp.MustCompile(`(?i)\s+as\s+(.+)$`)
 
 func GenerateFieldOrderRules(sql string) ([]string, bool) {
 	regRes := regSelectFields.FindStringSubmatch(sql)
 	if len(regRes) == 4 {
 		res := make([]string, 0)
-		for _, tmp := range strings.Split(strings.TrimSpace(regRes[2]), ",") {
-			if strings.Contains(tmp, " as ") {
-				asArr := strings.Split(tmp, " as ")
-				if len(asArr) != 2 {
+		fields, ok := splitSelectFields(strings.TrimSpace(regRes[2]))
+		if !ok {
+			return nil, false
+		}
+		for _, tmp := range fields {
+			tmp = strings.TrimSpace(tmp)
+			if tmp == "" {
+				continue
+			}
+			if asPos := regAlias.FindStringSubmatchIndex(tmp); asPos != nil {
+				alias := strings.TrimSpace(tmp[asPos[2]:asPos[3]])
+				if alias == "" {
 					return nil, false
 				}
-				res = append(res, strings.TrimSpace(asArr[1]))
-			} else {
-				res = append(res, strings.TrimSpace(tmp))
+				res = append(res, alias)
+				continue
 			}
+			res = append(res, tmp)
 		}
 		return res, true
 	}
 	return nil, false
+}
+
+func splitSelectFields(selectFields string) ([]string, bool) {
+	res := make([]string, 0)
+	var current strings.Builder
+	depth := 0
+	inSingleQuote := false
+	inDoubleQuote := false
+	inBacktick := false
+	escape := false
+
+	for _, ch := range selectFields {
+		if escape {
+			current.WriteRune(ch)
+			escape = false
+			continue
+		}
+		if (inSingleQuote || inDoubleQuote) && ch == '\\' {
+			current.WriteRune(ch)
+			escape = true
+			continue
+		}
+		switch ch {
+		case '\'':
+			if !inDoubleQuote && !inBacktick {
+				inSingleQuote = !inSingleQuote
+			}
+			current.WriteRune(ch)
+		case '"':
+			if !inSingleQuote && !inBacktick {
+				inDoubleQuote = !inDoubleQuote
+			}
+			current.WriteRune(ch)
+		case '`':
+			if !inSingleQuote && !inDoubleQuote {
+				inBacktick = !inBacktick
+			}
+			current.WriteRune(ch)
+		case '(':
+			if !inSingleQuote && !inDoubleQuote && !inBacktick {
+				depth++
+			}
+			current.WriteRune(ch)
+		case ')':
+			if !inSingleQuote && !inDoubleQuote && !inBacktick {
+				depth--
+				if depth < 0 {
+					return nil, false
+				}
+			}
+			current.WriteRune(ch)
+		case ',':
+			if !inSingleQuote && !inDoubleQuote && !inBacktick && depth == 0 {
+				res = append(res, current.String())
+				current.Reset()
+				continue
+			}
+			current.WriteRune(ch)
+		default:
+			current.WriteRune(ch)
+		}
+	}
+
+	if inSingleQuote || inDoubleQuote || inBacktick || depth != 0 {
+		return nil, false
+	}
+	res = append(res, current.String())
+	return res, true
 }

--- a/api/internal/pkg/utils/sql_test.go
+++ b/api/internal/pkg/utils/sql_test.go
@@ -59,7 +59,7 @@ OFFSET
 			want1: true,
 		},
 		{
-			name: "test-2",
+			name: "test-3",
 			args: args{
 				sql: `SELECT
   val as key,
@@ -80,6 +80,26 @@ OFFSET
   0`,
 			},
 			want:  []string{"key", "name", "tags", "ts"},
+			want1: true,
+		},
+		{
+			name: "test-function-alias-with-commas",
+			args: args{
+				sql: `SELECT
+  count(*) AS c,
+  replaceRegexpAll(request_uri, '([0-9]){3,}', '{0}') AS url
+FROM
+  access_logs
+WHERE
+  timestamp >= toDateTime(1687072299)
+  AND timestamp < toDateTime(1687158699)
+  AND (status = 500)
+GROUP BY
+  url
+ORDER BY
+  c DESC`,
+			},
+			want:  []string{"c", "url"},
 			want1: true,
 		},
 	}


### PR DESCRIPTION
Handle top-level comma splitting in SELECT fields and parse aliases case-insensitively to avoid tokenization errors with functions like replaceRegexpAll.