### PR TITLE
fix(helm): use mounted config path by default

### DIFF
--- a/data/helm/README.md
+++ b/data/helm/README.md
@@ -17,6 +17,8 @@ git clone https://github.com/clickvisual/clickvisual.git
 cd clickvisual && cp config/default.toml data/helm/clickvisual/default.toml
 ```
 
+The chart mounts this file at `configs/default.toml` and sets `EGO_CONFIG_PATH` to that path by default. Override `env.configPath` only when using a different mount path.
+
 - [**suggested**] use helm install to install clickvisual directly
 ```bash
 helm install clickvisual data/helm/clickvisual --set image.tag=latest --namespac default

--- a/data/helm/clickvisual/templates/deployment.yaml
+++ b/data/helm/clickvisual/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
             - name: EGO_DEBUG
               value: "{{ if hasKey .Values.env "debug" }}{{ .Values.env.debug | default true | toString }}{{ else }}{{ default "true" }}{{ end }}"
             - name: EGO_CONFIG_PATH
-              value: {{ .Values.env.configPath | default "config/default.toml" }}
+              value: {{ .Values.env.configPath | default "configs/default.toml" }}
             - name: EGO_LOG_WRITER
               value: {{ .Values.env.logWritter | default "stderr" }}
           securityContext:
@@ -70,4 +70,3 @@ spec:
           sources:
             - configMap:
                 name: {{ .Chart.Name }}
-

--- a/data/helm/clickvisual/values.yaml
+++ b/data/helm/clickvisual/values.yaml
@@ -32,7 +32,7 @@ service:
 
 # clickvisual env config, default if not set
 env:
- configPath: "config/default.toml"
+ configPath: "configs/default.toml"
  debug: "true"
  logWritter: "stderr"
 

--- a/docs/docs/en/clickvisual/02install/k8s-installation.md
+++ b/docs/docs/en/clickvisual/02install/k8s-installation.md
@@ -367,10 +367,12 @@ cd clickvisual && cp config/default.toml data/helm/clickvisual/default.toml
 ```
 Edit mysql、auth and other segment configurations in data/helm/clickvisual/default.toml,update mysql.dsn,auth.redisAddr,auth.redisPassword as you want.
 
-Update the value `configs/default.toml` in data/helm/clickvisual/templates/deployment.yaml if you need
+The Helm chart mounts this file at `configs/default.toml` and uses that path by default. To use another path, override `env.configPath` in your values file or on the command line:
 ```
-- name: EGO_CONFIG_PATH
-value: "configs/default.toml"
+helm install clickvisual data/helm/clickvisual \
+  --set image.tag=latest \
+  --set env.configPath=configs/default.toml \
+  --namespace default
 ```
 
 ### Install

--- a/docs/docs/zh/clickvisual/02install/k8s-installation.md
+++ b/docs/docs/zh/clickvisual/02install/k8s-installation.md
@@ -377,10 +377,12 @@ cd clickvisual && cp config/default.toml data/helm/clickvisual/default.toml
 ```
 修改 data/helm/clickvisual/default.toml 中的 mysql、auth 以及其他段配置，将 mysql.dsn 、 auth.redisAddr、auth.redisPassword 替换为你自己的配置。
 
-修改 data/helm/clickvisual/templates/deployment.yaml 中 value 为 `configs/default.toml` 默认是 `config/default.toml` 即仓库中的默认配置
+Helm Chart 会把该文件挂载到 `configs/default.toml`，并默认使用这个路径。如需使用其他路径，请在 values 文件或命令行中覆盖 `env.configPath`：
 ```
-- name: EGO_CONFIG_PATH
-value: "configs/default.toml"
+helm install clickvisual data/helm/clickvisual \
+  --set image.tag=latest \
+  --set env.configPath=configs/default.toml \
+  --namespace default
 ```
 
 ### 3.2 安装


### PR DESCRIPTION
## Summary
- align the Helm default `EGO_CONFIG_PATH` with the `/clickvisual/configs` mount
- keep `env.configPath` available for custom paths
- update Chinese and English Kubernetes installation docs

## Verification
- `helm lint data/helm/clickvisual --set image.tag=latest`
- rendered the default chart and confirmed `configs/default.toml` matches the mount
- rendered with `--set env.configPath=configs/custom.toml` and confirmed the override

Fixes #1158