### PR TITLE
feat(query): disable histogram by default

### DIFF
--- a/ui/src/models/dataLogs.ts
+++ b/ui/src/models/dataLogs.ts
@@ -552,7 +552,7 @@ const DataLogsModel = () => {
     cancelTokenLogsRef.current?.();
     cancelTokenHighChartsRef.current?.();
     const currentPane = logPanesHelper.logPanes[id.toString()];
-    const histogramChecked = currentPane?.histogramChecked ?? true;
+    const histogramChecked = currentPane?.histogramChecked ?? false;
 
     const filterDisableIds =
       JSON.parse(

--- a/ui/src/models/datalogs/useLogPanes.test.ts
+++ b/ui/src/models/datalogs/useLogPanes.test.ts
@@ -1,0 +1,7 @@
+import { DefaultPane } from "./useLogPanes";
+
+describe("DefaultPane", () => {
+  it("disables histogram queries by default", () => {
+    expect(DefaultPane.histogramChecked).toBe(false);
+  });
+});

--- a/ui/src/models/datalogs/useLogPanes.ts
+++ b/ui/src/models/datalogs/useLogPanes.ts
@@ -22,7 +22,7 @@ export const DefaultPane = {
   activeTabKey: TimeRangeType.Relative,
   highCharts: undefined,
   logs: undefined,
-  histogramChecked: true,
+  histogramChecked: false,
   foldingChecked: false,
   baseFieldsIndexList: undefined,
   logFieldsIndexList: undefined,

--- a/ui/src/pages/DataLogs/components/QueryResult/Content/RawLog/RawLogsOperations/SwitchLeft/HistogramSiwtch.tsx
+++ b/ui/src/pages/DataLogs/components/QueryResult/Content/RawLog/RawLogsOperations/SwitchLeft/HistogramSiwtch.tsx
@@ -32,7 +32,7 @@ const HistogramSwitch = ({ oldPane }: { oldPane: PaneType | undefined }) => {
   return (
     <>
       <Switch
-        checked={oldPane?.histogramChecked ?? true}
+        checked={oldPane?.histogramChecked ?? false}
         onChange={handleChangeHistogramChecked}
         size={"small"}
       />


### PR DESCRIPTION
## Summary

- disable histogram queries for newly opened log panes by default
- keep the existing histogram switch available for opt-in queries
- align query and switch fallbacks with the disabled default
- add a regression test for the pane default

Closes #1049

## Verification

- `yarn build` (UI production build)
- source-level red/green assertion for `DefaultPane.histogramChecked`
- `git diff --check`

## Known repository test tooling issue

The committed UI unit-test wrapper is currently not runnable in this branch because `yarn test` references a missing `ui/tests/beforeTest`, and Umi reports that the `test` command is not registered. The production build succeeds.