### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Thanks for these wonderful people:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=clickvisual/clickvisual&type=Date)](https://star-history.com/#clickvisual/clickvisual&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=clickvisual/clickvisual&type=Date)](https://star-history.dera.page/#clickvisual/clickvisual&Date)
 
 ## Thank You
 - [腾源会/WeOpen](https://cloud.tencent.com/act/pro/weopen-home)


### PR DESCRIPTION
The star history chart on the README is currently broken because the public star-history.com endpoint can no longer read the GitHub stargazer API without a token.

Switch the chart image and its link to the star-history.dera.page mirror, which uses an alternative data source that requires no API token. This restores the chart for our users.