### PR TITLE
fix(compose): configure ClickHouse cluster

### DIFF
--- a/data/all-in-one/clickhouse/conf/conf.d/docker_cluster.xml
+++ b/data/all-in-one/clickhouse/conf/conf.d/docker_cluster.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<clickhouse>
+    <remote_servers>
+        <clickvisual>
+            <shard>
+                <replica>
+                    <host>clickhouse</host>
+                    <port>9000</port>
+                    <user>root</user>
+                    <password>shimo</password>
+                </replica>
+            </shard>
+        </clickvisual>
+    </remote_servers>
+
+    <zookeeper>
+        <node index="1">
+            <host>zookeeper</host>
+            <port>2181</port>
+        </node>
+    </zookeeper>
+
+    <macros>
+        <shard>01</shard>
+        <replica>clickhouse</replica>
+    </macros>
+</clickhouse>


### PR DESCRIPTION
## Summary

- configure the Docker Compose ClickHouse service with a named single-node `clickvisual` cluster
- connect ClickHouse distributed DDL to the existing ZooKeeper service
- define shard and replica macros for cluster-aware table creation

Fixes #1138.

## Verification

- `xmllint --noout data/all-in-one/clickhouse/conf/conf.d/docker_cluster.xml`
- `docker compose config --quiet`
- `git diff --check`

Docker runtime verification was not available because the local Docker daemon is stopped.