### PR TITLE
feat(share): resolve log tables by name

### DIFF
--- a/ui/src/pages/DataLogs/hooks/shareTable.test.ts
+++ b/ui/src/pages/DataLogs/hooks/shareTable.test.ts
@@ -1,0 +1,31 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const {
+  resolveInitialTableId,
+  resolveSharedTableId,
+} = require("./shareTable.ts");
+
+test("resolves a unique table name to its numeric id", () => {
+  assert.equal(
+    resolveSharedTableId("app-log", [
+      { key: "table-5", name: "app-log" },
+      { key: "table-8", name: "audit-log" },
+    ]),
+    5
+  );
+});
+
+test("does not guess when table names are ambiguous", () => {
+  assert.equal(
+    resolveSharedTableId("app-log", [
+      { key: "table-5", name: "app-log" },
+      { key: "table-8", name: "app-log" },
+    ]),
+    undefined
+  );
+});
+
+test("does not let saved state override a name-based share link", () => {
+  assert.equal(resolveInitialTableId(true, undefined, 9), undefined);
+  assert.equal(resolveInitialTableId(false, undefined, 9), 9);
+});

--- a/ui/src/pages/DataLogs/hooks/shareTable.ts
+++ b/ui/src/pages/DataLogs/hooks/shareTable.ts
@@ -1,0 +1,23 @@
+interface SharedTable {
+  key?: string;
+  name?: string;
+}
+
+export const resolveInitialTableId = (
+  isShare: boolean,
+  urlTableId: string | number | undefined,
+  savedTableId: string | number | undefined
+) => (isShare ? urlTableId : urlTableId || savedTableId);
+
+export const resolveSharedTableId = (
+  tableName: string | undefined,
+  tables: SharedTable[]
+) => {
+  if (!tableName) return undefined;
+
+  const matches = tables.filter((table) => table.name === tableName);
+  if (matches.length !== 1) return undefined;
+
+  const match = matches[0].key?.match(/^table-(\d+)$/);
+  return match ? parseInt(match[1], 10) : undefined;
+};

--- a/ui/src/pages/DataLogs/hooks/useLogUrlParams.ts
+++ b/ui/src/pages/DataLogs/hooks/useLogUrlParams.ts
@@ -24,6 +24,7 @@ import dayjs from "dayjs";
 import { isEqual } from "lodash";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { TimeOption } from "../components/DateTimeSelected";
+import { resolveInitialTableId, resolveSharedTableId } from "./shareTable";
 import useTimeOptions from "./useTimeOptions";
 
 export interface UrlStateType {
@@ -33,6 +34,7 @@ export interface UrlStateType {
   database?: string | number;
   datasource?: string;
   table?: string;
+  tablename?: string;
   start?: string | number;
   end?: string | number;
   kw?: string;
@@ -321,7 +323,7 @@ export default function useLogUrlParams() {
 
   useEffect(() => {
     const lastDataLogsState = getLastDataLogsState();
-    setTid(urlState.tid || lastDataLogsState.tid);
+    setTid(resolveInitialTableId(isShare, urlState.tid, lastDataLogsState.tid));
   }, []);
 
   useEffect(() => {
@@ -337,6 +339,12 @@ export default function useLogUrlParams() {
         });
 
         currentTable.length == 1 && doSetUrlQuery(parseInt(tid));
+        onChangeIsTidInitialize(true);
+      }
+    } else if (isShare && urlState.tablename && allTables.length > 0) {
+      const sharedTableId = resolveSharedTableId(urlState.tablename, allTables);
+      if (sharedTableId) {
+        doSetUrlQuery(sharedTableId);
         onChangeIsTidInitialize(true);
       }
     } else if (


### PR DESCRIPTION
## Summary
- support `/share?tablename=...` links by resolving a unique table name from the loaded log tree
- keep existing `tid` and fully-qualified instance/database/table share parameters working
- prevent saved local table state from overriding name-based share links

Closes #1126

## Verification
- `node --test src/pages/DataLogs/hooks/shareTable.test.ts`
- `max build NODE_OPTIONS=--max_old_space_size=4096`
- `git diff --check`