### PR TITLE
feat(ego): support ClickHouse cluster initialization

### DIFF
--- a/api/cmd/ego/README.md
+++ b/api/cmd/ego/README.md
@@ -2,9 +2,11 @@
 
 ## 功能
 
-1. **创建 ClickHouse 实例** - 调用 `base.InstanceCreate` 接口创建 ClickHouse 实例
-2. **创建 logger 数据库** - 在创建的实例上调用 `base.DatabaseCreate` 创建名为 "logger" 的数据库
-3. **创建 ego 存储模板** - 在 logger 数据库上调用 `storage.CreateStorageByTemplate` 创建 ego 存储模板
+1. **创建 ClickHouse 实例记录** - 通过 service 层创建或复用名为 `clickhouse-instance` 的实例记录
+2. **创建 logger 数据库** - 通过 service 层在该实例上创建名为 `logger` 的数据库
+3. **创建 ego 存储模板** - 通过 service 层在 logger 数据库中创建 EGO 日志模板
+
+如果已存在 `clickhouse-instance` 实例记录，命令会复用该记录；复用时不会用本次 `clickhouse_dsn` 覆盖已保存的 DSN。
 
 ## 使用方法
 
@@ -12,7 +14,7 @@
 
 ```bash
 # 使用仓库中的运行配置和 ego 初始化配置
-./clickvisual ego \
+./bin/clickvisual ego \
   --config=./config/default.toml \
   --init-config=./config/init-config.example.toml
 ```
@@ -53,7 +55,7 @@ topics_ingress_stderr = "ingress-stderr-logs-ilogtail"
 使用 `--cluster` 传入时，非空 CLI 值优先于 TOML 中的 `cluster`：
 
 ```bash
-./clickvisual ego --config=./config/default.toml \
+./bin/clickvisual ego --config=./config/default.toml \
   --init-config=./config/init-config.example.toml \
   --cluster=shard2-repl1
 ```
@@ -85,3 +87,5 @@ topics_ingress_stderr = "ingress-stderr-logs-ilogtail"
 ```
 
 为避免泄露凭据，DSN 日志只显示 `configured` 或 `not configured`，不会回显 DSN 内容。使用 `--dry-run` 时只解析配置并输出摘要，不连接或校验 ClickHouse，也不执行 DDL。
+
+当前 ego 存储模板服务实际创建 app stdout 和 ingress stdout 两类表；`--topics-ego` 与 `--topics-ingress-stderr` 参数仍会被接受并保留默认值，但当前流程不会据此创建对应表。

--- a/api/cmd/ego/README.md
+++ b/api/cmd/ego/README.md
@@ -2,7 +2,7 @@
 
 ## 功能
 
-1. **创建 ClickHouse 实例** - 调用 `base.InstanceCreate` 接口创建 ClickHouse 实例，支持多节点情况
+1. **创建 ClickHouse 实例** - 调用 `base.InstanceCreate` 接口创建 ClickHouse 实例
 2. **创建 logger 数据库** - 在创建的实例上调用 `base.DatabaseCreate` 创建名为 "logger" 的数据库
 3. **创建 ego 存储模板** - 在 logger 数据库上调用 `storage.CreateStorageByTemplate` 创建 ego 存储模板
 
@@ -11,16 +11,21 @@
 ### 配置文件方式
 
 ```bash
-# 使用配置文件
-./clickvisual ego --init-config ./configs/init-config.example.toml --config=./configs/local.toml 
+# 使用仓库中的运行配置和 ego 初始化配置
+./clickvisual ego \
+  --config=./config/default.toml \
+  --init-config=./config/init-config.example.toml
 ```
+
+`--init-config` 是 TOML 文件；ClickHouse DSN、Kafka brokers 和 topic 等初始化参数可写在该文件中，也可通过命令行参数传入。命令行传入的非空值优先于 TOML 值；`cluster` 会先执行 TrimSpace，再进行判断。
 
 ## 参数说明
 
 | 参数 | 短参数 | 必需 | 说明 |
 |------|--------|------|------|
 | `--init-config` | `-i` | 否 | 初始化配置文件路径 |
-| `--clickhouse-dsn` | `-d` | 否 | ClickHouse DSN 连接字符串（有默认值） |
+| `--clickhouse-dsn` | `-d` | 否 | ClickHouse DSN 连接字符串（必须通过 CLI 或 TOML 提供） |
+| `--cluster` | | 否 | ClickHouse `system.clusters` 中的 cluster 名称；配置后启用集群模式 |
 | `--brokers` | `-b` | 否 | Kafka brokers 地址（有默认值） |
 | `--topics-app` | | 否 | 应用日志 topic（有默认值） |
 | `--topics-ego` | | 否 | Ego 日志 topic（有默认值） |
@@ -30,27 +35,34 @@
 
 ## 配置文件格式
 
-配置文件支持简单的 key=value 格式：
+`config/init-config.example.toml` 是可直接复制的 TOML 示例：
 
-```yaml
-# ClickHouse 连接配置
-clickhouse_dsn=tcp://localhost:9000?database=default&username=default&password=
+```toml
+clickhouse_dsn = "tcp://localhost:9000?database=default&username=default&password="
+# ClickHouse cluster 名称；取消注释后启用集群模式
+# cluster = "shard2-repl1"
+brokers = ["kafka-service.default:9092"]
+topics_app = "app-stdout-logs-ilogtail"
+topics_ego = "ego-stdout-logs-ilogtail"
+topics_ingress_stdout = "ingress-stdout-logs-ilogtail"
+topics_ingress_stderr = "ingress-stderr-logs-ilogtail"
+```
 
-# Kafka 配置
-brokers=localhost:9092
+`cluster` 必须是 ClickHouse `system.clusters` 中的名称，不是 Kubernetes cluster 名称，也不是节点地址列表。省略或传入空白值时保持单机模式，且不会查询 `system.clusters`。显式配置 cluster 后，ego 会在创建 logger 数据库和日志表之前校验：名称不存在、查询失败，或拓扑为 `1 shard × 1 replica` 都会失败；多 shard 或多 replica 的 cluster 可以通过。
 
-# Topic 配置
-topics_app=app-logs
-topics_ego=ego-logs
-topics_ingress_stdout=ingress-stdout
-topics_ingress_stderr=ingress-stderr
+使用 `--cluster` 传入时，非空 CLI 值优先于 TOML 中的 `cluster`：
+
+```bash
+./clickvisual ego --config=./config/default.toml \
+  --init-config=./config/init-config.example.toml \
+  --cluster=shard2-repl1
 ```
 
 ## 默认值
 
 如果未提供参数，系统会使用以下默认值：
 
-- **ClickHouse DSN**: `tcp://localhost:9000?database=default&username=default&password=`
+- **ClickHouse DSN**: 必须通过 `--clickhouse-dsn` 或 `clickhouse_dsn` 配置
 - **Kafka Brokers**: `kafka-service.default:9092`
 - **Topics App**: `app-stdout-logs-ilogtail`
 - **Topics Ego**: `ego-stdout-logs-ilogtail`
@@ -71,3 +83,5 @@ topics_ingress_stderr=ingress-stderr
 [INFO] ego 存储模板创建成功
 [INFO] ClickVisual 初始化完成
 ```
+
+为避免泄露凭据，DSN 日志只显示 `configured` 或 `not configured`，不会回显 DSN 内容。使用 `--dry-run` 时只解析配置并输出摘要，不连接或校验 ClickHouse，也不执行 DDL。

--- a/api/cmd/ego/ego.go
+++ b/api/cmd/ego/ego.go
@@ -18,6 +18,7 @@ import (
 	"github.com/clickvisual/clickvisual/api/internal/pkg/config"
 	appconfig "github.com/clickvisual/clickvisual/api/internal/pkg/config"
 	"github.com/clickvisual/clickvisual/api/internal/pkg/model/db"
+	"github.com/clickvisual/clickvisual/api/internal/pkg/model/dto"
 	"github.com/clickvisual/clickvisual/api/internal/pkg/model/view"
 	"github.com/clickvisual/clickvisual/api/internal/service"
 	"github.com/clickvisual/clickvisual/api/internal/service/install"
@@ -45,7 +46,18 @@ var (
 	topicsIngressStderr string
 	dryRun              bool
 
-	migrateMetadataSchema = install.Migration
+	migrateMetadataSchema     = install.Migration
+	loadClickHouseClusterInfo = func(instanceID int) (map[string]dto.ClusterInfo, error) {
+		op, err := service.InstanceManager.Load(instanceID)
+		if err != nil {
+			return nil, err
+		}
+		return op.ClusterInfo()
+	}
+	createClickHouseInstanceForEgo  = createClickHouseInstance
+	validateClickHouseClusterForEgo = validateClickHouseCluster
+	createLoggerDatabaseForEgo      = createLoggerDatabase
+	createEgoStorageTemplateForEgo  = createEgoStorageTemplate
 )
 
 var CmdInit = &cobra.Command{
@@ -217,21 +229,25 @@ func initializeClickVisual() error {
 	elog.Info("开始初始化 ClickVisual...")
 
 	// 1. 创建 ClickHouse 实例
-	instance, err := createClickHouseInstance()
+	instance, err := createClickHouseInstanceForEgo()
 	if err != nil {
 		return fmt.Errorf("创建 ClickHouse 实例失败: %v", err)
 	}
 	elog.Info("ClickHouse 实例创建成功", elog.Int("ID", instance.ID))
 
+	if err := validateClickHouseClusterForEgo(instance.ID, cluster); err != nil {
+		return fmt.Errorf("校验 ClickHouse cluster 失败: %w", err)
+	}
+
 	// 2. 创建 logger 数据库
-	databaseID, err := createLoggerDatabase(instance.ID)
+	databaseID, err := createLoggerDatabaseForEgo(instance.ID)
 	if err != nil {
 		return fmt.Errorf("创建 logger 数据库失败: %v", err)
 	}
 	elog.Info("logger 数据库创建成功", elog.Int("ID", databaseID))
 
 	// 3. 创建 ego 存储模板
-	err = createEgoStorageTemplate(databaseID, instance)
+	err = createEgoStorageTemplateForEgo(databaseID, instance)
 	if err != nil {
 		return fmt.Errorf("创建 ego 存储模板失败: %v", err)
 	}
@@ -342,6 +358,39 @@ func createEgoStorageTemplate(databaseID int, instance *db.BaseInstance) error {
 
 func normalizeClusterName(value string) string {
 	return strings.TrimSpace(value)
+}
+
+func validateClickHouseCluster(instanceID int, clusterName string) error {
+	clusterName = normalizeClusterName(clusterName)
+	if clusterName == "" {
+		return nil
+	}
+
+	clusters, err := loadClickHouseClusterInfo(instanceID)
+	if err != nil {
+		return fmt.Errorf("查询 ClickHouse system.clusters 失败: %w", err)
+	}
+
+	info, ok := clusters[clusterName]
+	if !ok {
+		available := make([]string, 0)
+		for name, candidate := range clusters {
+			if candidate.MaxShardNum > 1 || candidate.MaxReplicaNum > 1 {
+				available = append(available, name)
+			}
+		}
+		sort.Strings(available)
+		availableText := strings.Join(available, ", ")
+		if availableText == "" {
+			availableText = "无"
+		}
+		return fmt.Errorf("ClickHouse cluster %q 不存在，可用多节点 cluster: %s", clusterName, availableText)
+	}
+
+	if info.MaxShardNum <= 1 && info.MaxReplicaNum <= 1 {
+		return fmt.Errorf("ClickHouse cluster %q 为 1 shard × 1 replica，请移除 cluster 配置使用单机模式", clusterName)
+	}
+	return nil
 }
 
 func clickHouseDSNLogValue(value string) string {

--- a/api/cmd/ego/ego.go
+++ b/api/cmd/ego/ego.go
@@ -46,7 +46,13 @@ var (
 	topicsIngressStderr string
 	dryRun              bool
 
-	migrateMetadataSchema     = install.Migration
+	migrateMetadataSchema       = install.Migration
+	initializeEgoServicesForEgo = func() {
+		ego.New().Invoker(
+			invoker.Init,
+			service.Init,
+		)
+	}
 	loadClickHouseClusterInfo = func(instanceID int) (map[string]dto.ClusterInfo, error) {
 		op, err := service.InstanceManager.Load(instanceID)
 		if err != nil {
@@ -96,16 +102,6 @@ func init() {
 }
 
 func CmdFunc(cmd *cobra.Command, args []string) {
-	if err := ensureMetadataSchemaForEgo(); err != nil {
-		elog.Panic("初始化 metadata schema 失败: " + err.Error())
-	}
-
-	// 初始化应用
-	ego.New().Invoker(
-		invoker.Init,
-		service.Init,
-	)
-
 	// 加载初始化配置
 	if initConfigFile != "" {
 		if err := loadInitConfig(initConfigFile); err != nil {
@@ -152,6 +148,13 @@ func CmdFunc(cmd *cobra.Command, args []string) {
 		elog.Info("Dry run 模式，跳过实际操作")
 		return
 	}
+
+	if err := ensureMetadataSchemaForEgo(); err != nil {
+		elog.Panic("初始化 metadata schema 失败: " + err.Error())
+	}
+
+	// 初始化应用
+	initializeEgoServicesForEgo()
 
 	// 执行初始化步骤
 	if err := initializeClickVisual(); err != nil {

--- a/api/cmd/ego/ego.go
+++ b/api/cmd/ego/ego.go
@@ -382,7 +382,7 @@ func validateClickHouseCluster(instanceID int, clusterName string) error {
 
 	info, ok := clusters[clusterName]
 	if !ok {
-		available := make([]string, 0)
+		var available []string
 		for name, candidate := range clusters {
 			if candidate.MaxShardNum > 1 || candidate.MaxReplicaNum > 1 {
 				available = append(available, name)

--- a/api/cmd/ego/ego.go
+++ b/api/cmd/ego/ego.go
@@ -2,7 +2,9 @@ package init
 
 import (
 	"fmt"
+	"net/url"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -60,6 +62,7 @@ func init() {
 	CmdInit.InheritedFlags()
 	CmdInit.Flags().StringVarP(&initConfigFile, "init-config", "i", "", "初始化配置文件路径")
 	CmdInit.Flags().StringVarP(&clickhouseDSN, "clickhouse-dsn", "d", "", "ClickHouse DSN 连接字符串")
+	CmdInit.Flags().StringVar(&cluster, "cluster", "", "ClickHouse cluster 名称")
 	CmdInit.Flags().StringVarP(&brokers, "brokers", "b", "", "Kafka brokers 地址")
 	CmdInit.Flags().StringVarP(&topicsApp, "topics-app", "", "", "应用日志 topic")
 	CmdInit.Flags().StringVarP(&topicsEgo, "topics-ego", "", "", "Ego 日志 topic")
@@ -87,10 +90,15 @@ func CmdFunc(cmd *cobra.Command, args []string) {
 			elog.Panic("加载初始化配置失败: " + err.Error())
 		}
 	}
+	clickhouseDSN = normalizeClickHouseDSN(clickhouseDSN)
+	cluster = normalizeClusterName(cluster)
 
 	// 验证必需参数，设置默认值
 	if clickhouseDSN == "" {
 		elog.Panic("ClickHouse DSN 不能为空")
+	}
+	if err := validateClickHouseDSN(clickhouseDSN); err != nil {
+		elog.Panic(err.Error())
 	}
 	if brokers == "" {
 		brokers = "kafka-service.default:9092"
@@ -110,7 +118,8 @@ func CmdFunc(cmd *cobra.Command, args []string) {
 
 	// 显示解析后的配置
 	elog.Info("配置解析完成:")
-	elog.Info("ClickHouse DSN: " + clickhouseDSN)
+	elog.Info("ClickHouse DSN: " + clickHouseDSNLogValue(clickhouseDSN))
+	elog.Info("ClickHouse Cluster: " + cluster)
 	elog.Info("Kafka Brokers: " + brokers)
 	elog.Info("Topics App: " + topicsApp)
 	elog.Info("Topics Ego: " + topicsEgo)
@@ -124,7 +133,7 @@ func CmdFunc(cmd *cobra.Command, args []string) {
 
 	// 执行初始化步骤
 	if err := initializeClickVisual(); err != nil {
-		elog.Panic("初始化失败: " + err.Error())
+		elog.Panic("初始化失败: " + redactSensitiveValue(err.Error(), clickhouseDSN))
 	}
 
 	fmt.Println("ClickVisual 初始化完成")
@@ -194,9 +203,11 @@ func parseConfigContent(content string) error {
 		topicsIngressStderr = config.TopicsIngressStderr
 	}
 
-	if cluster == "" && config.Cluster != "" {
-		cluster = config.Cluster
+	cluster = normalizeClusterName(cluster)
+	if cluster == "" {
+		cluster = normalizeClusterName(config.Cluster)
 	}
+	clickhouseDSN = normalizeClickHouseDSN(clickhouseDSN)
 
 	return nil
 }
@@ -232,6 +243,9 @@ func initializeClickVisual() error {
 // createClickHouseInstance 创建 ClickHouse 实例
 func createClickHouseInstance() (*db.BaseInstance, error) {
 	elog.Info("创建 ClickHouse 实例...")
+	if err := validateClickHouseDSN(clickhouseDSN); err != nil {
+		return nil, err
+	}
 
 	// 检查 ClickHouse 实例是否存在
 	instance, err := db.InstanceInfoX(invoker.Db, map[string]interface{}{"name": "clickhouse-instance"})
@@ -255,7 +269,7 @@ func createClickHouseInstance() (*db.BaseInstance, error) {
 		return nil, err
 	}
 	if instance.ID == 0 {
-		elog.Error("创建 ClickHouse 实例失败", l.E(err), l.A("instance", instance))
+		elog.Error("创建 ClickHouse 实例失败", l.E(err))
 		return nil, fmt.Errorf("创建 ClickHouse 实例失败")
 	}
 	return &instance, nil
@@ -311,7 +325,7 @@ func createEgoStorageTemplate(databaseID int, instance *db.BaseInstance) error {
 		TopicsIngressStdout: topicsIngressStdout,
 		TopicsIngressStderr: topicsIngressStderr,
 	}
-	elog.Info("createEgoStorageTemplate", l.A("instance", instance), l.A("req", req))
+	elog.Info("createEgoStorageTemplate", l.A("req", req))
 	// 调用存储服务创建模板
 	database := db.BaseDatabase{}
 	database.ID = databaseID
@@ -323,5 +337,85 @@ func createEgoStorageTemplate(databaseID int, instance *db.BaseInstance) error {
 		return err
 	}
 
+	return nil
+}
+
+func normalizeClusterName(value string) string {
+	return strings.TrimSpace(value)
+}
+
+func clickHouseDSNLogValue(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "not configured"
+	}
+	return "configured"
+}
+
+func redactSensitiveValue(message, value string) string {
+	if strings.TrimSpace(value) == "" {
+		return message
+	}
+	trimmedValue := strings.TrimSpace(value)
+	sensitiveValues := []string{value, trimmedValue}
+	if parsed, err := url.Parse(trimmedValue); err == nil {
+		if parsed.User != nil {
+			sensitiveValues = append(sensitiveValues, parsed.User.String(), parsed.User.Username())
+			if password, ok := parsed.User.Password(); ok {
+				sensitiveValues = append(sensitiveValues, password)
+			}
+		}
+		for key, values := range parsed.Query() {
+			key = strings.ToLower(key)
+			if key == "username" || key == "password" {
+				sensitiveValues = append(sensitiveValues, values...)
+			}
+		}
+		for _, part := range strings.Split(parsed.RawQuery, "&") {
+			pieces := strings.SplitN(part, "=", 2)
+			if len(pieces) != 2 {
+				continue
+			}
+			key, err := url.QueryUnescape(pieces[0])
+			if err != nil {
+				continue
+			}
+			key = strings.ToLower(key)
+			if key == "username" || key == "password" {
+				sensitiveValues = append(sensitiveValues, pieces[1])
+			}
+		}
+	}
+	uniqueSensitiveValues := make(map[string]struct{}, len(sensitiveValues))
+	for _, sensitiveValue := range sensitiveValues {
+		if strings.TrimSpace(sensitiveValue) != "" {
+			uniqueSensitiveValues[sensitiveValue] = struct{}{}
+			uniqueSensitiveValues[url.QueryEscape(sensitiveValue)] = struct{}{}
+		}
+	}
+	sensitiveValues = sensitiveValues[:0]
+	for sensitiveValue := range uniqueSensitiveValues {
+		sensitiveValues = append(sensitiveValues, sensitiveValue)
+	}
+	sort.Slice(sensitiveValues, func(i, j int) bool {
+		return len(sensitiveValues[i]) > len(sensitiveValues[j])
+	})
+	for _, sensitiveValue := range sensitiveValues {
+		message = strings.ReplaceAll(message, sensitiveValue, "[REDACTED]")
+	}
+	return message
+}
+
+func normalizeClickHouseDSN(value string) string {
+	return strings.TrimSpace(value)
+}
+
+func validateClickHouseDSN(value string) error {
+	value = normalizeClickHouseDSN(value)
+	if value == "" {
+		return fmt.Errorf("ClickHouse DSN 格式无效")
+	}
+	if _, err := url.Parse(value); err != nil {
+		return fmt.Errorf("ClickHouse DSN 格式无效")
+	}
 	return nil
 }

--- a/api/cmd/ego/ego.go
+++ b/api/cmd/ego/ego.go
@@ -54,10 +54,20 @@ var (
 		}
 		return op.ClusterInfo()
 	}
-	createClickHouseInstanceForEgo  = createClickHouseInstance
-	validateClickHouseClusterForEgo = validateClickHouseCluster
-	createLoggerDatabaseForEgo      = createLoggerDatabase
-	createEgoStorageTemplateForEgo  = createEgoStorageTemplate
+	createClickHouseInstanceForEgo    = createClickHouseInstance
+	validateClickHouseClusterForEgo   = validateClickHouseCluster
+	createLoggerDatabaseForEgo        = createLoggerDatabase
+	createEgoStorageTemplateForEgo    = createEgoStorageTemplate
+	databaseInfoX                     = db.DatabaseInfoX
+	databaseDelete                    = db.DatabaseDelete
+	createDatabase                    = service.DatabaseCreate
+	defaultCreateStorageByEgoTemplate = func(uid int, database db.BaseDatabase, req view.ReqCreateStorageByTemplateEgo) error {
+		if service.Storage == nil {
+			return fmt.Errorf("storage service 未初始化")
+		}
+		return service.Storage.CreateByEgoTemplate(uid, database, req)
+	}
+	createStorageByEgoTemplate = defaultCreateStorageByEgoTemplate
 )
 
 var CmdInit = &cobra.Command{
@@ -240,14 +250,14 @@ func initializeClickVisual() error {
 	}
 
 	// 2. 创建 logger 数据库
-	databaseID, err := createLoggerDatabaseForEgo(instance.ID)
+	database, err := createLoggerDatabaseForEgo(instance)
 	if err != nil {
 		return fmt.Errorf("创建 logger 数据库失败: %v", err)
 	}
-	elog.Info("logger 数据库创建成功", elog.Int("ID", databaseID))
+	elog.Info("logger 数据库创建成功", elog.Int("ID", database.ID))
 
 	// 3. 创建 ego 存储模板
-	err = createEgoStorageTemplateForEgo(databaseID, instance)
+	err = createEgoStorageTemplateForEgo(database)
 	if err != nil {
 		return fmt.Errorf("创建 ego 存储模板失败: %v", err)
 	}
@@ -292,63 +302,59 @@ func createClickHouseInstance() (*db.BaseInstance, error) {
 }
 
 // createLoggerDatabase 创建 logger 数据库
-func createLoggerDatabase(instanceID int) (int, error) {
+func createLoggerDatabase(instance *db.BaseInstance) (db.BaseDatabase, error) {
+	if instance == nil || instance.ID == 0 {
+		return db.BaseDatabase{}, fmt.Errorf("ClickHouse instance 未初始化")
+	}
 	elog.Info("创建 logger 数据库...")
 
 	// 检查 logger 数据库是否存在
-	database, err := db.DatabaseInfoX(invoker.Db, map[string]interface{}{"name": "logger"})
+	database, err := databaseInfoX(invoker.Db, map[string]interface{}{"name": "logger"})
 	if err != nil {
 		// 未找到记录不视为错误，继续创建
 		if !strings.Contains(strings.ToLower(err.Error()), "record not found") {
-			return 0, err
+			return db.BaseDatabase{}, err
 		}
 	}
 	if database.ID != 0 {
 		// delete database
-		err = db.DatabaseDelete(invoker.Db, database.ID)
+		err = databaseDelete(invoker.Db, database.ID)
 		if err != nil {
-			return 0, fmt.Errorf("删除 logger 数据库失败: %v", err)
+			return db.BaseDatabase{}, fmt.Errorf("删除 logger 数据库失败: %v", err)
 		}
 	}
 	req := db.BaseDatabase{
-		Iid:          instanceID,
+		Iid:          instance.ID,
 		Name:         "logger",
-		Cluster:      "",
+		Cluster:      normalizeClusterName(cluster),
 		Uid:          1, // 使用系统用户
 		IsCreateByCV: 1,
 		Desc:         "ClickVisual 初始化创建的 logger 数据库",
 	}
-	if cluster != "" {
-		req.Cluster = cluster
-	}
-	database, err = service.DatabaseCreate(req)
+	database, err = createDatabase(req)
 	if err != nil {
-		return 0, err
+		return db.BaseDatabase{}, err
 	}
+	database.Instance = instance
 
-	return database.ID, nil
+	return database, nil
 }
 
 // createEgoStorageTemplate 创建 ego 存储模板
-func createEgoStorageTemplate(databaseID int, instance *db.BaseInstance) error {
+func createEgoStorageTemplate(database db.BaseDatabase) error {
 	elog.Info("创建 ego 存储模板...")
 
 	req := view.ReqCreateStorageByTemplateEgo{
 		Brokers:             brokers,
-		DatabaseId:          databaseID,
+		DatabaseId:          database.ID,
 		TopicsApp:           topicsApp,
 		TopicsEgo:           topicsEgo,
 		TopicsIngressStdout: topicsIngressStdout,
 		TopicsIngressStderr: topicsIngressStderr,
 	}
-	elog.Info("createEgoStorageTemplate", l.A("req", req))
+	elog.Info("createEgoStorageTemplate", l.A("databaseID", database.ID), l.A("cluster", database.Cluster), l.A("req", req))
 	// 调用存储服务创建模板
-	database := db.BaseDatabase{}
-	database.ID = databaseID
-	database.Name = "logger"
-	database.Iid = instance.ID
-	database.Instance = instance
-	err := service.Storage.CreateByEgoTemplate(1, database, req)
+	err := createStorageByEgoTemplate(1, database, req)
 	if err != nil {
 		return err
 	}

--- a/api/cmd/ego/ego_test.go
+++ b/api/cmd/ego/ego_test.go
@@ -1,11 +1,15 @@
 package init
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/gotomicro/ego/core/econf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/clickvisual/clickvisual/api/internal/pkg/model/db"
+	"github.com/clickvisual/clickvisual/api/internal/pkg/model/dto"
 )
 
 func resetEgoCommandState(t *testing.T) {
@@ -150,4 +154,130 @@ func TestEnsureMetadataSchemaForEgoMigratesPrivateLiteEdition(t *testing.T) {
 
 	require.NoError(t, ensureMetadataSchemaForEgo())
 	assert.True(t, called)
+}
+
+func TestValidateClickHouseClusterSkipsLoaderForEmptyCluster(t *testing.T) {
+	called := false
+	old := loadClickHouseClusterInfo
+	loadClickHouseClusterInfo = func(instanceID int) (map[string]dto.ClusterInfo, error) {
+		called = true
+		return nil, nil
+	}
+	t.Cleanup(func() { loadClickHouseClusterInfo = old })
+
+	require.NoError(t, validateClickHouseCluster(1, "  "))
+	assert.False(t, called)
+}
+
+func TestValidateClickHouseClusterAllowsMultipleShards(t *testing.T) {
+	old := loadClickHouseClusterInfo
+	loadClickHouseClusterInfo = func(instanceID int) (map[string]dto.ClusterInfo, error) {
+		return map[string]dto.ClusterInfo{"prod": {Name: "prod", MaxShardNum: 2, MaxReplicaNum: 1}}, nil
+	}
+	t.Cleanup(func() { loadClickHouseClusterInfo = old })
+
+	require.NoError(t, validateClickHouseCluster(1, " prod "))
+}
+
+func TestValidateClickHouseClusterAllowsMultipleReplicas(t *testing.T) {
+	old := loadClickHouseClusterInfo
+	loadClickHouseClusterInfo = func(instanceID int) (map[string]dto.ClusterInfo, error) {
+		return map[string]dto.ClusterInfo{"prod": {Name: "prod", MaxShardNum: 1, MaxReplicaNum: 2}}, nil
+	}
+	t.Cleanup(func() { loadClickHouseClusterInfo = old })
+
+	require.NoError(t, validateClickHouseCluster(1, "prod"))
+}
+
+func TestValidateClickHouseClusterRejectsUnknownClusterWithAvailableMultiNodeNames(t *testing.T) {
+	old := loadClickHouseClusterInfo
+	loadClickHouseClusterInfo = func(instanceID int) (map[string]dto.ClusterInfo, error) {
+		return map[string]dto.ClusterInfo{
+			"zeta":  {Name: "zeta", MaxShardNum: 1, MaxReplicaNum: 3},
+			"alpha": {Name: "alpha", MaxShardNum: 2, MaxReplicaNum: 1},
+			"solo":  {Name: "solo", MaxShardNum: 1, MaxReplicaNum: 1},
+		}, nil
+	}
+	t.Cleanup(func() { loadClickHouseClusterInfo = old })
+
+	err := validateClickHouseCluster(1, "missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `ClickHouse cluster "missing" 不存在`)
+	assert.Contains(t, err.Error(), "alpha, zeta")
+	assert.NotContains(t, err.Error(), "solo")
+}
+
+func TestValidateClickHouseClusterUnknownClusterReportsNoAvailableMultiNodeNames(t *testing.T) {
+	old := loadClickHouseClusterInfo
+	loadClickHouseClusterInfo = func(instanceID int) (map[string]dto.ClusterInfo, error) {
+		return map[string]dto.ClusterInfo{"solo": {Name: "solo", MaxShardNum: 1, MaxReplicaNum: 1}}, nil
+	}
+	t.Cleanup(func() { loadClickHouseClusterInfo = old })
+
+	err := validateClickHouseCluster(1, "missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `ClickHouse cluster "missing" 不存在`)
+	assert.Contains(t, err.Error(), "可用多节点 cluster: 无")
+}
+
+func TestValidateClickHouseClusterRejectsSingleNodeCluster(t *testing.T) {
+	old := loadClickHouseClusterInfo
+	loadClickHouseClusterInfo = func(instanceID int) (map[string]dto.ClusterInfo, error) {
+		return map[string]dto.ClusterInfo{"solo": {Name: "solo", MaxShardNum: 1, MaxReplicaNum: 1}}, nil
+	}
+	t.Cleanup(func() { loadClickHouseClusterInfo = old })
+
+	err := validateClickHouseCluster(1, "solo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "1 shard × 1 replica")
+	assert.Contains(t, err.Error(), "移除 cluster 配置使用单机模式")
+}
+
+func TestValidateClickHouseClusterWrapsLoaderError(t *testing.T) {
+	old := loadClickHouseClusterInfo
+	loadClickHouseClusterInfo = func(instanceID int) (map[string]dto.ClusterInfo, error) {
+		return nil, errors.New("system.clusters unavailable")
+	}
+	t.Cleanup(func() { loadClickHouseClusterInfo = old })
+
+	err := validateClickHouseCluster(1, "prod")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "查询 ClickHouse system.clusters 失败")
+	assert.ErrorContains(t, err, "system.clusters unavailable")
+}
+
+func TestInitializeClickVisualStopsBeforeLoggerDatabaseWhenClusterValidationFails(t *testing.T) {
+	oldCreateInstance := createClickHouseInstanceForEgo
+	oldValidateCluster := validateClickHouseClusterForEgo
+	oldCreateDatabase := createLoggerDatabaseForEgo
+	oldCreateStorage := createEgoStorageTemplateForEgo
+	t.Cleanup(func() {
+		createClickHouseInstanceForEgo = oldCreateInstance
+		validateClickHouseClusterForEgo = oldValidateCluster
+		createLoggerDatabaseForEgo = oldCreateDatabase
+		createEgoStorageTemplateForEgo = oldCreateStorage
+	})
+
+	loggerCalled := false
+	storageCalled := false
+	createClickHouseInstanceForEgo = func() (*db.BaseInstance, error) {
+		return &db.BaseInstance{BaseModel: db.BaseModel{ID: 7}}, nil
+	}
+	validateClickHouseClusterForEgo = func(instanceID int, clusterName string) error {
+		return errors.New("cluster topology invalid")
+	}
+	createLoggerDatabaseForEgo = func(instanceID int) (int, error) {
+		loggerCalled = true
+		return 1, nil
+	}
+	createEgoStorageTemplateForEgo = func(databaseID int, instance *db.BaseInstance) error {
+		storageCalled = true
+		return nil
+	}
+
+	err := initializeClickVisual()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "校验 ClickHouse cluster 失败")
+	assert.False(t, loggerCalled)
+	assert.False(t, storageCalled)
 }

--- a/api/cmd/ego/ego_test.go
+++ b/api/cmd/ego/ego_test.go
@@ -7,9 +7,12 @@ import (
 	"github.com/gotomicro/ego/core/econf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 
 	"github.com/clickvisual/clickvisual/api/internal/pkg/model/db"
 	"github.com/clickvisual/clickvisual/api/internal/pkg/model/dto"
+	"github.com/clickvisual/clickvisual/api/internal/pkg/model/view"
+	"github.com/clickvisual/clickvisual/api/internal/service"
 )
 
 func resetEgoCommandState(t *testing.T) {
@@ -123,6 +126,194 @@ func TestRedactSensitiveValueHandlesConvertedEncodedCredentials(t *testing.T) {
 	assert.NotContains(t, redacted, "%ZZ")
 	assert.NotContains(t, redacted, "s@cret")
 	assert.NotContains(t, redacted, "s%40cret")
+}
+
+func TestCreateLoggerDatabasePreservesClusterAndInstance(t *testing.T) {
+	resetEgoCommandState(t)
+	cluster = "  cluster-a  "
+	instance := &db.BaseInstance{BaseModel: db.BaseModel{ID: 7}}
+
+	oldDatabaseInfoX := databaseInfoX
+	oldDatabaseDelete := databaseDelete
+	oldCreateDatabase := createDatabase
+	t.Cleanup(func() {
+		databaseInfoX = oldDatabaseInfoX
+		databaseDelete = oldDatabaseDelete
+		createDatabase = oldCreateDatabase
+	})
+
+	databaseInfoX = func(_ *gorm.DB, _ map[string]interface{}) (db.BaseDatabase, error) {
+		return db.BaseDatabase{}, errors.New("record not found")
+	}
+	databaseDelete = func(_ *gorm.DB, _ int) error {
+		return nil
+	}
+	var captured db.BaseDatabase
+	createDatabase = func(req db.BaseDatabase) (db.BaseDatabase, error) {
+		captured = req
+		req.ID = 42
+		return req, nil
+	}
+
+	database, err := createLoggerDatabase(instance)
+	require.NoError(t, err)
+	assert.Equal(t, 7, captured.Iid)
+	assert.Equal(t, "cluster-a", captured.Cluster)
+	assert.Equal(t, 42, database.ID)
+	assert.Equal(t, 7, database.Iid)
+	assert.Equal(t, "logger", database.Name)
+	assert.Equal(t, "cluster-a", database.Cluster)
+	assert.Same(t, instance, database.Instance)
+}
+
+func TestCreateStorageByEgoTemplateReturnsErrorWhenServiceUninitialized(t *testing.T) {
+	oldStorage := service.Storage
+	oldCreateStorage := createStorageByEgoTemplate
+	t.Cleanup(func() {
+		service.Storage = oldStorage
+		createStorageByEgoTemplate = oldCreateStorage
+	})
+
+	service.Storage = nil
+	err := createStorageByEgoTemplate(1, db.BaseDatabase{}, view.ReqCreateStorageByTemplateEgo{})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "storage service 未初始化")
+}
+
+func TestCreateLoggerDatabaseRejectsInvalidInstanceBeforeLookup(t *testing.T) {
+	oldDatabaseInfoX := databaseInfoX
+	t.Cleanup(func() { databaseInfoX = oldDatabaseInfoX })
+	lookupCalled := false
+	databaseInfoX = func(_ *gorm.DB, _ map[string]interface{}) (db.BaseDatabase, error) {
+		lookupCalled = true
+		return db.BaseDatabase{}, nil
+	}
+
+	for name, instance := range map[string]*db.BaseInstance{
+		"nil":  nil,
+		"zero": &db.BaseInstance{},
+	} {
+		t.Run(name, func(t *testing.T) {
+			lookupCalled = false
+			_, err := createLoggerDatabase(instance)
+			require.Error(t, err)
+			assert.False(t, lookupCalled)
+		})
+	}
+}
+
+func TestCreateLoggerDatabaseShortCircuitsDatabaseErrors(t *testing.T) {
+	t.Run("lookup error", func(t *testing.T) {
+		oldInfo, oldDelete, oldCreate := databaseInfoX, databaseDelete, createDatabase
+		t.Cleanup(func() {
+			databaseInfoX, databaseDelete, createDatabase = oldInfo, oldDelete, oldCreate
+		})
+		deleteCalled, createCalled := false, false
+		databaseInfoX = func(_ *gorm.DB, _ map[string]interface{}) (db.BaseDatabase, error) {
+			return db.BaseDatabase{}, errors.New("lookup failed")
+		}
+		databaseDelete = func(_ *gorm.DB, _ int) error { deleteCalled = true; return nil }
+		createDatabase = func(db.BaseDatabase) (db.BaseDatabase, error) {
+			createCalled = true
+			return db.BaseDatabase{}, nil
+		}
+		_, err := createLoggerDatabase(&db.BaseInstance{BaseModel: db.BaseModel{ID: 7}})
+		require.Error(t, err)
+		assert.False(t, deleteCalled)
+		assert.False(t, createCalled)
+	})
+
+	t.Run("delete error", func(t *testing.T) {
+		oldInfo, oldDelete, oldCreate := databaseInfoX, databaseDelete, createDatabase
+		t.Cleanup(func() {
+			databaseInfoX, databaseDelete, createDatabase = oldInfo, oldDelete, oldCreate
+		})
+		createCalled := false
+		databaseInfoX = func(_ *gorm.DB, _ map[string]interface{}) (db.BaseDatabase, error) {
+			return db.BaseDatabase{BaseModel: db.BaseModel{ID: 9}}, nil
+		}
+		databaseDelete = func(_ *gorm.DB, id int) error {
+			assert.Equal(t, 9, id)
+			return errors.New("delete failed")
+		}
+		createDatabase = func(db.BaseDatabase) (db.BaseDatabase, error) {
+			createCalled = true
+			return db.BaseDatabase{}, nil
+		}
+		_, err := createLoggerDatabase(&db.BaseInstance{BaseModel: db.BaseModel{ID: 7}})
+		require.Error(t, err)
+		assert.False(t, createCalled)
+	})
+
+	t.Run("create error", func(t *testing.T) {
+		oldInfo, oldDelete, oldCreate := databaseInfoX, databaseDelete, createDatabase
+		t.Cleanup(func() {
+			databaseInfoX, databaseDelete, createDatabase = oldInfo, oldDelete, oldCreate
+		})
+		deleteCalled := false
+		databaseInfoX = func(_ *gorm.DB, _ map[string]interface{}) (db.BaseDatabase, error) {
+			return db.BaseDatabase{}, errors.New("record not found")
+		}
+		databaseDelete = func(_ *gorm.DB, _ int) error { deleteCalled = true; return nil }
+		createDatabase = func(db.BaseDatabase) (db.BaseDatabase, error) {
+			return db.BaseDatabase{}, errors.New("create failed")
+		}
+		_, err := createLoggerDatabase(&db.BaseInstance{BaseModel: db.BaseModel{ID: 7}})
+		require.Error(t, err)
+		assert.False(t, deleteCalled)
+	})
+
+	t.Run("existing database is deleted before create", func(t *testing.T) {
+		oldInfo, oldDelete, oldCreate := databaseInfoX, databaseDelete, createDatabase
+		t.Cleanup(func() {
+			databaseInfoX, databaseDelete, createDatabase = oldInfo, oldDelete, oldCreate
+		})
+		calls := make([]string, 0, 2)
+		databaseInfoX = func(_ *gorm.DB, _ map[string]interface{}) (db.BaseDatabase, error) {
+			calls = append(calls, "lookup")
+			return db.BaseDatabase{BaseModel: db.BaseModel{ID: 9}}, nil
+		}
+		databaseDelete = func(_ *gorm.DB, id int) error {
+			calls = append(calls, "delete")
+			assert.Equal(t, 9, id)
+			return nil
+		}
+		createDatabase = func(req db.BaseDatabase) (db.BaseDatabase, error) {
+			calls = append(calls, "create")
+			req.ID = 42
+			return req, nil
+		}
+		database, err := createLoggerDatabase(&db.BaseInstance{BaseModel: db.BaseModel{ID: 7}})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"lookup", "delete", "create"}, calls)
+		assert.Equal(t, 42, database.ID)
+	})
+}
+
+func TestCreateEgoStorageTemplatePassesDatabaseCluster(t *testing.T) {
+	resetEgoCommandState(t)
+	database := db.BaseDatabase{
+		BaseModel:    db.BaseModel{ID: 42},
+		Iid:          7,
+		Name:         "logger",
+		Uid:          1,
+		Cluster:      "cluster-a",
+		IsCreateByCV: 1,
+		Desc:         "ClickVisual 初始化创建的 logger 数据库",
+		Instance:     &db.BaseInstance{BaseModel: db.BaseModel{ID: 7}},
+	}
+
+	oldCreateStorage := createStorageByEgoTemplate
+	t.Cleanup(func() { createStorageByEgoTemplate = oldCreateStorage })
+	var captured db.BaseDatabase
+	createStorageByEgoTemplate = func(_ int, got db.BaseDatabase, _ view.ReqCreateStorageByTemplateEgo) error {
+		captured = got
+		return nil
+	}
+
+	require.NoError(t, createEgoStorageTemplate(database))
+	assert.Equal(t, database, captured)
+	assert.Same(t, database.Instance, captured.Instance)
 }
 
 func TestEnsureMetadataSchemaForEgoSkipsFullEdition(t *testing.T) {
@@ -266,11 +457,11 @@ func TestInitializeClickVisualStopsBeforeLoggerDatabaseWhenClusterValidationFail
 	validateClickHouseClusterForEgo = func(instanceID int, clusterName string) error {
 		return errors.New("cluster topology invalid")
 	}
-	createLoggerDatabaseForEgo = func(instanceID int) (int, error) {
+	createLoggerDatabaseForEgo = func(instance *db.BaseInstance) (db.BaseDatabase, error) {
 		loggerCalled = true
-		return 1, nil
+		return db.BaseDatabase{BaseModel: db.BaseModel{ID: 1}}, nil
 	}
-	createEgoStorageTemplateForEgo = func(databaseID int, instance *db.BaseInstance) error {
+	createEgoStorageTemplateForEgo = func(database db.BaseDatabase) error {
 		storageCalled = true
 		return nil
 	}

--- a/api/cmd/ego/ego_test.go
+++ b/api/cmd/ego/ego_test.go
@@ -472,3 +472,92 @@ func TestInitializeClickVisualStopsBeforeLoggerDatabaseWhenClusterValidationFail
 	assert.False(t, loggerCalled)
 	assert.False(t, storageCalled)
 }
+
+func TestCmdFuncDryRunSkipsSideEffects(t *testing.T) {
+	resetEgoCommandState(t)
+	econf.Reset()
+	t.Cleanup(econf.Reset)
+	econf.Set("app.v2Edition", "private-lite")
+	clickhouseDSN = "tcp://clickhouse:9000"
+	cluster = "prod"
+	dryRun = true
+
+	var migrationCalled, serviceInitCalled, instanceCalled, clusterCalled, databaseCalled, storageCalled bool
+	oldMigrate := migrateMetadataSchema
+	oldInitServices := initializeEgoServicesForEgo
+	oldCreateInstance := createClickHouseInstanceForEgo
+	oldValidateCluster := validateClickHouseClusterForEgo
+	oldCreateDatabase := createLoggerDatabaseForEgo
+	oldCreateStorage := createEgoStorageTemplateForEgo
+	t.Cleanup(func() {
+		migrateMetadataSchema = oldMigrate
+		initializeEgoServicesForEgo = oldInitServices
+		createClickHouseInstanceForEgo = oldCreateInstance
+		validateClickHouseClusterForEgo = oldValidateCluster
+		createLoggerDatabaseForEgo = oldCreateDatabase
+		createEgoStorageTemplateForEgo = oldCreateStorage
+	})
+	migrateMetadataSchema = func() error { migrationCalled = true; return nil }
+	initializeEgoServicesForEgo = func() { serviceInitCalled = true }
+	createClickHouseInstanceForEgo = func() (*db.BaseInstance, error) {
+		instanceCalled = true
+		return &db.BaseInstance{BaseModel: db.BaseModel{ID: 1}}, nil
+	}
+	validateClickHouseClusterForEgo = func(int, string) error { clusterCalled = true; return nil }
+	createLoggerDatabaseForEgo = func(*db.BaseInstance) (db.BaseDatabase, error) {
+		databaseCalled = true
+		return db.BaseDatabase{}, nil
+	}
+	createEgoStorageTemplateForEgo = func(db.BaseDatabase) error { storageCalled = true; return nil }
+
+	CmdFunc(nil, nil)
+
+	assert.False(t, migrationCalled)
+	assert.False(t, serviceInitCalled)
+	assert.False(t, instanceCalled)
+	assert.False(t, clusterCalled)
+	assert.False(t, databaseCalled)
+	assert.False(t, storageCalled)
+}
+
+func TestCmdFuncNormalModeInitializesBeforeClickVisual(t *testing.T) {
+	resetEgoCommandState(t)
+	econf.Reset()
+	t.Cleanup(econf.Reset)
+	econf.Set("app.v2Edition", "private-lite")
+	clickhouseDSN = "tcp://clickhouse:9000"
+	cluster = "prod"
+	dryRun = false
+
+	var calls []string
+	oldMigrate := migrateMetadataSchema
+	oldInitServices := initializeEgoServicesForEgo
+	oldCreateInstance := createClickHouseInstanceForEgo
+	oldValidateCluster := validateClickHouseClusterForEgo
+	oldCreateDatabase := createLoggerDatabaseForEgo
+	oldCreateStorage := createEgoStorageTemplateForEgo
+	t.Cleanup(func() {
+		migrateMetadataSchema = oldMigrate
+		initializeEgoServicesForEgo = oldInitServices
+		createClickHouseInstanceForEgo = oldCreateInstance
+		validateClickHouseClusterForEgo = oldValidateCluster
+		createLoggerDatabaseForEgo = oldCreateDatabase
+		createEgoStorageTemplateForEgo = oldCreateStorage
+	})
+	migrateMetadataSchema = func() error { calls = append(calls, "migration"); return nil }
+	initializeEgoServicesForEgo = func() { calls = append(calls, "service") }
+	createClickHouseInstanceForEgo = func() (*db.BaseInstance, error) {
+		calls = append(calls, "instance")
+		return &db.BaseInstance{BaseModel: db.BaseModel{ID: 1}}, nil
+	}
+	validateClickHouseClusterForEgo = func(int, string) error { calls = append(calls, "cluster"); return nil }
+	createLoggerDatabaseForEgo = func(*db.BaseInstance) (db.BaseDatabase, error) {
+		calls = append(calls, "database")
+		return db.BaseDatabase{BaseModel: db.BaseModel{ID: 2}}, nil
+	}
+	createEgoStorageTemplateForEgo = func(db.BaseDatabase) error { calls = append(calls, "storage"); return nil }
+
+	CmdFunc(nil, nil)
+
+	assert.Equal(t, []string{"migration", "service", "instance", "cluster", "database", "storage"}, calls)
+}

--- a/api/cmd/ego/ego_test.go
+++ b/api/cmd/ego/ego_test.go
@@ -8,6 +8,119 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func resetEgoCommandState(t *testing.T) {
+	t.Helper()
+	oldInitConfigFile := initConfigFile
+	oldClickhouseDSN := clickhouseDSN
+	oldCluster := cluster
+	oldBrokers := brokers
+	oldTopicsApp := topicsApp
+	oldTopicsEgo := topicsEgo
+	oldTopicsIngressStdout := topicsIngressStdout
+	oldTopicsIngressStderr := topicsIngressStderr
+	oldDryRun := dryRun
+	t.Cleanup(func() {
+		initConfigFile = oldInitConfigFile
+		clickhouseDSN = oldClickhouseDSN
+		cluster = oldCluster
+		brokers = oldBrokers
+		topicsApp = oldTopicsApp
+		topicsEgo = oldTopicsEgo
+		topicsIngressStdout = oldTopicsIngressStdout
+		topicsIngressStderr = oldTopicsIngressStderr
+		dryRun = oldDryRun
+	})
+
+	initConfigFile = ""
+	clickhouseDSN = ""
+	cluster = ""
+	brokers = ""
+	topicsApp = ""
+	topicsEgo = ""
+	topicsIngressStdout = ""
+	topicsIngressStderr = ""
+	dryRun = false
+}
+
+func TestClusterFlagRegistered(t *testing.T) {
+	flag := CmdInit.Flags().Lookup("cluster")
+	require.NotNil(t, flag)
+	assert.Empty(t, flag.DefValue)
+}
+
+func TestParseConfigContentLoadsCluster(t *testing.T) {
+	resetEgoCommandState(t)
+
+	require.NoError(t, parseConfigContent("cluster = \"  shard2-repl1  \""))
+	assert.Equal(t, "shard2-repl1", cluster)
+}
+
+func TestParseConfigContentPreservesCLICluster(t *testing.T) {
+	resetEgoCommandState(t)
+	cluster = "cli-cluster"
+
+	require.NoError(t, parseConfigContent("cluster = \"toml-cluster\""))
+	assert.Equal(t, "cli-cluster", cluster)
+}
+
+func TestClickHouseDSNIsNormalizedAndValidated(t *testing.T) {
+	resetEgoCommandState(t)
+	require.NoError(t, parseConfigContent("clickhouse_dsn = \"  tcp://clickhouse:9000  \""))
+	assert.Equal(t, "tcp://clickhouse:9000", clickhouseDSN)
+
+	clickhouseDSN = "   "
+	assert.Empty(t, normalizeClickHouseDSN(clickhouseDSN))
+	require.Error(t, validateClickHouseDSN("tcp://clickhouse:9000/%ZZ?password=secret"))
+}
+
+func TestMalformedClickHouseDSNErrorDoesNotLeakCredentials(t *testing.T) {
+	dsn := "tcp://clickhouse:9000/%ZZ?username=admin&password=secret"
+	err := validateClickHouseDSN(dsn)
+	require.Error(t, err)
+	assert.Equal(t, "ClickHouse DSN 格式无效", err.Error())
+	assert.NotContains(t, err.Error(), "admin")
+	assert.NotContains(t, err.Error(), "secret")
+	assert.NotContains(t, err.Error(), dsn)
+}
+
+func TestDSNHelpersDoNotLeakCredentials(t *testing.T) {
+	dsn := "tcp://clickhouse:9000?username=admin&password=secret"
+	assert.Equal(t, "configured", clickHouseDSNLogValue(dsn))
+	assert.Equal(t, "not configured", clickHouseDSNLogValue("  "))
+
+	message := "failed to connect " + dsn
+	redacted := redactSensitiveValue(message, dsn)
+	assert.Equal(t, "failed to connect [REDACTED]", redacted)
+	assert.NotContains(t, redacted, "admin")
+	assert.NotContains(t, redacted, "secret")
+
+	partial := redactSensitiveValue("credentials username=admin password=secret", dsn)
+	assert.NotContains(t, partial, "admin")
+	assert.NotContains(t, partial, "secret")
+	encodedDSN := "tcp://clickhouse:9000?username=%61dmin&password=%73ecret"
+	encoded := redactSensitiveValue("credentials username=%61dmin&password=%73ecret", encodedDSN)
+	assert.NotContains(t, encoded, "%61dmin")
+	assert.NotContains(t, encoded, "%73ecret")
+}
+
+func TestRedactSensitiveValueHandlesOverlappingCredentials(t *testing.T) {
+	dsn := "tcp://admin:adminsecret@clickhouse:9000"
+	message := "credentials username=admin password=adminsecret"
+	redacted := redactSensitiveValue(message, dsn)
+	assert.NotContains(t, redacted, "admin")
+	assert.NotContains(t, redacted, "adminsecret")
+	assert.NotContains(t, redacted, "secret")
+}
+
+func TestRedactSensitiveValueHandlesConvertedEncodedCredentials(t *testing.T) {
+	originalDSN := "tcp://host:9000?username=%25ZZ&password=s@cret"
+	message := "failed clickhouse://%ZZ:s%40cret@host:9000/default"
+	redacted := redactSensitiveValue(message, originalDSN)
+	assert.NotContains(t, redacted, "%ZZ")
+	assert.NotContains(t, redacted, "s@cret")
+	assert.NotContains(t, redacted, "s%40cret")
+}
+
 func TestEnsureMetadataSchemaForEgoSkipsFullEdition(t *testing.T) {
 	econf.Reset()
 	t.Cleanup(econf.Reset)

--- a/config/init-config.example.toml
+++ b/config/init-config.example.toml
@@ -1,5 +1,7 @@
 # ClickHouse 连接配置
 clickhouse_dsn="tcp://localhost:9000?database=default&username=default&password="
+# ClickHouse cluster 名称；取消注释后启用集群模式
+# cluster="shard2-repl1"
 
 # Kafka 配置
 brokers=["kafka-service.default:9092", "kafka-service.default:9093", "kafka-service.default:9094"]

--- a/config/init-config.example.toml
+++ b/config/init-config.example.toml
@@ -8,4 +8,6 @@ brokers=["kafka-service.default:9092", "kafka-service.default:9093", "kafka-serv
 
 # Topic 配置
 topics_app="app-stdout-logs-ilogtail"
+topics_ego="ego-stdout-logs-ilogtail"
 topics_ingress_stdout="ingress-stdout-logs-ilogtail"
+topics_ingress_stderr="ingress-stderr-logs-ilogtail"

--- a/docs/docs/en/clickvisual/03funcintro/template-gen.md
+++ b/docs/docs/en/clickvisual/03funcintro/template-gen.md
@@ -1,52 +1,53 @@
 # Template Generation
 
-## Log collection template for ego framework
+## Initialize ego log templates
 
-### Single machine creation
-Note whether the subpath is configured. If the subpath is configured in the environment variable, such as /clickvisual/, you need to replace ` http://127.0.0.1:19001/api/v1/template/1 ` with ` http://127.0.0.1:19001/clickvisual/api/v1/template/1 `
-```sh
-curl --location --request POST 'http://127.0.0.1:19001/api/v1/template/1' \
---header 'Content-Type: application/json' \
---data-raw '{
-    "dsn": "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60",
-    "clusterName": "clusterName",
-    "brokers": "kafka:9092"
-}'
+The `ego` command creates the ClickHouse instance, the `logger` database, and the log table templates. Use the repository's runtime config and init TOML file:
+
+```bash
+./bin/clickvisual ego \
+  --config=./config/default.toml \
+  --init-config=./config/init-config.example.toml
 ```
 
-### No replica cluster creation
-Note whether the subpath is configured. If the subpath is configured in the environment variable, such as /clickvisual/, you need to replace ` http://127.0.0.1:19001/api/v1/template/1 ` with ` http://127.0.0.1:19001/clickvisual/api/v1/template/1 `
+The init file is TOML. Provide the ClickHouse DSN with `clickhouse_dsn` or `--clickhouse-dsn`; Kafka brokers and topics can likewise be set in TOML or with their flags.
 
-k8sClusterName is k8s cluster name  
-instanceClusterName is ClickHouse cluster
-```sh
-curl --location --request POST 'http://127.0.0.1:19001/api/v1/template/1' \
---header 'Content-Type: application/json' \
---data-raw '{
-    "dsn": "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60",
-    "k8sClusterName": "clusterName", 
-    "brokers": "kafka:9092",
-    "instanceClusterName": "shard2-repl1"
-}'
+### ClickHouse cluster
+
+`cluster` is a name from ClickHouse `system.clusters`. It is not a Kubernetes cluster name or a node list. Uncomment it in TOML when cluster mode is needed:
+
+```toml
+clickhouse_dsn = "tcp://localhost:9000?database=default&username=default&password="
+# ClickHouse cluster name; uncomment to enable cluster mode
+# cluster = "shard2-repl1"
 ```
 
-### topic 
-%s is clusterName for parameter call
+Or pass it on the command line (a non-empty CLI value wins over TOML, after TrimSpace):
+
+```bash
+./bin/clickvisual ego --config=./config/default.toml \
+  --init-config=./config/init-config.example.toml \
+  --cluster=shard2-repl1
 ```
-var kafkaTopicORM = map[string]string{
-	"app_stdout":     "app-stdout-logs-%s",
-	"ego_stdout":     "ego-stdout-logs-%s",
-	"ingress_stdout": "ingress-stdout-logs-%s",
-	"ingress_stderr": "ingress-stderr-logs-%s",
-}
+
+If `cluster` is omitted or empty, ego remains in standalone mode and does not query `system.clusters`. An explicit cluster is validated before the logger database and tables are created: an unknown name, query error, or `1 shard × 1 replica` topology fails; a cluster with multiple shards or multiple replicas passes. `--dry-run` only parses configuration and prints a summary—no ClickHouse connection or validation and no DDL are performed. DSN logs show only `configured` or `not configured`, never credentials.
+
+### topic
+Log topics come from `topics_app`, `topics_ego`, `topics_ingress_stdout`, and `topics_ingress_stderr` in the init TOML or from the corresponding command-line flags. If omitted, ego uses these built-in defaults:
+
+```toml
+topics_app = "app-stdout-logs-ilogtail"
+topics_ego = "ego-stdout-logs-ilogtail"
+topics_ingress_stdout = "ingress-stdout-logs-ilogtail"
+topics_ingress_stderr = "ingress-stderr-logs-ilogtail"
 ```
 
 
 ### Results
-- Created a clickvisual_default instance
-- Created a clickvisual_default database
-- Created some log libraries: app-stdout, ego-stdout, ingress-stdout, ingress-stderr
-- Created some Analysis fields in log libraries
+- Created a ClickHouse instance record
+- Created the `logger` database (using the optional cluster setting)
+- Created app, ego, and ingress stdout/stderr log tables and consumption templates
+- Wrote log-table metadata and analysis fields
 
 
 ![img.png](../../../images/template_one_1.png)

--- a/docs/docs/en/clickvisual/03funcintro/template-gen.md
+++ b/docs/docs/en/clickvisual/03funcintro/template-gen.md
@@ -2,7 +2,7 @@
 
 ## Initialize ego log templates
 
-The `ego` command creates the ClickHouse instance, the `logger` database, and the log table templates. Use the repository's runtime config and init TOML file:
+The `ego` command creates or reuses the ClickHouse instance record, creates the `logger` database, and creates the log table templates. Use the repository's runtime config and init TOML file:
 
 ```bash
 ./bin/clickvisual ego \
@@ -11,6 +11,28 @@ The `ego` command creates the ClickHouse instance, the `logger` database, and th
 ```
 
 The init file is TOML. Provide the ClickHouse DSN with `clickhouse_dsn` or `--clickhouse-dsn`; Kafka brokers and topics can likewise be set in TOML or with their flags.
+
+If a `clickhouse-instance` record already exists, ego reuses it; reuse does not overwrite the stored DSN with the `clickhouse_dsn` from this run.
+
+### Create templates through the API
+
+In the full edition, call the API endpoint `POST /api/v2/storage/ego` for an existing database. The private-lite edition does not register the storage-creation API; use the `clickvisual ego` CLI instead. The API request requires an authenticated session (the default cookie name is `clickvisual_session`) and edit permission on the target database. If the deployment uses a subpath, include that subpath in the URL. The API creates templates only in an existing database: it does not create an instance or database, does not accept a cluster parameter, and uses the cluster metadata already stored on the target database. The CLI `ego` flow is responsible for creating or reusing the instance, creating the `logger` database, and performing cluster pre-validation.
+
+When the four topics are omitted in CLI/TOML configuration, `CmdFunc` supplies the built-in defaults. All four topic fields are `required` in the full-edition API JSON body; the API does not supply defaults, so each must be non-empty. `topicsEgo` and `topicsIngressStderr` are compatibility fields required by the API, but the current template service does not use them or create their tables.
+
+```bash
+curl --location --request POST 'http://127.0.0.1:19001/api/v2/storage/ego' \
+  --cookie 'clickvisual_session=<session-cookie>' \
+  --header 'Content-Type: application/json' \
+  --data-raw '{
+    "brokers": "kafka:9092",
+    "databaseId": 1,
+    "topicsApp": "app-stdout-logs-ilogtail",
+    "topicsEgo": "ego-stdout-logs-ilogtail",
+    "topicsIngressStdout": "ingress-stdout-logs-ilogtail",
+    "topicsIngressStderr": "ingress-stderr-logs-ilogtail"
+  }'
+```
 
 ### ClickHouse cluster
 
@@ -22,7 +44,7 @@ clickhouse_dsn = "tcp://localhost:9000?database=default&username=default&passwor
 # cluster = "shard2-repl1"
 ```
 
-Or pass it on the command line (a non-empty CLI value wins over TOML, after TrimSpace):
+Or pass it on the command line (a non-empty CLI value wins over TOML, after trimming surrounding whitespace):
 
 ```bash
 ./bin/clickvisual ego --config=./config/default.toml \
@@ -32,8 +54,8 @@ Or pass it on the command line (a non-empty CLI value wins over TOML, after Trim
 
 If `cluster` is omitted or empty, ego remains in standalone mode and does not query `system.clusters`. An explicit cluster is validated before the logger database and tables are created: an unknown name, query error, or `1 shard × 1 replica` topology fails; a cluster with multiple shards or multiple replicas passes. `--dry-run` only parses configuration and prints a summary—no ClickHouse connection or validation and no DDL are performed. DSN logs show only `configured` or `not configured`, never credentials.
 
-### topic
-Log topics come from `topics_app`, `topics_ego`, `topics_ingress_stdout`, and `topics_ingress_stderr` in the init TOML or from the corresponding command-line flags. If omitted, ego uses these built-in defaults:
+### Topics
+Log topics come from `topics_app`, `topics_ego`, `topics_ingress_stdout`, and `topics_ingress_stderr` in the init TOML or from the corresponding command-line flags. The current template service uses `topics_app` and `topics_ingress_stdout` to create the app stdout and ingress stdout tables. When omitted in CLI/TOML configuration, ego supplies the built-in defaults; the API endpoint does not supply defaults and requires all four fields to be non-empty. The JSON fields `topicsEgo` and `topicsIngressStderr` are compatibility fields required by the API, but the current service does not use them or create those tables.
 
 ```toml
 topics_app = "app-stdout-logs-ilogtail"
@@ -44,14 +66,7 @@ topics_ingress_stderr = "ingress-stderr-logs-ilogtail"
 
 
 ### Results
-- Created a ClickHouse instance record
+- Created or reused a ClickHouse instance record
 - Created the `logger` database (using the optional cluster setting)
-- Created app, ego, and ingress stdout/stderr log tables and consumption templates
+- Created app stdout and ingress stdout log tables and consumption templates
 - Wrote log-table metadata and analysis fields
-
-
-![img.png](../../../images/template_one_1.png)
-
-![img_1.png](../../../images/template_one_2.png)
-
-![img_2.png](../../../images/template_one_3.png)

--- a/docs/docs/zh/clickvisual/03funcintro/template-gen.md
+++ b/docs/docs/zh/clickvisual/03funcintro/template-gen.md
@@ -1,54 +1,53 @@
 # 日志库创建模板
 
-## 对 EGO 框架日志采集模板
+## 使用 ego 初始化
 
-### 单机创建
-注意是否配置了 subpath，如果环境变量中配置了子路径例如 /clickvisual/ 则需要从
-`http://127.0.0.1:19001/api/v1/template/1` 替换为 `http://127.0.0.1:19001/clickvisual/api/v1/template/1`
-```sh
-curl --location --request POST 'http://127.0.0.1:19001/api/v1/template/1' \
---header 'Content-Type: application/json' \
---data-raw '{
-    "dsn": "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60",
-    "clusterName": "clusterName",
-    "brokers": "kafka:9092"
-}'
+`ego` 命令会创建 ClickHouse 实例、`logger` 数据库和日志表模板。运行配置使用真实的 `config/default.toml`，初始化参数使用 `config/init-config.example.toml`：
+
+```bash
+./bin/clickvisual ego \
+  --config=./config/default.toml \
+  --init-config=./config/init-config.example.toml
 ```
 
-### 无副本集群创建
-注意是否配置了 subpath，如果环境变量中配置了子路径例如 /clickvisual/ 则需要从
-`http://127.0.0.1:19001/api/v1/template/1` 替换为 `http://127.0.0.1:19001/clickvisual/api/v1/template/1`
+初始化配置是 TOML。ClickHouse DSN 必须通过 `clickhouse_dsn` 或 `--clickhouse-dsn` 提供；Kafka brokers 和 topic 也可在 TOML 或对应 flag 中设置。
 
-k8sClusterName 为 k8s 集群的名称  
-instanceClusterName 为 ClickHouse 的 cluster
-```sh
-curl --location --request POST 'http://127.0.0.1:19001/api/v1/template/1' \
---header 'Content-Type: application/json' \
---data-raw '{
-    "dsn": "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60",
-    "k8sClusterName": "clusterName", 
-    "brokers": "kafka:9092",
-    "instanceClusterName": "shard2-repl1"
-}'
+### ClickHouse cluster
+
+`cluster` 是 ClickHouse `system.clusters` 中的名称，不是 Kubernetes cluster，也不是节点列表。可以在 TOML 中取消注释：
+
+```toml
+clickhouse_dsn = "tcp://localhost:9000?database=default&username=default&password="
+# ClickHouse cluster 名称；取消注释后启用集群模式
+# cluster = "shard2-repl1"
 ```
+
+或通过命令行指定（非空 CLI 值优先于 TOML，值会先 TrimSpace）：
+
+```bash
+./bin/clickvisual ego --config=./config/default.toml \
+  --init-config=./config/init-config.example.toml \
+  --cluster=shard2-repl1
+```
+
+省略 `cluster` 或传入空值时保持单机模式，且不会查询 `system.clusters`。显式 cluster 会在创建 logger 数据库和日志表之前校验：名称不存在、查询失败，或拓扑为 `1 shard × 1 replica` 时失败；多 shard 或多 replica 的 cluster 可以通过。`--dry-run` 只解析配置并输出摘要，不连接或校验 ClickHouse，也不执行 DDL。DSN 日志仅显示 `configured`/`not configured`，不会回显凭据。
 
 ### topic 说明
-%s 为参数调用中的 clusterName
-```
-var kafkaTopicORM = map[string]string{
-	"app_stdout":     "app-stdout-logs-%s",
-	"ego_stdout":     "ego-stdout-logs-%s",
-	"ingress_stdout": "ingress-stdout-logs-%s",
-	"ingress_stderr": "ingress-stderr-logs-%s",
-}
+日志 topic 由初始化 TOML 中的 `topics_app`、`topics_ego`、`topics_ingress_stdout`、`topics_ingress_stderr` 或对应命令行 flag 指定；未指定时使用 ego 内置默认值：
+
+```toml
+topics_app = "app-stdout-logs-ilogtail"
+topics_ego = "ego-stdout-logs-ilogtail"
+topics_ingress_stdout = "ingress-stdout-logs-ilogtail"
+topics_ingress_stderr = "ingress-stderr-logs-ilogtail"
 ```
 
 
 ### 效果
-- 创建 clickvisual_default 的实例
-- 创建 clickvisual_default 的数据库
-- 创建 app-stdout, ego-stdout, ingress-stdout, ingress-stderr 日志库
-- 创建日志库中的分析字段
+- 创建 ClickHouse 实例记录
+- 创建 `logger` 数据库（按可选 cluster 配置创建）
+- 创建 app、ego、ingress stdout/stderr 日志表和消费模板
+- 写入日志表 metadata 与分析字段
 
 
 ![img.png](../../../images/template_one_1.png)

--- a/docs/docs/zh/clickvisual/03funcintro/template-gen.md
+++ b/docs/docs/zh/clickvisual/03funcintro/template-gen.md
@@ -2,7 +2,7 @@
 
 ## 使用 ego 初始化
 
-`ego` 命令会创建 ClickHouse 实例、`logger` 数据库和日志表模板。运行配置使用真实的 `config/default.toml`，初始化参数使用 `config/init-config.example.toml`：
+`ego` 命令会创建或复用 ClickHouse 实例记录，创建 `logger` 数据库和日志表模板。运行配置使用真实的 `config/default.toml`，初始化参数使用 `config/init-config.example.toml`：
 
 ```bash
 ./bin/clickvisual ego \
@@ -11,6 +11,28 @@
 ```
 
 初始化配置是 TOML。ClickHouse DSN 必须通过 `clickhouse_dsn` 或 `--clickhouse-dsn` 提供；Kafka brokers 和 topic 也可在 TOML 或对应 flag 中设置。
+
+如果已存在名为 `clickhouse-instance` 的实例记录，命令会复用该记录；复用时不会用本次 `clickhouse_dsn` 覆盖已保存的 DSN。
+
+### 通过 API 创建模板
+
+在完整版中，已有数据库时可以调用 API 接口 `POST /api/v2/storage/ego` 创建模板。private-lite 不注册模板创建 API 接口，必须使用 `clickvisual ego` CLI。API 请求需要已认证会话（默认 cookie 名为 `clickvisual_session`）以及目标数据库的编辑权限；如果部署配置了 subpath，请在 URL 中加入该 subpath。API 只在已有数据库上创建模板，不创建实例或数据库，不接收 cluster 参数；cluster 取目标数据库已保存的元数据。实例、`logger` 数据库创建以及 cluster 预校验由 CLI `ego` 流程负责。
+
+CLI/TOML 中省略四个 topic 时，`CmdFunc` 会补上内置默认值；API 接口的四个 topic 字段均为必填，接口不会补默认值。`topicsEgo` 与 `topicsIngressStderr` 是 API 必填兼容字段，但当前模板服务不使用它们，也不会创建对应表。
+
+```bash
+curl --location --request POST 'http://127.0.0.1:19001/api/v2/storage/ego' \
+  --cookie 'clickvisual_session=<session-cookie>' \
+  --header 'Content-Type: application/json' \
+  --data-raw '{
+    "brokers": "kafka:9092",
+    "databaseId": 1,
+    "topicsApp": "app-stdout-logs-ilogtail",
+    "topicsEgo": "ego-stdout-logs-ilogtail",
+    "topicsIngressStdout": "ingress-stdout-logs-ilogtail",
+    "topicsIngressStderr": "ingress-stderr-logs-ilogtail"
+  }'
+```
 
 ### ClickHouse cluster
 
@@ -33,7 +55,7 @@ clickhouse_dsn = "tcp://localhost:9000?database=default&username=default&passwor
 省略 `cluster` 或传入空值时保持单机模式，且不会查询 `system.clusters`。显式 cluster 会在创建 logger 数据库和日志表之前校验：名称不存在、查询失败，或拓扑为 `1 shard × 1 replica` 时失败；多 shard 或多 replica 的 cluster 可以通过。`--dry-run` 只解析配置并输出摘要，不连接或校验 ClickHouse，也不执行 DDL。DSN 日志仅显示 `configured`/`not configured`，不会回显凭据。
 
 ### topic 说明
-日志 topic 由初始化 TOML 中的 `topics_app`、`topics_ego`、`topics_ingress_stdout`、`topics_ingress_stderr` 或对应命令行 flag 指定；未指定时使用 ego 内置默认值：
+日志 topic 由初始化 TOML 中的 `topics_app`、`topics_ego`、`topics_ingress_stdout`、`topics_ingress_stderr` 或对应命令行 flag 指定；当前模板服务使用 `topics_app` 和 `topics_ingress_stdout` 创建 app stdout、ingress stdout 表。CLI/TOML 中未指定时使用 ego 内置默认值；API 接口不会补默认值，四个字段都必须传入非空值。JSON 中的 `topicsEgo` 与 `topicsIngressStderr` 是 API 必填兼容字段，但当前模板服务不使用它们，也不会创建对应表：
 
 ```toml
 topics_app = "app-stdout-logs-ilogtail"
@@ -44,14 +66,7 @@ topics_ingress_stderr = "ingress-stderr-logs-ilogtail"
 
 
 ### 效果
-- 创建 ClickHouse 实例记录
+- 创建或复用 ClickHouse 实例记录
 - 创建 `logger` 数据库（按可选 cluster 配置创建）
-- 创建 app、ego、ingress stdout/stderr 日志表和消费模板
+- 创建 app stdout、ingress stdout 日志表和消费模板
 - 写入日志表 metadata 与分析字段
-
-
-![img.png](../../../images/template_one_1.png)
-
-![img_1.png](../../../images/template_one_2.png)
-
-![img_2.png](../../../images/template_one_3.png)


### PR DESCRIPTION
## Summary
- add ClickHouse cluster configuration through EGO CLI and TOML, with CLI precedence and single-node compatibility
- validate explicit `system.clusters` topology before logger metadata or storage changes, and preserve the complete database/cluster context through template creation
- keep dry-run side-effect free, redact ClickHouse credentials from logs, and align EGO examples plus Chinese/English public docs

## Verification
- `go test ./api/cmd/ego -count=1`
- `go test -race ./api/cmd/ego -count=1`
- `go vet ./api/cmd/ego`
- `go build -o /tmp/clickvisual-ego-pr-build ./api/cmd/ego`
- `git diff --check origin/master...HEAD`
- final Standards and Spec reviews: Critical 0 / Important 0 / Minor 0

## Known baseline issue
- `go test ./api/internal/service/inquiry/clickhouse -count=1` fails in both this branch and `origin/master@f969df3f` on the same existing `Test_adaSelectPart/test-3` and `Test_adaSelectPart1/test-1` assertions

## Manual smoke
- Pending against a real multi-shard or multi-replica ClickHouse cluster; automated EGO coverage is complete