### PR TITLE
feat(query): TECHNOLOGY-3829 优化日志查询交互、主题与短链分享

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 logs
 data
+devops
+.agents
 ui/node_modules
 ui-v2/node_modules
 bin

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ proxt.ts
 /configs
 /api/bin
 /api/logs
+/devops/
 
 /data/k8s/fluent-bit/
 /data/all-in-one/kafka/data/

--- a/api/internal/api/apiv2/base/shorturl.go
+++ b/api/internal/api/apiv2/base/shorturl.go
@@ -32,7 +32,7 @@ func ShortURLRedirect(c *core.Context) {
 		elog.Error("update call cnt error", elog.FieldErr(err))
 		return
 	}
-	c.Redirect(301, shortUrl.OriginUrl)
+	c.Redirect(301, shorturl.NormalizeRedirectURL(shortUrl.OriginUrl))
 }
 
 // ShortURLCreate  godoc

--- a/api/internal/api/apiv2/query/compile.go
+++ b/api/internal/api/apiv2/query/compile.go
@@ -11,6 +11,7 @@ import (
 	"github.com/clickvisual/clickvisual/api/internal/pkg/constx"
 	dbmodel "github.com/clickvisual/clickvisual/api/internal/pkg/model/db"
 	view "github.com/clickvisual/clickvisual/api/internal/pkg/model/view"
+	"github.com/clickvisual/clickvisual/api/internal/service"
 	"github.com/clickvisual/clickvisual/api/internal/service/querycompile"
 )
 
@@ -63,11 +64,12 @@ func buildCompileContext(tid int) (querycompile.CompileContext, error) {
 	if tableInfo.Name == "" || tableInfo.Database == nil {
 		return querycompile.CompileContext{}, fmt.Errorf("table %d not found", tid)
 	}
+	rawLogFieldExists, defaultRawLogExists := rawLogColumnAvailability(tableInfo)
 	rawLogColumn, rawLogUnavailable := rawLogColumnForTable(
 		tableInfo.CreateType,
 		tableInfo.RawLogField,
-		tableColumnRecorded(tableInfo.ID, tableInfo.RawLogField),
-		tableColumnRecorded(tableInfo.ID, "_raw_log_"),
+		rawLogFieldExists,
+		defaultRawLogExists,
 	)
 	return querycompile.CompileContext{
 		TableName:                fmt.Sprintf("`%s`.`%s`", tableInfo.Database.Name, tableInfo.Name),
@@ -90,6 +92,54 @@ func rawLogColumnForTable(createType int, rawLogField string, rawLogFieldExists 
 		return "", true
 	}
 	return "_raw_log_", false
+}
+
+func rawLogColumnAvailability(tableInfo dbmodel.BaseTable) (rawLogFieldExists bool, defaultRawLogExists bool) {
+	rawLogField := strings.TrimSpace(tableInfo.RawLogField)
+	rawLogFieldExists = rawLogField != "" && tableColumnRecorded(tableInfo.ID, rawLogField)
+	defaultRawLogExists = tableColumnRecorded(tableInfo.ID, "_raw_log_")
+	if tableInfo.CreateType != constx.TableCreateTypeExist {
+		return rawLogFieldExists, defaultRawLogExists
+	}
+	if rawLogField != "" && rawLogFieldExists {
+		return rawLogFieldExists, defaultRawLogExists
+	}
+	if rawLogField == "" && defaultRawLogExists {
+		return rawLogFieldExists, defaultRawLogExists
+	}
+	columns := tablePhysicalColumns(tableInfo)
+	if rawLogField != "" && columns[rawLogField] {
+		rawLogFieldExists = true
+	}
+	if columns["_raw_log_"] {
+		defaultRawLogExists = true
+	}
+	return rawLogFieldExists, defaultRawLogExists
+}
+
+func tablePhysicalColumns(tableInfo dbmodel.BaseTable) map[string]bool {
+	columns := make(map[string]bool)
+	if tableInfo.Database == nil || tableInfo.Database.Name == "" || tableInfo.Name == "" {
+		return columns
+	}
+	op, err := service.InstanceManager.Load(tableInfo.Database.Iid)
+	if err != nil {
+		return columns
+	}
+	list, err := op.ListColumn(tableInfo.Database.Name, tableInfo.Name, false)
+	if err != nil {
+		return columns
+	}
+	for _, item := range list {
+		if item == nil {
+			continue
+		}
+		name := strings.TrimSpace(item.Name)
+		if name != "" {
+			columns[name] = true
+		}
+	}
+	return columns
 }
 
 func tableColumnRecorded(tid int, field string) bool {

--- a/api/internal/api/apiv2/query/run.go
+++ b/api/internal/api/apiv2/query/run.go
@@ -1,6 +1,8 @@
 package query
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -55,6 +57,18 @@ type FieldStatsResponse struct {
 	Plan  view.QueryPlan   `json:"plan"`
 }
 
+type sqlExecutor interface {
+	DoSQL(string) (view.RespComplete, error)
+}
+
+type contextSQLExecutor interface {
+	DoSQLContext(context.Context, string) (view.RespComplete, error)
+}
+
+func isRequestCanceled(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
 // Run godoc
 // @Summary      执行结构化日志查询
 // @Tags         QUERY
@@ -90,8 +104,11 @@ func Run(c *core.Context) {
 		c.JSONE(core.CodeErr, "clickhouse i/o timeout", err)
 		return
 	}
-	result, err := runStructuredQueryWithFallback(op, req, ctx)
+	result, err := runStructuredQueryWithFallback(c.Request.Context(), op, req, ctx)
 	if err != nil {
+		if isRequestCanceled(err) {
+			return
+		}
 		c.JSONE(core.CodeErr, err.Error(), err)
 		return
 	}
@@ -106,10 +123,8 @@ func Run(c *core.Context) {
 	})
 }
 
-func runStructuredQueryWithFallback(op interface {
-	DoSQL(string) (view.RespComplete, error)
-}, req view.QueryRequestV2, ctx querycompile.CompileContext) (queryRunResult, error) {
-	result, err := runStructuredQueryOnce(op, req, ctx)
+func runStructuredQueryWithFallback(reqCtx context.Context, op sqlExecutor, req view.QueryRequestV2, ctx querycompile.CompileContext) (queryRunResult, error) {
+	result, err := runStructuredQueryOnce(reqCtx, op, req, ctx)
 	if err != nil {
 		return queryRunResult{}, err
 	}
@@ -120,7 +135,7 @@ func runStructuredQueryWithFallback(op interface {
 	if !ok {
 		return result, nil
 	}
-	fallbackResult, err := runStructuredQueryOnce(op, fallbackReq, ctx)
+	fallbackResult, err := runStructuredQueryOnce(reqCtx, op, fallbackReq, ctx)
 	if err != nil {
 		elog.Warn("query v2 raw log fallback failed", elog.FieldErr(err), elog.String("sql", result.SQL))
 		return result, nil
@@ -131,9 +146,7 @@ func runStructuredQueryWithFallback(op interface {
 	return result, nil
 }
 
-func runStructuredQueryOnce(op interface {
-	DoSQL(string) (view.RespComplete, error)
-}, req view.QueryRequestV2, ctx querycompile.CompileContext) (queryRunResult, error) {
+func runStructuredQueryOnce(reqCtx context.Context, op sqlExecutor, req view.QueryRequestV2, ctx querycompile.CompileContext) (queryRunResult, error) {
 	sql, plan, err := querycompile.Compile(req, ctx)
 	if err != nil {
 		return queryRunResult{}, err
@@ -142,15 +155,20 @@ func runStructuredQueryOnce(op interface {
 	if err != nil {
 		return queryRunResult{}, err
 	}
-	logs, err := op.DoSQL(sql)
+	logs, err := runSQL(reqCtx, op, sql)
 	if err != nil {
-		elog.Error("query v2 run logs failed", elog.FieldErr(err), elog.String("sql", sql))
+		if !isRequestCanceled(err) {
+			elog.Error("query v2 run logs failed", elog.FieldErr(err), elog.String("sql", sql))
+		}
 		return queryRunResult{}, err
 	}
 	count := uint64(len(logs.Logs))
-	if countResp, countErr := op.DoSQL(countSQL); countErr == nil {
+	if countResp, countErr := runSQL(reqCtx, op, countSQL); countErr == nil {
 		count = extractCount(countResp.Logs, count)
 	} else {
+		if isRequestCanceled(countErr) {
+			return queryRunResult{}, countErr
+		}
 		elog.Warn("query v2 run count failed", elog.FieldErr(countErr), elog.String("sql", countSQL))
 	}
 	return queryRunResult{
@@ -250,8 +268,11 @@ func FieldStats(c *core.Context) {
 		c.JSONE(core.CodeErr, "clickhouse i/o timeout", err)
 		return
 	}
-	result, err := runFieldStatsWithFallback(op, req, ctx)
+	result, err := runFieldStatsWithFallback(c.Request.Context(), op, req, ctx)
 	if err != nil {
+		if isRequestCanceled(err) {
+			return
+		}
 		c.JSONE(core.CodeErr, err.Error(), err)
 		return
 	}
@@ -263,10 +284,8 @@ func FieldStats(c *core.Context) {
 	})
 }
 
-func runFieldStatsWithFallback(op interface {
-	DoSQL(string) (view.RespComplete, error)
-}, req view.QueryFieldStatsRequest, ctx querycompile.CompileContext) (fieldStatsRunResult, error) {
-	result, err := runFieldStatsOnce(op, req, ctx)
+func runFieldStatsWithFallback(reqCtx context.Context, op sqlExecutor, req view.QueryFieldStatsRequest, ctx querycompile.CompileContext) (fieldStatsRunResult, error) {
+	result, err := runFieldStatsOnce(reqCtx, op, req, ctx)
 	if err != nil {
 		return fieldStatsRunResult{}, err
 	}
@@ -277,7 +296,7 @@ func runFieldStatsWithFallback(op interface {
 	if !ok {
 		return result, nil
 	}
-	fallbackResult, err := runFieldStatsOnce(op, fallbackReq, ctx)
+	fallbackResult, err := runFieldStatsOnce(reqCtx, op, fallbackReq, ctx)
 	if err != nil {
 		elog.Warn("query v2 field stats raw log fallback failed", elog.FieldErr(err), elog.String("sql", result.SQL))
 		return result, nil
@@ -288,22 +307,24 @@ func runFieldStatsWithFallback(op interface {
 	return result, nil
 }
 
-func runFieldStatsOnce(op interface {
-	DoSQL(string) (view.RespComplete, error)
-}, req view.QueryFieldStatsRequest, ctx querycompile.CompileContext) (fieldStatsRunResult, error) {
+func runFieldStatsOnce(reqCtx context.Context, op sqlExecutor, req view.QueryFieldStatsRequest, ctx querycompile.CompileContext) (fieldStatsRunResult, error) {
 	statsSQL, totalSQL, plan, err := querycompile.CompileFieldStats(req, ctx)
 	if err != nil {
 		return fieldStatsRunResult{}, err
 	}
-	totalResp, err := op.DoSQL(totalSQL)
+	totalResp, err := runSQL(reqCtx, op, totalSQL)
 	if err != nil {
-		elog.Error("query v2 field stats total failed", elog.FieldErr(err), elog.String("sql", totalSQL))
+		if !isRequestCanceled(err) {
+			elog.Error("query v2 field stats total failed", elog.FieldErr(err), elog.String("sql", totalSQL))
+		}
 		return fieldStatsRunResult{}, err
 	}
 	total := extractCount(totalResp.Logs, 0)
-	statsResp, err := op.DoSQL(statsSQL)
+	statsResp, err := runSQL(reqCtx, op, statsSQL)
 	if err != nil {
-		elog.Error("query v2 field stats failed", elog.FieldErr(err), elog.String("sql", statsSQL))
+		if !isRequestCanceled(err) {
+			elog.Error("query v2 field stats failed", elog.FieldErr(err), elog.String("sql", statsSQL))
+		}
 		return fieldStatsRunResult{}, err
 	}
 	items := make([]FieldStatsItem, 0, len(statsResp.Logs))
@@ -325,6 +346,23 @@ func runFieldStatsOnce(op interface {
 		SQL:   statsSQL,
 		Plan:  plan,
 	}, nil
+}
+
+func runSQL(reqCtx context.Context, op sqlExecutor, sql string) (view.RespComplete, error) {
+	if err := reqCtx.Err(); err != nil {
+		return view.RespComplete{}, err
+	}
+	if contextOp, ok := op.(contextSQLExecutor); ok {
+		return contextOp.DoSQLContext(reqCtx, sql)
+	}
+	resp, err := op.DoSQL(sql)
+	if err != nil {
+		return resp, err
+	}
+	if err := reqCtx.Err(); err != nil {
+		return view.RespComplete{}, err
+	}
+	return resp, nil
 }
 
 func rawLogFieldStatsFallbackRequest(req view.QueryFieldStatsRequest) (view.QueryFieldStatsRequest, bool) {
@@ -352,11 +390,12 @@ func buildRunContext(tid int) (querycompile.CompileContext, dbmodel.BaseTable, e
 	if tableInfo.Name == "" || tableInfo.Database == nil {
 		return querycompile.CompileContext{}, dbmodel.BaseTable{}, fmt.Errorf("table %d not found", tid)
 	}
+	rawLogFieldExists, defaultRawLogExists := rawLogColumnAvailability(tableInfo)
 	rawLogColumn, rawLogUnavailable := rawLogColumnForTable(
 		tableInfo.CreateType,
 		tableInfo.RawLogField,
-		tableColumnRecorded(tableInfo.ID, tableInfo.RawLogField),
-		tableColumnRecorded(tableInfo.ID, "_raw_log_"),
+		rawLogFieldExists,
+		defaultRawLogExists,
 	)
 	return querycompile.CompileContext{
 		TableName:                fmt.Sprintf("`%s`.`%s`", tableInfo.Database.Name, tableInfo.Name),

--- a/api/internal/api/apiv2/query/run_test.go
+++ b/api/internal/api/apiv2/query/run_test.go
@@ -1,13 +1,36 @@
 package query
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/clickvisual/clickvisual/api/internal/pkg/constx"
 	view "github.com/clickvisual/clickvisual/api/internal/pkg/model/view"
+	"github.com/clickvisual/clickvisual/api/internal/service/querycompile"
 )
+
+type cancelAfterFirstSQLOperator struct {
+	cancel context.CancelFunc
+	calls  []string
+}
+
+func (o *cancelAfterFirstSQLOperator) DoSQL(sql string) (view.RespComplete, error) {
+	o.calls = append(o.calls, sql)
+	return view.RespComplete{}, nil
+}
+
+func (o *cancelAfterFirstSQLOperator) DoSQLContext(_ context.Context, sql string) (view.RespComplete, error) {
+	o.calls = append(o.calls, sql)
+	if len(o.calls) == 1 {
+		o.cancel()
+		return view.RespComplete{Logs: []map[string]interface{}{{"count": uint64(1)}}}, nil
+	}
+	return view.RespComplete{Logs: []map[string]interface{}{{"field_value": "svc", "count": uint64(1)}}}, nil
+}
 
 func TestRawLogFallbackRequestRewritesBusinessColumns(t *testing.T) {
 	req := view.QueryRequestV2{
@@ -108,6 +131,37 @@ func TestRawLogFieldStatsFallbackRequestRewritesFieldAndFilters(t *testing.T) {
 	assert.Equal(t, view.QueryFieldSourceJSONPath, next.Conditions[0].Field.Source)
 	assert.Equal(t, "status", next.Conditions[0].Field.Path)
 	assert.False(t, next.Conditions[0].Field.IsAccelerated)
+}
+
+func TestRunFieldStatsStopsBeforeStatsQueryWhenContextIsCanceled(t *testing.T) {
+	reqCtx, cancel := context.WithCancel(context.Background())
+	op := &cancelAfterFirstSQLOperator{cancel: cancel}
+	req := view.QueryFieldStatsRequest{
+		QueryRequestV2: view.QueryRequestV2{
+			ST: 1785254400,
+			ET: 1785340740,
+		},
+		Field: view.QueryFieldRef{
+			FieldKey:       "container.name",
+			DisplayName:    "container.name",
+			Source:         view.QueryFieldSourceColumn,
+			Path:           "container.name",
+			ValueType:      view.QueryValueTypeString,
+			IsAccelerated:  true,
+			AcceleratedCol: "container.name",
+		},
+		Limit: 10,
+	}
+
+	_, err := runFieldStatsOnce(reqCtx, op, req, querycompile.CompileContext{
+		TableName: "`logger`.`app_stdout`",
+		TimeField: "_time_second_",
+	})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled), "expected context.Canceled, got %v", err)
+	assert.Len(t, op.calls, 1)
+	assert.Contains(t, op.calls[0], "SELECT count() AS count")
 }
 
 func TestRawLogColumnForTableUsesStoredRawLogFieldOnlyForExistingTable(t *testing.T) {

--- a/api/internal/api/apiv2/query/token.go
+++ b/api/internal/api/apiv2/query/token.go
@@ -150,9 +150,12 @@ func TokenRun(c *core.Context) {
 		c.JSONE(core.CodeErr, "clickhouse i/o timeout", err)
 		return
 	}
-	result, err := runStructuredQueryWithFallback(op, req, ctx)
+	result, err := runStructuredQueryWithFallback(c.Request.Context(), op, req, ctx)
 	costMs := time.Since(startedAt).Milliseconds()
 	if err != nil {
+		if isRequestCanceled(err) {
+			return
+		}
 		recordTokenAudit(c, principal, tableInfo, req, 0, costMs, querytoken.AuditStatusFailed, err)
 		c.JSONE(core.CodeErr, err.Error(), err)
 		return

--- a/api/internal/api/apiv2/storage/storage.go
+++ b/api/internal/api/apiv2/storage/storage.go
@@ -151,10 +151,10 @@ func supportsGlobalMatchForTable(tableInfo db.BaseTable, fields []*db.BaseIndex)
 		return true
 	}
 	rawLogField := strings.TrimSpace(tableInfo.RawLogField)
-	if rawLogField != "" && analysisFieldExists(fields, rawLogField) {
+	if rawLogField != "" && (analysisFieldExists(fields, rawLogField) || physicalTableColumnExists(tableInfo, rawLogField)) {
 		return true
 	}
-	return analysisFieldExists(fields, "_raw_log_")
+	return analysisFieldExists(fields, "_raw_log_") || physicalTableColumnExists(tableInfo, "_raw_log_")
 }
 
 func analysisFieldExists(fields []*db.BaseIndex, field string) bool {
@@ -167,6 +167,30 @@ func analysisFieldExists(fields []*db.BaseIndex, field string) bool {
 			continue
 		}
 		if item.GetFieldName() == field || strings.TrimSpace(item.Field) == field {
+			return true
+		}
+	}
+	return false
+}
+
+func physicalTableColumnExists(tableInfo db.BaseTable, field string) bool {
+	field = strings.TrimSpace(field)
+	if field == "" || tableInfo.Database == nil || tableInfo.Database.Name == "" || tableInfo.Name == "" {
+		return false
+	}
+	op, err := service.InstanceManager.Load(tableInfo.Database.Iid)
+	if err != nil {
+		return false
+	}
+	columns, err := op.ListColumn(tableInfo.Database.Name, tableInfo.Name, false)
+	if err != nil {
+		return false
+	}
+	for _, item := range columns {
+		if item == nil {
+			continue
+		}
+		if strings.TrimSpace(item.Name) == field {
 			return true
 		}
 	}

--- a/api/internal/api/apiv2/storage/storage_test.go
+++ b/api/internal/api/apiv2/storage/storage_test.go
@@ -9,10 +9,28 @@ import (
 	"github.com/clickvisual/clickvisual/api/internal/invoker"
 	"github.com/clickvisual/clickvisual/api/internal/pkg/component/core"
 	"github.com/clickvisual/clickvisual/api/internal/pkg/config"
+	"github.com/clickvisual/clickvisual/api/internal/pkg/constx"
+	"github.com/clickvisual/clickvisual/api/internal/pkg/model/db"
 	"github.com/clickvisual/clickvisual/api/internal/pkg/model/view"
 	"github.com/clickvisual/clickvisual/api/internal/router/middlewares"
 	"github.com/clickvisual/clickvisual/api/internal/service"
 )
+
+func TestSupportsGlobalMatchForTableUsesMetadata(t *testing.T) {
+	assert.True(t, supportsGlobalMatchForTable(db.BaseTable{CreateType: constx.TableCreateTypeJSONEachRow}, nil))
+
+	assert.True(t, supportsGlobalMatchForTable(
+		db.BaseTable{CreateType: constx.TableCreateTypeExist, RawLogField: " body "},
+		[]*db.BaseIndex{{Field: "body"}},
+	))
+
+	assert.True(t, supportsGlobalMatchForTable(
+		db.BaseTable{CreateType: constx.TableCreateTypeExist},
+		[]*db.BaseIndex{{Field: "_raw_log_"}},
+	))
+
+	assert.False(t, supportsGlobalMatchForTable(db.BaseTable{CreateType: constx.TableCreateTypeExist}, nil))
+}
 
 func TestCreateJSONAsString(t *testing.T) {
 	config.InitCfg()

--- a/api/internal/router/router_test.go
+++ b/api/internal/router/router_test.go
@@ -186,6 +186,7 @@ func TestV2RoutesPrivateLiteEdition(t *testing.T) {
 		{method: http.MethodGet, path: "/api/v2/base/instances"},
 		{method: http.MethodGet, path: "/api/v2/base/settings/instances"},
 		{method: http.MethodPost, path: "/api/v2/base/shorturls"},
+		{method: http.MethodGet, path: "/api/v2/storage/:storage-id/analysis-fields"},
 		{method: http.MethodGet, path: "/api/v2/query/filters"},
 		{method: http.MethodGet, path: "/api/v2/query/instances/:instance-id/databases/:database/tables"},
 		{method: http.MethodPost, path: "/api/v2/query/compile"},

--- a/api/internal/router/v2.go
+++ b/api/internal/router/v2.go
@@ -185,6 +185,7 @@ func v2PrivateLite(r *gin.RouterGroup) {
 	}
 	// Log query APIs. Log table creation stays outside HTTP in private-lite mode and is driven by `clickvisual ego`.
 	{
+		r.GET("/storage/:storage-id/analysis-fields", core.Handle(storage.AnalysisFields))
 		r.GET("/query/filters", core.Handle(queryv2.List))
 		r.GET("/query/filters/:filter-id", core.Handle(queryv2.Get))
 		r.POST("/query/filters", core.Handle(queryv2.Create))

--- a/api/internal/service/inquiry/clickhouse/clickhouse.go
+++ b/api/internal/service/inquiry/clickhouse/clickhouse.go
@@ -698,8 +698,12 @@ func (c *ClickHouseX) DeleteDatabase(name string, cluster string) (err error) {
 }
 
 func (c *ClickHouseX) DoSQL(sql string) (res view.RespComplete, err error) {
+	return c.DoSQLContext(context.Background(), sql)
+}
+
+func (c *ClickHouseX) DoSQLContext(ctx context.Context, sql string) (res view.RespComplete, err error) {
 	res.Logs = make([]map[string]interface{}, 0)
-	tmp, err := c.doQueryWithRetry(sql, true)
+	tmp, err := c.doQueryWithRetryContext(ctx, sql, true)
 	if err != nil {
 		return
 	}
@@ -2154,28 +2158,36 @@ func (c *ClickHouseX) groupBySQL(param view.ReqQuery) (sql string) {
 }
 
 func (c *ClickHouseX) doQueryWithRetry(sql string, isShowNull bool) (res []map[string]interface{}, err error) {
-	res, err = c.doQuery(sql, isShowNull)
+	return c.doQueryWithRetryContext(context.Background(), sql, isShowNull)
+}
+
+func (c *ClickHouseX) doQueryWithRetryContext(ctx context.Context, sql string, isShowNull bool) (res []map[string]interface{}, err error) {
+	res, err = c.doQueryContext(ctx, sql, isShowNull)
 	if err != nil {
 		elog.Error("doQueryFailed", elog.Any("step", "doQuery"), elog.Any("sql", sql), l.E(err))
-		// if strings.Contains(err.Error(), "password is incorrect") {
-		elog.Error("doQueryWithRetry", elog.Any("step", "doQuery"), elog.Any("sql", sql), l.E(err))
 		// 重试十次
 		maxRetries := 10
 		for i := 0; i < maxRetries; i++ {
-			res, err = c.doQuery(sql, isShowNull)
+			if ctx.Err() != nil {
+				return res, err
+			}
+			res, err = c.doQueryContext(ctx, sql, isShowNull)
 			if err == nil || !strings.Contains(err.Error(), "password is incorrect") {
 				return res, err
 			}
 			elog.Error("doQueryWithRetry", elog.Any("step", "retry"), elog.Any("attempt", i+1), elog.Any("sql", sql), l.E(err))
-			// }
 		}
 	}
 	return res, err
 }
 
 func (c *ClickHouseX) doQuery(sql string, isShowNull bool) (res []map[string]interface{}, err error) {
+	return c.doQueryContext(context.Background(), sql, isShowNull)
+}
+
+func (c *ClickHouseX) doQueryContext(ctx context.Context, sql string, isShowNull bool) (res []map[string]interface{}, err error) {
 	res = make([]map[string]interface{}, 0)
-	rows, err := c.db.Query(sql)
+	rows, err := c.db.QueryContext(ctx, sql)
 	if err != nil {
 		return res, errors.Wrap(err, sql)
 	}

--- a/api/internal/service/inquiry/databend/databend.go
+++ b/api/internal/service/inquiry/databend/databend.go
@@ -917,8 +917,12 @@ func (c *Databend) DeleteDatabase(name string, cluster string) (err error) {
 }
 
 func (c *Databend) DoSQL(sql string) (res view2.RespComplete, err error) {
+	return c.DoSQLContext(context.Background(), sql)
+}
+
+func (c *Databend) DoSQLContext(ctx context.Context, sql string) (res view2.RespComplete, err error) {
 	res.Logs = make([]map[string]interface{}, 0)
-	tmp, err := c.doQuery(sql)
+	tmp, err := c.doQueryContext(ctx, sql)
 	if err != nil {
 		return
 	}
@@ -927,8 +931,12 @@ func (c *Databend) DoSQL(sql string) (res view2.RespComplete, err error) {
 }
 
 func (c *Databend) doQuery(sql string) (res []map[string]interface{}, err error) {
+	return c.doQueryContext(context.Background(), sql)
+}
+
+func (c *Databend) doQueryContext(ctx context.Context, sql string) (res []map[string]interface{}, err error) {
 	res = make([]map[string]interface{}, 0)
-	rows, err := c.db.Query(sql)
+	rows, err := c.db.QueryContext(ctx, sql)
 	if err != nil {
 		return res, errors.Wrap(err, sql)
 	}

--- a/api/internal/service/querycompile/compiler.go
+++ b/api/internal/service/querycompile/compiler.go
@@ -141,7 +141,6 @@ func compileCondition(cond view.QueryConditionV2, ctx CompileContext) (expr stri
 	if err != nil {
 		return "", view.PlannedCondition{}, err
 	}
-	fieldExpr, cond = normalizeLogLevelCondition(fieldExpr, cond)
 	expr, err = compileOperator(fieldExpr, cond.Operator, cond.Value, cond.ValueTo, cond.Field.ValueType)
 	if err != nil {
 		return "", view.PlannedCondition{}, err
@@ -186,53 +185,6 @@ func compileRawLogEscapedQuoteFallback(expr string, cond view.QueryConditionV2, 
 		return fmt.Sprintf("(%s NOT LIKE '%%%s%%' AND %s NOT LIKE '%%%s%%')", expr, normalPattern, expr, jsonEscapedPattern)
 	}
 	return fmt.Sprintf("(%s LIKE '%%%s%%' OR %s LIKE '%%%s%%')", expr, normalPattern, expr, jsonEscapedPattern)
-}
-
-func normalizeLogLevelCondition(expr string, cond view.QueryConditionV2) (string, view.QueryConditionV2) {
-	if !isLogLevelField(cond.Field.FieldKey) && !isLogLevelField(cond.Field.Path) {
-		return expr, cond
-	}
-	if cond.Field.ValueType != view.QueryValueTypeString && cond.Field.ValueType != view.QueryValueTypeUnknown {
-		return expr, cond
-	}
-	switch cond.Operator {
-	case view.QueryOperatorEQ, view.QueryOperatorNEQ, view.QueryOperatorContains, view.QueryOperatorNotContains, view.QueryOperatorIn:
-	default:
-		return expr, cond
-	}
-	cond.Value = normalizeLogLevelValue(cond.Value)
-	cond.ValueTo = normalizeLogLevelValue(cond.ValueTo)
-	return fmt.Sprintf("lowerUTF8(replaceRegexpAll(%s, '\\x1b\\\\[[0-9;]*m', ''))", expr), cond
-}
-
-func isLogLevelField(field string) bool {
-	switch strings.ToLower(strings.TrimSpace(field)) {
-	case "lv", "level", "severity", "log_level":
-		return true
-	default:
-		return false
-	}
-}
-
-func normalizeLogLevelValue(value interface{}) interface{} {
-	switch typed := value.(type) {
-	case []interface{}:
-		items := make([]interface{}, 0, len(typed))
-		for _, item := range typed {
-			items = append(items, normalizeLogLevelValue(item))
-		}
-		return items
-	case []string:
-		items := make([]string, 0, len(typed))
-		for _, item := range typed {
-			items = append(items, strings.ToLower(strings.TrimSpace(item)))
-		}
-		return items
-	case string:
-		return strings.ToLower(strings.TrimSpace(typed))
-	default:
-		return value
-	}
 }
 
 func buildFieldExpression(field view.QueryFieldRef, ctx CompileContext) (expr string, execution string, highCost bool, err error) {

--- a/api/internal/service/querycompile/compiler_test.go
+++ b/api/internal/service/querycompile/compiler_test.go
@@ -307,7 +307,7 @@ func TestCompileRawLogLogicalFieldRequiresConfiguredRawColumn(t *testing.T) {
 	assert.Contains(t, err.Error(), "未配置日志内容字段")
 }
 
-func TestCompileNormalizesLogLevelEquality(t *testing.T) {
+func TestCompileUsesExactJSONPathConditionForLogLevelEquality(t *testing.T) {
 	req := view.QueryRequestV2{
 		Tid: 1,
 		ST:  1710000000,
@@ -335,11 +335,12 @@ func TestCompileNormalizesLogLevelEquality(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.Contains(t, sql, "lowerUTF8(replaceRegexpAll(JSONExtractString(_raw_log_, 'lv')")
+	assert.Contains(t, sql, "JSONExtractString(_raw_log_, 'lv') = 'warn'")
+	assert.NotContains(t, sql, "lowerUTF8(replaceRegexpAll")
 	assert.Contains(t, sql, "= 'warn'")
 }
 
-func TestCompileNormalizesLogLevelColumnEquality(t *testing.T) {
+func TestCompileUsesExactColumnConditionForLogLevelEquality(t *testing.T) {
 	req := view.QueryRequestV2{
 		Tid: 1,
 		ST:  1710000000,
@@ -367,9 +368,9 @@ func TestCompileNormalizesLogLevelColumnEquality(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.Contains(t, sql, "lowerUTF8(replaceRegexpAll(`lv`")
+	assert.Contains(t, sql, "`lv` = 'WARN'")
+	assert.NotContains(t, sql, "lowerUTF8(replaceRegexpAll(`lv`")
 	assert.NotContains(t, sql, "JSONExtractString(_raw_log_, 'lv')")
-	assert.Contains(t, sql, "= 'warn'")
 }
 
 func TestCompileSupportsNestedJSONPath(t *testing.T) {
@@ -482,8 +483,10 @@ func TestCompileFieldStatsUsesCurrentFilters(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Contains(t, statsSQL, "_time_second_ >= toDateTime(1710000000)")
-	assert.Contains(t, statsSQL, "lowerUTF8(replaceRegexpAll(`lv`")
-	assert.Contains(t, statsSQL, "= 'error'")
+	assert.Contains(t, statsSQL, "`lv` = 'error'")
+	assert.NotContains(t, statsSQL, "lowerUTF8(replaceRegexpAll(`lv`")
+	assert.Contains(t, totalSQL, "`lv` = 'error'")
+	assert.NotContains(t, totalSQL, "lowerUTF8(replaceRegexpAll(`lv`")
 	assert.Contains(t, statsSQL, "ifNull(toString(`container.name`), '') != ''")
 	assert.Contains(t, statsSQL, "GROUP BY field_value")
 	assert.Contains(t, statsSQL, "LIMIT 5")

--- a/api/internal/service/shorturl/shorturl.go
+++ b/api/internal/service/shorturl/shorturl.go
@@ -3,6 +3,7 @@ package shorturl
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -15,6 +16,8 @@ import (
 	"github.com/clickvisual/clickvisual/api/internal/pkg/model/db"
 )
 
+type shareTableIDResolver func(url.Values) int
+
 func Clean() {
 	for {
 		time.Sleep(time.Minute * 10)
@@ -23,13 +26,10 @@ func Clean() {
 }
 
 func GenShortURL(ur string) (string, error) {
-	u, err := url.Parse(ur)
+	u2, err := normalizeOriginURL(ur, resolveShareTableID)
 	if err != nil {
-		return "", fmt.Errorf("url parse error: %w", err)
+		return "", err
 	}
-	v := u.Query()
-	v.Set("tab", "custom")
-	u2 := fmt.Sprintf("%s://%s%s?%s", u.Scheme, u.Host, u.Path, v.Encode())
 	// 判断是否存在相同的记录
 	existShortURL, _ := db.ShortURLInfoByURL(invoker.Db, u2)
 	if existShortURL.ID != 0 {
@@ -57,4 +57,131 @@ func GenShortURL(ur string) (string, error) {
 	short := fmt.Sprintf("%s/api/share/%s", rootUrl, sCode)
 	elog.Info("GenShortURL", elog.String("short", short), elog.String("originUrl", u2))
 	return short, nil
+}
+
+func NormalizeRedirectURL(ur string) string {
+	u2, err := normalizeOriginURL(ur, resolveShareTableID)
+	if err != nil {
+		return ur
+	}
+	return u2
+}
+
+func normalizeOriginURL(ur string, resolveTableID shareTableIDResolver) (string, error) {
+	u, err := url.Parse(ur)
+	if err != nil {
+		return "", fmt.Errorf("url parse error: %w", err)
+	}
+	v := u.Query()
+	normalizeShareTimeParams(v)
+	normalizeShareQueryParams(v)
+	normalizeShareTableParams(v, resolveTableID)
+	v.Set("tab", "custom")
+	u.RawQuery = v.Encode()
+	u.Fragment = ""
+	return u.String(), nil
+}
+
+func normalizeShareTimeParams(values url.Values) {
+	if values.Get("start") != "" && values.Get("end") != "" {
+		return
+	}
+	start := parseShareDateTime(values.Get("startTime"))
+	end := parseShareDateTime(values.Get("endTime"))
+	if start <= 0 || end <= start {
+		return
+	}
+	values.Set("start", strconv.FormatInt(start, 10))
+	values.Set("end", strconv.FormatInt(end, 10))
+	values.Del("startTime")
+	values.Del("endTime")
+}
+
+func parseShareDateTime(value string) int64 {
+	rawValue := strings.TrimSpace(value)
+	if rawValue == "" {
+		return 0
+	}
+	if unix, err := strconv.ParseInt(rawValue, 10, 64); err == nil && unix > 0 {
+		return unix
+	}
+	layouts := []string{
+		time.RFC3339,
+		"2006-01-02T15:04:05",
+		"2006-01-02T15:04",
+		"2006-01-02 15:04:05",
+		"2006-01-02 15:04",
+	}
+	for _, layout := range layouts {
+		parsed, err := time.ParseInLocation(layout, rawValue, time.Local)
+		if err == nil {
+			return parsed.Unix()
+		}
+	}
+	return 0
+}
+
+func normalizeShareQueryParams(values url.Values) {
+	if values.Get("kw") != "" {
+		return
+	}
+	query := strings.TrimSpace(values.Get("query"))
+	if query != "" {
+		values.Set("kw", query)
+	}
+}
+
+func normalizeShareTableParams(values url.Values, resolveTableID shareTableIDResolver) {
+	if values.Get("tid") != "" {
+		return
+	}
+	if tableID := parsePositiveInt(values.Get("tableId")); tableID > 0 {
+		values.Set("tid", strconv.Itoa(tableID))
+		return
+	}
+	if resolveTableID == nil {
+		return
+	}
+	if strings.TrimSpace(values.Get("database")) == "" || strings.TrimSpace(values.Get("table")) == "" {
+		return
+	}
+	tableID := resolveTableID(values)
+	if tableID > 0 {
+		values.Set("tid", strconv.Itoa(tableID))
+	}
+}
+
+func resolveShareTableID(values url.Values) int {
+	databaseName := strings.TrimSpace(values.Get("database"))
+	tableName := strings.TrimSpace(values.Get("table"))
+	if databaseName == "" || tableName == "" {
+		return 0
+	}
+	query := invoker.Db.Table(db.TableNameBaseTable+" AS t").
+		Select("t.id").
+		Joins("JOIN "+db.TableNameBaseDatabase+" AS d ON d.id = t.did").
+		Where("d.name = ? AND t.name = ? AND d.dtime = 0 AND t.dtime = 0", databaseName, tableName).
+		Order("t.id ASC")
+	instanceID := parsePositiveInt(values.Get("instanceId"))
+	if instanceID == 0 {
+		instanceID = parsePositiveInt(values.Get("iid"))
+	}
+	if instanceID > 0 {
+		query = query.Where("d.iid = ?", instanceID)
+	}
+	var result struct {
+		ID int
+	}
+	if err := query.First(&result).Error; err != nil {
+		return 0
+	}
+	return result.ID
+}
+
+func parsePositiveInt(value string) int {
+	parsed, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || parsed <= 0 {
+		return 0
+	}
+	return parsed
 }

--- a/api/internal/service/shorturl/shorturl_test.go
+++ b/api/internal/service/shorturl/shorturl_test.go
@@ -1,0 +1,97 @@
+package shorturl
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestNormalizeOriginURLAddsTableIDForDatabaseTableShare(t *testing.T) {
+	got, err := normalizeOriginURL(
+		"http://172.17.9.83/mdp/clickvisual/share/?start=1785138360&end=1785139260&database=logger&table=app_stdout",
+		func(values url.Values) int {
+			if values.Get("database") != "logger" || values.Get("table") != "app_stdout" {
+				t.Fatalf("unexpected table scope: %s.%s", values.Get("database"), values.Get("table"))
+			}
+			return 9527
+		},
+	)
+	if err != nil {
+		t.Fatalf("normalizeOriginURL error: %v", err)
+	}
+
+	parsed, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("parse normalized URL error: %v", err)
+	}
+	values := parsed.Query()
+	if values.Get("start") != "1785138360" {
+		t.Fatalf("start was not preserved: %q", values.Get("start"))
+	}
+	if values.Get("end") != "1785139260" {
+		t.Fatalf("end was not preserved: %q", values.Get("end"))
+	}
+	if values.Get("tid") != "9527" {
+		t.Fatalf("tid was not resolved: %q", values.Get("tid"))
+	}
+	if values.Get("tab") != "custom" {
+		t.Fatalf("tab was not normalized: %q", values.Get("tab"))
+	}
+}
+
+func TestNormalizeOriginURLAddsLegacyShareParamsForV2Share(t *testing.T) {
+	got, err := normalizeOriginURL(
+		"http://localhost/share?database=logger&table=app_stdout&startTime=2026-07-24T11:33&endTime=2026-07-24T11:48&query=%60lv%60+%3D+%27error%27",
+		func(url.Values) int {
+			return 9527
+		},
+	)
+	if err != nil {
+		t.Fatalf("normalizeOriginURL error: %v", err)
+	}
+
+	values, err := url.ParseQuery(mustParseURL(t, got).RawQuery)
+	if err != nil {
+		t.Fatalf("parse query error: %v", err)
+	}
+	if values.Get("start") == "" || values.Get("end") == "" {
+		t.Fatalf("start/end were not derived: %q %q", values.Get("start"), values.Get("end"))
+	}
+	if values.Get("startTime") != "" || values.Get("endTime") != "" {
+		t.Fatalf("startTime/endTime should be removed after normalization: %q %q", values.Get("startTime"), values.Get("endTime"))
+	}
+	if values.Get("kw") != "`lv` = 'error'" {
+		t.Fatalf("kw was not derived from query: %q", values.Get("kw"))
+	}
+	if values.Get("query") != "`lv` = 'error'" {
+		t.Fatalf("query was not preserved: %q", values.Get("query"))
+	}
+}
+
+func TestNormalizeOriginURLDoesNotResolveExistingTableID(t *testing.T) {
+	called := false
+	got, err := normalizeOriginURL(
+		"http://localhost/share?database=logger&table=app_stdout&tid=1001",
+		func(url.Values) int {
+			called = true
+			return 9527
+		},
+	)
+	if err != nil {
+		t.Fatalf("normalizeOriginURL error: %v", err)
+	}
+	if called {
+		t.Fatal("resolver should not be called when tid already exists")
+	}
+	if mustParseURL(t, got).Query().Get("tid") != "1001" {
+		t.Fatalf("existing tid was not preserved: %s", got)
+	}
+}
+
+func mustParseURL(t *testing.T, value string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(value)
+	if err != nil {
+		t.Fatalf("parse URL error: %v", err)
+	}
+	return parsed
+}

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -10,6 +10,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@elastic/charts": "^72.0.0",
+    "@elastic/eui": "^117.1.0",
+    "@elastic/eui-theme-borealis": "^8.0.0",
+    "@emotion/css": "^11.13.5",
+    "@emotion/react": "^11.14.0",
+    "moment": "^2.30.1",
+    "moment-timezone": "^0.5.48",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-router-dom": "^6.12.0",

--- a/ui-v2/src/domains/query/api/query.ts
+++ b/ui-v2/src/domains/query/api/query.ts
@@ -1,4 +1,4 @@
-import { client } from "../../../shared/http/client";
+import { client, type RequestOptions } from "../../../shared/http/client";
 import type {
   AIDraftResponse,
   AILinkAnalyzeInput,
@@ -226,19 +226,22 @@ export async function resolveQueryTableId(payload: QueryTableIdPayload): Promise
 
 export async function getQueryLogs(
   tableId: number,
-  params: QueryLogsParams
+  params: QueryLogsParams,
+  options?: RequestOptions
 ): Promise<QueryLogsResponse> {
   const query = buildQueryString(params);
-  return client.get<QueryLogsResponse>(`/api/v1/tables/${tableId}/logs?${query}`);
+  return client.get<QueryLogsResponse>(`/api/v1/tables/${tableId}/logs?${query}`, options);
 }
 
 export async function getQueryCharts(
   tableId: number,
-  params: QueryLogsParams
+  params: QueryLogsParams,
+  options?: RequestOptions
 ): Promise<QueryHistogramBucket[]> {
   const query = buildQueryString(params);
   const data = await client.get<{ histograms?: QueryHistogramBucket[] } | QueryHistogramBucket[]>(
-    `/api/v1/tables/${tableId}/charts?${query}`
+    `/api/v1/tables/${tableId}/charts?${query}`,
+    options
   );
   if (Array.isArray(data)) {
     return data;
@@ -277,18 +280,23 @@ export async function getQueryAnalysisFields(
   };
   return {
     baseFields: normalize(data?.baseFields),
-    logFields: normalize(data?.logFields)
+    logFields: normalize(data?.logFields),
+    supportsGlobalMatch: data?.supportsGlobalMatch
   };
 }
 
-export async function runQueryV2(payload: QueryRequestV2): Promise<QueryRunResponse> {
-  return client.post<QueryRunResponse>("/api/v2/query/run", payload);
+export async function runQueryV2(
+  payload: QueryRequestV2,
+  options?: RequestOptions
+): Promise<QueryRunResponse> {
+  return client.post<QueryRunResponse>("/api/v2/query/run", payload, options);
 }
 
 export async function getQueryFieldStats(
-  payload: QueryFieldStatsRequest
+  payload: QueryFieldStatsRequest,
+  options?: RequestOptions
 ): Promise<QueryFieldStatsResponse> {
-  return client.post<QueryFieldStatsResponse>("/api/v2/query/field-stats", payload);
+  return client.post<QueryFieldStatsResponse>("/api/v2/query/field-stats", payload, options);
 }
 
 export async function getQueryAutocomplete(

--- a/ui-v2/src/domains/query/hooks/useQueryWorkspace.ts
+++ b/ui-v2/src/domains/query/hooks/useQueryWorkspace.ts
@@ -28,11 +28,31 @@ import type {
   QuerySourceTable
 } from "../types/contracts";
 
-const DEFAULT_PAGE_SIZE = 20;
+const DEFAULT_PAGE_SIZE = 50;
 const QUERY_HISTORY_STORAGE_KEY = "clickvisual-v2-query-history";
 const DEFAULT_CONDITION_OPERATOR = "=";
-const GLOBAL_MATCH_FIELD = "全局匹配";
+const GLOBAL_MATCH_FIELD = "All fields";
+const LEGACY_GLOBAL_MATCH_FIELD = "全局匹配";
 const GLOBAL_MATCH_COLUMN = "_raw_log_";
+
+type QueryRunRange = {
+  st: number;
+  et: number;
+};
+
+type QueryRunSnapshot = {
+  range: QueryRunRange;
+  conditions: QueryConditionV2[];
+};
+
+function isAbortRequestError(error: unknown) {
+  return (
+    (error instanceof Error && error.name === "AbortError") ||
+    (typeof DOMException !== "undefined" &&
+      error instanceof DOMException &&
+      error.name === "AbortError")
+  );
+}
 
 let conditionSeed = 1;
 
@@ -101,17 +121,17 @@ function createEmptyCondition(): QueryFilterCondition {
 function normalizeNumberValue(value: string | number, field: string) {
   if (typeof value === "number") {
     if (!Number.isFinite(value)) {
-      throw new Error(`字段 ${field || "unknown"} 需要数字值`);
+      throw new Error(`Field ${field || "unknown"} requires a number`);
     }
     return String(value);
   }
   const trimmed = value.trim();
   if (!trimmed) {
-    throw new Error(`字段 ${field || "unknown"} 需要数字值`);
+    throw new Error(`Field ${field || "unknown"} requires a number`);
   }
   const parsed = Number(trimmed);
   if (!Number.isFinite(parsed)) {
-    throw new Error(`字段 ${field || "unknown"} 需要数字值`);
+    throw new Error(`Field ${field || "unknown"} requires a number`);
   }
   return String(parsed);
 }
@@ -126,10 +146,17 @@ function normalizeDateTimeValue(value: string | number) {
 }
 
 function quoteQueryField(field: string) {
-  if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(field)) {
-    return field;
-  }
   return `\`${field.replaceAll("`", "``")}\``;
+}
+
+function isGlobalMatchField(field: string) {
+  const normalized = String(field || "").trim();
+  return normalized === GLOBAL_MATCH_FIELD || normalized === LEGACY_GLOBAL_MATCH_FIELD;
+}
+
+function normalizeSuggestionFieldKey(field: string) {
+  const normalized = String(field || "").trim();
+  return isGlobalMatchField(normalized) ? GLOBAL_MATCH_FIELD.toLowerCase() : normalized;
 }
 
 function unquoteQueryValue(value: string) {
@@ -146,24 +173,36 @@ function createConditionFromQueryToken(token: string, index: number): QueryFilte
   if (!trimmed) {
     return null;
   }
-  const match = trimmed.match(/^(.+?)\s+(not\s+like|like|!=|=)\s+(.+)$/i);
+  const match = trimmed.match(/^(.+?)\s*(not\s+like|like|!=|=)\s*(.+)$/i);
   if (!match) {
     return null;
   }
   const rawField = match[1].trim().replace(/^`|`$/g, "");
   const rawOperator = match[2].toLowerCase() as QueryFilterCondition["operator"];
-  let value = unquoteQueryValue(match[3]);
-  const isGlobalLike = rawField === GLOBAL_MATCH_COLUMN && rawOperator === "like";
-  if (isGlobalLike && value.startsWith("%") && value.endsWith("%") && value.length >= 2) {
+  const rawValue = match[3].trim();
+  const rawValueQuote = rawValue[0];
+  const isExplicitStringValue =
+    (rawValueQuote === "'" || rawValueQuote === "\"") && rawValue.endsWith(rawValueQuote);
+  let value = unquoteQueryValue(rawValue);
+  const isGlobalMatch =
+    rawField === GLOBAL_MATCH_COLUMN && (rawOperator === "like" || rawOperator === "not like");
+  if (isGlobalMatch && value.startsWith("%") && value.endsWith("%") && value.length >= 2) {
     value = value.slice(1, -1);
   }
   return {
     id: `cond_url_${index}`,
-    field: isGlobalLike ? GLOBAL_MATCH_FIELD : rawField,
-    operator: isGlobalLike ? "like" : rawOperator,
+    field: isGlobalMatch ? GLOBAL_MATCH_FIELD : rawField,
+    operator: rawOperator,
     value,
-    valueType: /^-?\d+(\.\d+)?$/.test(value) && !isGlobalLike ? "number" : "string"
+    valueType: /^-?\d+(\.\d+)?$/.test(value) && !isExplicitStringValue && !isGlobalMatch ? "number" : "string"
   };
+}
+
+function parseQueryTextConditions(query: string) {
+  return query
+    .split(/\s+AND\s+/i)
+    .map((item, index) => createConditionFromQueryToken(item, index))
+    .filter((item): item is QueryFilterCondition => Boolean(item));
 }
 
 function readInitialQueryConditions() {
@@ -186,10 +225,7 @@ function readInitialQueryConditions() {
       ] as QueryFilterCondition[];
     }
   }
-  return query
-    .split(/\s+AND\s+/i)
-    .map((item, index) => createConditionFromQueryToken(item, index))
-    .filter((item): item is QueryFilterCondition => Boolean(item));
+  return parseQueryTextConditions(query);
 }
 
 function writeQueryToURL(query: string) {
@@ -211,7 +247,7 @@ function writeQueryToURL(query: string) {
 
 function validateOperatorValueType(operator: QueryFilterCondition["operator"], valueType: QueryFilterValueType) {
   if ((operator === "like" || operator === "not like") && valueType !== "string") {
-    throw new Error(`${operator} 只支持字符串字段`);
+    throw new Error(`${operator} only supports string fields`);
   }
 }
 
@@ -231,11 +267,12 @@ function buildVisualQuery(conditions: QueryFilterCondition[]) {
     .map((condition) => {
       const field = String(condition.field || "").trim();
       if (!field) {
-        throw new Error("筛选字段不能为空");
+        throw new Error("Field is required");
       }
-      if (field === GLOBAL_MATCH_FIELD) {
+      if (isGlobalMatchField(field)) {
         const raw = String(condition.value ?? "").replaceAll("'", "\\'");
-        return `${GLOBAL_MATCH_COLUMN} like '%${raw}%'`;
+        const operator = condition.operator === "not like" ? "not like" : "like";
+        return `${quoteQueryField(GLOBAL_MATCH_COLUMN)} ${operator} '%${raw}%'`;
       }
       validateOperatorValueType(condition.operator, condition.valueType);
       const normalizedValue =
@@ -247,6 +284,15 @@ function buildVisualQuery(conditions: QueryFilterCondition[]) {
       return `${quoteQueryField(field)} ${condition.operator} ${normalizedValue}`;
     })
     .join(" AND ");
+}
+
+function buildCombinedQuery(rawQuery: string, visualQuery: string) {
+  const raw = rawQuery.trim();
+  const visual = visualQuery.trim();
+  if (raw && visual) {
+    return `${raw} AND ${visual}`;
+  }
+  return raw || visual;
 }
 
 function storageFieldName(field: QueryStorageAnalysisField) {
@@ -284,8 +330,8 @@ function fieldValueType(condition: QueryFilterCondition) {
 }
 
 function conditionOperator(condition: QueryFilterCondition) {
-  if (String(condition.field || "").trim() === GLOBAL_MATCH_FIELD) {
-    return "contains";
+  if (isGlobalMatchField(condition.field)) {
+    return condition.operator === "not like" ? "not_contains" : "contains";
   }
   if (condition.operator === "like") {
     return "contains";
@@ -301,7 +347,7 @@ export function buildQueryFieldRef(
   analysisFields: QueryAnalysisFieldsResponse
 ): QueryFieldRef {
   const fieldKey = String(condition.field || "").trim();
-  if (fieldKey === GLOBAL_MATCH_FIELD) {
+  if (isGlobalMatchField(fieldKey)) {
     return {
       fieldKey: GLOBAL_MATCH_COLUMN,
       displayName: GLOBAL_MATCH_FIELD,
@@ -349,12 +395,23 @@ export function buildQueryFieldRef(
   }
   const logField = findStorageField(analysisFields.logFields, fieldKey);
   const name = logField ? storageFieldName(logField) : fieldKey;
+  if (logField) {
+    return {
+      fieldKey: name,
+      displayName: logField.alias || name,
+      source: "column",
+      path: name,
+      valueType: storageFieldTyp(logField),
+      isAccelerated: true,
+      acceleratedCol: name
+    };
+  }
   return {
     fieldKey: name,
-    displayName: logField?.alias || name,
+    displayName: name,
     source: "json_path",
     path: name,
-    valueType: logField ? storageFieldTyp(logField) : fieldValueType(condition),
+    valueType: fieldValueType(condition),
     isAccelerated: false
   };
 }
@@ -377,6 +434,17 @@ export function buildStructuredConditions(
     }));
 }
 
+export function buildEffectiveStructuredConditions(
+  queryText: string,
+  conditions: QueryFilterCondition[],
+  analysisFields: QueryAnalysisFieldsResponse
+): QueryConditionV2[] {
+  return [
+    ...buildStructuredConditions(parseQueryTextConditions(queryText), analysisFields),
+    ...buildStructuredConditions(conditions, analysisFields)
+  ];
+}
+
 function hasUnsupportedGlobalMatchCondition(
   conditions: QueryFilterCondition[],
   analysisFields: QueryAnalysisFieldsResponse
@@ -386,7 +454,7 @@ function hasUnsupportedGlobalMatchCondition(
     conditions.some(
       (condition) =>
         !condition.disabled &&
-        String(condition.field || "").trim() === GLOBAL_MATCH_FIELD &&
+        isGlobalMatchField(condition.field) &&
         String(condition.value ?? "").trim()
     )
   );
@@ -416,11 +484,12 @@ export function useQueryWorkspace(
   const [savedFilterProfiles, setSavedFilterProfiles] = useState<QueryFilterProfile[]>([]);
   const [savedFilterLoading, setSavedFilterLoading] = useState(false);
   const [page, setPage] = useState(options?.initialPage && options.initialPage > 0 ? options.initialPage : 1);
-  const [pageSize] = useState(
+  const [pageSize, setPageSize] = useState(
     options?.initialPageSize && options.initialPageSize > 0 ? options.initialPageSize : DEFAULT_PAGE_SIZE
   );
   const [logs, setLogs] = useState<QueryLogsResponse | null>(null);
   const [charts, setCharts] = useState<QueryHistogramBucket[]>([]);
+  const [lastRunSnapshot, setLastRunSnapshot] = useState<QueryRunSnapshot | null>(null);
   const [analysisFields, setAnalysisFields] = useState<QueryAnalysisFieldsResponse>({
     baseFields: [],
     logFields: [],
@@ -434,6 +503,7 @@ export function useQueryWorkspace(
   const [contextLoading, setContextLoading] = useState(false);
   const autocompleteRequestIdRef = useRef(0);
   const queryRunIdRef = useRef(0);
+  const queryAbortControllerRef = useRef<AbortController | null>(null);
   const treeSelectionTargetRef = useRef<QuerySourceTreeTarget | null>(null);
 
   const selectedInstance = useMemo(
@@ -451,9 +521,23 @@ export function useQueryWorkspace(
     [selectedDatabaseEntry, selectedTable]
   );
 
+  function abortActiveQueryRequest() {
+    queryAbortControllerRef.current?.abort();
+    queryAbortControllerRef.current = null;
+  }
+
+  function cancelQuery() {
+    queryRunIdRef.current += 1;
+    abortActiveQueryRequest();
+    setLoading(false);
+    setChartLoading(false);
+  }
+
   function clearQueryResults() {
+    cancelQuery();
     setLogs(null);
     setCharts([]);
+    setLastRunSnapshot(null);
   }
 
   function pickTreeName(preferred: string | undefined, fallback: string, options: string[]) {
@@ -528,7 +612,7 @@ export function useQueryWorkspace(
       });
       setErrorMessage("");
     } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : "实例列表加载失败");
+      setErrorMessage(error instanceof Error ? error.message : "Failed to load sources");
     } finally {
       setContextLoading(false);
     }
@@ -543,6 +627,7 @@ export function useQueryWorkspace(
     })();
     return () => {
       active = false;
+      abortActiveQueryRequest();
     };
   }, []);
 
@@ -707,57 +792,73 @@ export function useQueryWorkspace(
   }, [queryText, selectedInstanceId]);
 
   useEffect(() => {
-    let nextQuery = queryText.trim();
-    if (!nextQuery) {
-      try {
-        nextQuery = buildVisualQuery(conditions);
-      } catch {
+    let generatedQuery = "";
+    try {
+      generatedQuery = buildVisualQuery(conditions);
+    } catch {
+      if (!queryText.trim()) {
         return;
       }
     }
+    const nextQuery = buildCombinedQuery(queryText, generatedQuery);
     writeQueryToURL(nextQuery);
   }, [conditions, queryText]);
 
   async function runQuery(
     nextPage = page,
     overrideRange?: { st: number; et: number },
-    overrideConditions?: QueryFilterCondition[]
+    overrideConditions?: QueryFilterCondition[],
+    overrideQueryText?: string,
+    overridePageSize?: number
   ) {
+    cancelQuery();
     const effectiveTableId = selectedTableId ?? selectedTableEntry?.id ?? null;
     if (!effectiveTableId) {
-      setErrorMessage("请先选择完整的实例、数据库和日志表");
+      setErrorMessage("Select an instance, database, and log table first");
       return;
     }
     const timeParams = overrideRange ?? createTimeParams(startTime, endTime);
     if (!timeParams) {
-      setErrorMessage("请选择有效的开始时间和结束时间");
+      setErrorMessage("Select a valid start and end time");
       return;
     }
     const effectiveConditions = overrideConditions ?? conditions;
+    const effectiveQueryText = overrideQueryText ?? queryText;
     if (hasUnsupportedGlobalMatchCondition(effectiveConditions, analysisFields)) {
-      setErrorMessage("当前日志表未配置日志内容字段，不能使用全局匹配");
+      setErrorMessage("Current log table has no log content field, cannot use All fields");
       return;
     }
     let generatedQuery = "";
     try {
       generatedQuery = buildVisualQuery(effectiveConditions);
     } catch (error) {
-      if (!queryText.trim()) {
-        setErrorMessage(error instanceof Error ? error.message : "筛选条件不合法");
+      if (!effectiveQueryText.trim()) {
+        setErrorMessage(error instanceof Error ? error.message : "Invalid conditions");
         return;
       }
     }
-    const requestQuery = overrideConditions ? generatedQuery || undefined : queryText.trim() || generatedQuery || undefined;
+    const requestQuery = buildCombinedQuery(effectiveQueryText, generatedQuery) || undefined;
     const structuredConditions = buildStructuredConditions(effectiveConditions, analysisFields);
-    const shouldUseStructuredRun =
-      (overrideConditions ? true : !queryText.trim()) && structuredConditions.length > 0;
+    const effectiveStructuredConditions = buildEffectiveStructuredConditions(
+      effectiveQueryText,
+      effectiveConditions,
+      analysisFields
+    );
+    const shouldUseStructuredRun = !effectiveQueryText.trim() && structuredConditions.length > 0;
+    const effectivePageSize =
+      overridePageSize && Number.isFinite(overridePageSize) && overridePageSize > 0
+        ? Math.round(overridePageSize)
+        : pageSize;
 
     const params = {
       ...timeParams,
       query: requestQuery,
       page: nextPage,
-      pageSize
+      pageSize: effectivePageSize
     };
+    const abortController = new AbortController();
+    queryAbortControllerRef.current = abortController;
+    const requestOptions = { signal: abortController.signal };
     const runId = queryRunIdRef.current + 1;
     queryRunIdRef.current = runId;
 
@@ -771,23 +872,40 @@ export function useQueryWorkspace(
           st: timeParams.st,
           et: timeParams.et,
           page: nextPage,
-          pageSize,
+          pageSize: effectivePageSize,
           conditions: structuredConditions,
           sorts: [],
           displayFields: []
-        })
-      : getQueryLogs(effectiveTableId, params);
+        },
+        requestOptions
+      )
+      : getQueryLogs(effectiveTableId, params, requestOptions);
 
     const [logsResult, chartsResult] = await Promise.allSettled([
       logsRequest,
-      getQueryCharts(effectiveTableId, params)
+      getQueryCharts(effectiveTableId, params, requestOptions)
     ]);
     if (queryRunIdRef.current !== runId) {
+      return;
+    }
+    if (queryAbortControllerRef.current === abortController) {
+      queryAbortControllerRef.current = null;
+    }
+
+    const logsAborted = logsResult.status === "rejected" && isAbortRequestError(logsResult.reason);
+    const chartsAborted = chartsResult.status === "rejected" && isAbortRequestError(chartsResult.reason);
+    if (abortController.signal.aborted || logsAborted || chartsAborted) {
+      setLoading(false);
+      setChartLoading(false);
       return;
     }
 
     if (logsResult.status === "fulfilled") {
       setLogs(logsResult.value);
+      setLastRunSnapshot({
+        range: timeParams,
+        conditions: effectiveStructuredConditions
+      });
       setPage(nextPage);
       if (nextPage === 1 && requestQuery) {
         const historyStore = readQueryHistory();
@@ -805,7 +923,7 @@ export function useQueryWorkspace(
       }
     } else {
       setLogs(null);
-      setErrorMessage(logsResult.reason instanceof Error ? logsResult.reason.message : "日志查询失败");
+      setErrorMessage(logsResult.reason instanceof Error ? logsResult.reason.message : "Query failed");
     }
 
     if (chartsResult.status === "fulfilled") {
@@ -827,28 +945,42 @@ export function useQueryWorkspace(
               {
                 field: GLOBAL_MATCH_FIELD,
                 source: "column" as const,
-                sourceLabel: "全局匹配",
-                queryLabel: "日志内容 LIKE",
+                sourceLabel: "All fields",
+                queryLabel: "Log content LIKE",
                 valueType: "string" as const
               }
             ];
-      return [
+      const options = [
         ...globalMatchOptions,
         ...analysisFields.baseFields.map((item) => ({
           field: storageFieldName(item),
           source: "column" as const,
-          sourceLabel: "物理列",
-          queryLabel: "列查询",
+          sourceLabel: "Column",
+          queryLabel: "Column query",
           valueType: storageFieldTyp(item)
         })),
         ...analysisFields.logFields.map((item) => ({
           field: storageFieldName(item),
-          source: "json_path" as const,
-          sourceLabel: "解析字段",
-          queryLabel: "JSON 路径查询",
+          source: "column" as const,
+          sourceLabel: "Parsed field",
+          queryLabel: "Indexed field",
           valueType: storageFieldTyp(item)
         }))
-      ].filter((item) => item.field);
+      ];
+      const seenFields = new Set<string>();
+      return options
+        .map((item) => ({ ...item, field: String(item.field || "").trim() }))
+        .filter((item) => {
+          if (!item.field) {
+            return false;
+          }
+          const key = normalizeSuggestionFieldKey(item.field);
+          if (seenFields.has(key)) {
+            return false;
+          }
+          seenFields.add(key);
+          return true;
+        });
     },
     [analysisFields]
   );
@@ -860,10 +992,10 @@ export function useQueryWorkspace(
   async function saveCurrentQuery(name: string, timeRange: { startTime: string; endTime: string }) {
     const normalizedName = name.trim();
     if (!normalizedName) {
-      throw new Error("请输入收藏名称");
+      throw new Error("Enter a saved query name");
     }
     if (!selectedInstanceId || !selectedInstance || !selectedDatabase || !selectedTable) {
-      throw new Error("请先选择完整的实例、数据库和日志表");
+      throw new Error("Select an instance, database, and log table first");
     }
     const enabledConditions = conditions.filter(
       (condition) =>
@@ -872,7 +1004,7 @@ export function useQueryWorkspace(
         String(condition.value ?? "").trim()
     );
     if (enabledConditions.length === 0) {
-      throw new Error("当前收藏只支持条件构建器，请先添加至少一个条件");
+      throw new Error("Saved queries currently require at least one condition");
     }
     const saved = await createQueryFilter({
       name: normalizedName,
@@ -922,6 +1054,7 @@ export function useQueryWorkspace(
     pageSize,
     logs,
     charts,
+    lastRunSnapshot,
     analysisFields,
     suggestionFieldOptions,
     suggestionFields,
@@ -964,6 +1097,7 @@ export function useQueryWorkspace(
     },
     setQueryText,
     setConditions,
+    setPageSize,
     setActiveConditionId,
     addCondition: () => {
       const next = createEmptyCondition();
@@ -992,19 +1126,24 @@ export function useQueryWorkspace(
         return next;
       });
     },
-    buildQueryText: () => buildVisualQuery(conditions),
+    buildQueryText: () => buildCombinedQuery(queryText, buildVisualQuery(conditions)),
     applyFilterProfile: (profile: QueryFilterProfile) => {
       const nextConditions = Array.isArray(profile.conditions) ? profile.conditions : [];
       setConditions(nextConditions);
       setActiveConditionId(nextConditions[0]?.id ?? null);
-      setQueryText(buildVisualQuery(nextConditions));
+      setQueryText("");
     },
-    applySuggestion: (value: string) => setQueryText(value),
+    applySuggestion: (value: string) => {
+      setQueryText(value);
+      setConditions([]);
+      setActiveConditionId(null);
+    },
     clearQueryHistory,
     saveCurrentQuery,
     deleteSavedFilterProfile,
     refreshSavedFilterProfiles,
     runQuery,
+    cancelQuery,
     setPage,
     refreshSourceTree
   };

--- a/ui-v2/src/domains/query/pages/QueryPage.tsx
+++ b/ui-v2/src/domains/query/pages/QueryPage.tsx
@@ -1,4 +1,33 @@
-import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, forwardRef, useEffect, useMemo, useRef, useState } from "react";
+import type { CSSProperties, DragEvent, KeyboardEvent, MouseEvent, ReactNode, UIEvent, WheelEvent } from "react";
+import {
+  EuiButtonIcon,
+  EuiDatePicker,
+  EuiFieldSearch,
+  EuiFieldText,
+  EuiIcon,
+  EuiPopover,
+  EuiSuperSelect,
+  EuiTab,
+  EuiTabs,
+  EuiToolTip
+} from "@elastic/eui";
+import {
+  Axis,
+  BrushAxis,
+  Chart,
+  type CustomTooltipProps,
+  HistogramBarSeries,
+  Position,
+  RectAnnotation,
+  ScaleType,
+  Settings,
+  Tooltip,
+  TooltipType
+} from "@elastic/charts";
+import type { PartialTheme } from "@elastic/charts";
+import moment from "moment";
+import "moment/locale/zh-cn";
 import QueryAccessLogLibraryModal from "../components/QueryAccessLogLibraryModal";
 import QueryCreateDatabaseModal from "../components/QueryCreateDatabaseModal";
 import QueryEditDatabaseModal from "../components/QueryEditDatabaseModal";
@@ -14,6 +43,7 @@ import type {
   QueryFieldRef,
   QueryFilterCondition,
   QueryFilterValueType,
+  QueryStorageAnalysisField,
   QuerySourceDatabase,
   QuerySourceInstance,
   QuerySourceTable,
@@ -24,11 +54,17 @@ import { isPrivateLiteEdition } from "../../../shared/config/runtime";
 import { buildShareRouteHref, buildV2RouteHref } from "../../../shared/layout/VersionSwitcher";
 
 type QueryDateRange = [Date, Date] | null;
+type QueryAbsolutePickerRange = {
+  start: string;
+  end: string;
+};
+type TimeRangeAbsoluteField = "start" | "end";
 type QueryConditionModalMode = "create" | "edit";
 type NormalizedLogRow = {
   original: Record<string, unknown>;
   parsed: Record<string, unknown>;
   timeText: string;
+  levelField?: string;
   levelText: string;
   messageText: string;
 };
@@ -69,6 +105,50 @@ type TraceSpanNode = {
   depth: number;
   virtual?: boolean;
 };
+type QueryEmptyStateProps = {
+  icon: ReactNode;
+  title: string;
+  description?: string;
+  variant?: "histogram" | "result";
+  tone?: "neutral" | "loading" | "empty";
+};
+type QueryFieldPickerOption = {
+  field: string;
+  source: string;
+  sourceLabel: string;
+  queryLabel: string;
+  valueType: QueryFilterValueType;
+};
+type HistogramSelection = {
+  anchorIndex: number;
+  hoverIndex: number;
+};
+type HistogramSelectionRange = {
+  startIndex: number;
+  endIndex: number;
+  from: number;
+  to: number;
+  count: number;
+};
+type HistogramIntervalValue =
+  | "auto"
+  | "1m"
+  | "5m"
+  | "10m"
+  | "15m"
+  | "30m"
+  | "1h"
+  | "3h"
+  | "6h"
+  | "12h"
+  | "1d"
+  | "1w";
+type HistogramChartDatum = {
+  x: number;
+  count: number;
+  from: number;
+  to: number;
+};
 type TraceGroup = {
   key: string;
   traceId: string;
@@ -105,36 +185,411 @@ type OpenLogTab = {
   databaseName: string;
   tableName: string;
 };
-type QuickTimeRange = {
-  label: string;
-  minutes: number;
-};
 type LogDetailNestedEntry = {
   key: string;
   value: string;
   fieldRef?: QueryFieldRef;
 };
+type QueryFieldCatalogGroupKey = "log" | "base" | "all";
+type QueryFieldCatalogItem = {
+  key: string;
+  field: string;
+  label: string;
+  group: QueryFieldCatalogGroupKey;
+  columnKey: string;
+  valueType: QueryFilterValueType;
+  sampleValue: unknown;
+  fieldRef: QueryFieldRef;
+  canToggleColumn: boolean;
+  isColumnVisible: boolean;
+  canShowTopValues: boolean;
+};
+type QueryFieldCatalogGroup = {
+  key: QueryFieldCatalogGroupKey;
+  title: string;
+  items: QueryFieldCatalogItem[];
+};
+type QueryFieldStatsState = {
+  field: string;
+  fieldRef: QueryFieldRef;
+  loading: boolean;
+  data: QueryFieldStatsResponse | null;
+  error: string;
+};
+type QueryFieldStatsView = {
+  unsupportedError: boolean;
+  shouldUseLoaded: boolean;
+  items: QueryFieldStatsResponse["items"];
+  total: number;
+  source: string;
+};
 
-const DEFAULT_RESULT_COLUMN_KEYS = ["__time", "__level", "__message"] as const;
+const CONTAINER_NAME_RESULT_COLUMN_KEY = "container.name";
+const LEGACY_CONTAINER_NAME_RESULT_COLUMN_KEY = "_container_name_";
+const DEFAULT_RESULT_COLUMN_KEYS = ["__time", "__level", "tid", "__message", CONTAINER_NAME_RESULT_COLUMN_KEY, "error"] as const;
+const LEGACY_DEFAULT_RESULT_COLUMN_KEYS = ["__time", "__level", "__message"] as const;
 const RESULT_COLUMN_STORAGE_PREFIX = "clickvisual-v2-query-result-columns";
+const RESULT_COLUMN_STORAGE_VERSION = 2;
 const OPEN_LOG_TABS_STORAGE_PREFIX = "clickvisual-v2-query-open-tabs";
-const QUICK_TIME_RANGES: QuickTimeRange[] = [
-  { label: "Last 15 minutes", minutes: 15 },
-  { label: "Last 30 minutes", minutes: 30 },
-  { label: "Last 1 hour", minutes: 60 },
-  { label: "Last 6 hours", minutes: 6 * 60 },
-  { label: "Last 12 hours", minutes: 12 * 60 },
-  { label: "Last 24 hours", minutes: 24 * 60 },
-  { label: "Last 2 days", minutes: 2 * 24 * 60 },
-  { label: "Last 7 days", minutes: 7 * 24 * 60 },
-  { label: "Last 30 days", minutes: 30 * 24 * 60 },
-  { label: "Last 90 days", minutes: 90 * 24 * 60 },
-  { label: "Last 6 months", minutes: 183 * 24 * 60 },
-  { label: "Last 1 year", minutes: 365 * 24 * 60 }
+const GLOBAL_MATCH_FIELD = "All fields";
+const LEGACY_GLOBAL_MATCH_FIELD = "全局匹配";
+const GLOBAL_MATCH_DISPLAY_LABEL = GLOBAL_MATCH_FIELD;
+const QUERY_PAGE_SIZE_OPTIONS = [50, 100, 200] as const;
+const RESULT_TABLE_TOGGLE_COLUMN_WIDTH = 34;
+const QUERY_OVERSCROLL_GUARD_CLASS = "cv-query-overscroll-guard";
+const QUERY_HORIZONTAL_WHEEL_THRESHOLD = 4;
+const QUERY_HORIZONTAL_WHEEL_DOMINANCE_RATIO = 1.15;
+const HISTOGRAM_HEIGHT = 112;
+const HISTOGRAM_AUTO_TARGET_BARS = 50;
+const HISTOGRAM_LOADING_BARS = [26, 34, 22, 48, 66, 42, 30, 58, 74, 36, 52, 28, 44, 62, 32, 50, 70, 38] as const;
+const RESULT_LOADING_ROWS = [
+  ["52%", "36%", "86%", "64%", "48%"],
+  ["58%", "42%", "72%", "52%", "62%"],
+  ["46%", "34%", "92%", "58%", "44%"],
+  ["64%", "38%", "78%", "68%", "56%"],
+  ["50%", "40%", "88%", "46%", "60%"],
+  ["56%", "32%", "74%", "62%", "50%"]
+] as const;
+const FIELD_STATS_LOADING_ROWS = ["82%", "68%", "76%", "54%", "72%", "60%"] as const;
+const HISTOGRAM_INTERVAL_OPTIONS: Array<{ value: HistogramIntervalValue; label: string; milliseconds?: number }> = [
+  { value: "auto", label: "Auto" },
+  { value: "1m", label: "1 minute", milliseconds: 60_000 },
+  { value: "5m", label: "5 minutes", milliseconds: 5 * 60_000 },
+  { value: "10m", label: "10 minutes", milliseconds: 10 * 60_000 },
+  { value: "15m", label: "15 minutes", milliseconds: 15 * 60_000 },
+  { value: "30m", label: "30 minutes", milliseconds: 30 * 60_000 },
+  { value: "1h", label: "1 hour", milliseconds: 60 * 60_000 },
+  { value: "3h", label: "3 hours", milliseconds: 3 * 60 * 60_000 },
+  { value: "6h", label: "6 hours", milliseconds: 6 * 60 * 60_000 },
+  { value: "12h", label: "12 hours", milliseconds: 12 * 60 * 60_000 },
+  { value: "1d", label: "1 day", milliseconds: 24 * 60 * 60_000 },
+  { value: "1w", label: "1 week", milliseconds: 7 * 24 * 60 * 60_000 }
 ];
+
+function shouldGuardHorizontalWheel(event: globalThis.WheelEvent) {
+  const deltaX = event.deltaX;
+  const deltaY = event.deltaY;
+  if (
+    event.defaultPrevented ||
+    event.ctrlKey ||
+    Math.abs(deltaX) < QUERY_HORIZONTAL_WHEEL_THRESHOLD ||
+    Math.abs(deltaX) < Math.abs(deltaY) * QUERY_HORIZONTAL_WHEEL_DOMINANCE_RATIO
+  ) {
+    return false;
+  }
+  return !canConsumeHorizontalWheel(event.target, deltaX);
+}
+
+function canConsumeHorizontalWheel(target: EventTarget | null, deltaX: number) {
+  if (typeof document === "undefined" || !(target instanceof Node)) {
+    return false;
+  }
+  const start = target instanceof Element ? target : target.parentElement;
+  const candidates: Element[] = [];
+  for (let element: Element | null = start; element; element = element.parentElement) {
+    candidates.push(element);
+  }
+  const scrollingElement = document.scrollingElement;
+  if (scrollingElement && !candidates.includes(scrollingElement)) {
+    candidates.push(scrollingElement);
+  }
+  if (!candidates.includes(document.documentElement)) {
+    candidates.push(document.documentElement);
+  }
+  for (const element of candidates) {
+    if (element.scrollWidth <= element.clientWidth + 1) {
+      continue;
+    }
+    const overflowX = window.getComputedStyle(element).overflowX;
+    if (overflowX !== "auto" && overflowX !== "scroll" && overflowX !== "overlay") {
+      continue;
+    }
+    const maxScrollLeft = element.scrollWidth - element.clientWidth;
+    if ((deltaX > 0 && element.scrollLeft < maxScrollLeft - 1) || (deltaX < 0 && element.scrollLeft > 1)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const HISTOGRAM_BAR_COLOR = "#f97316";
+const HISTOGRAM_SELECTION_COLOR = "#f97316";
+const HISTOGRAM_CHART_THEME: PartialTheme = {
+  chartMargins: {
+    top: 6,
+    right: 8,
+    bottom: 6,
+    left: 2
+  },
+  axes: {
+    axisLine: {
+      visible: false
+    },
+    tickLine: {
+      visible: false,
+      size: 0,
+      padding: 4
+    },
+    tickLabel: {
+      fontSize: 10,
+      fill: "#69707d",
+      padding: { inner: 6, outer: 4 },
+      wrapLines: 1,
+      truncate: "end"
+    },
+    gridLine: {
+      horizontal: {
+        visible: true,
+        stroke: "#edf1f6",
+        strokeWidth: 1,
+        opacity: 0.8,
+        dash: []
+      },
+      vertical: {
+        visible: true,
+        stroke: "#f5f7fa",
+        strokeWidth: 1,
+        opacity: 0.56,
+        dash: []
+      }
+    }
+  },
+  barSeriesStyle: {
+    rect: {
+      opacity: 0.88,
+      widthRatio: 0.68
+    },
+    rectBorder: {
+      visible: false,
+      strokeWidth: 0
+    }
+  },
+  brush: {
+    fill: HISTOGRAM_SELECTION_COLOR,
+    stroke: HISTOGRAM_SELECTION_COLOR,
+    strokeWidth: 1,
+    opacity: 0.14
+  },
+  rectAnnotation: {
+    fill: HISTOGRAM_SELECTION_COLOR,
+    stroke: HISTOGRAM_SELECTION_COLOR,
+    strokeWidth: 0,
+    opacity: 0.1
+  }
+};
+const HISTOGRAM_BOTTOM_AXIS_STYLE = {
+  tickLabel: {
+    offset: {
+      x: 8,
+      y: 1,
+      reference: "global"
+    }
+  }
+} as const;
+const HISTOGRAM_LEFT_AXIS_STYLE = {
+  tickLabel: {
+    offset: {
+      x: 0,
+      y: -1,
+      reference: "global"
+    }
+  }
+} as const;
+const RESULT_COLUMN_FIELD_PRIORITY = ["tid", "msg", "message", CONTAINER_NAME_RESULT_COLUMN_KEY, "error"] as const;
+const RESULT_BUILTIN_FIELD_ALIASES = [
+  "time",
+  "timestamp",
+  "ts",
+  "level",
+  "severity",
+  "lv",
+  "log_level",
+  "msg",
+  "message",
+  "content",
+  "body"
+] as const;
+const RESULT_COLUMN_META_FIELD_PRIORITY = [
+  "_raw_log_",
+  "_raw_log",
+  "_raw",
+  "raw_log",
+  "raw",
+  "rawLogJson",
+  "_cluster_",
+  "_source_",
+  "_log_agent_",
+  "_namespace_",
+  "_pod_name_",
+  "_node_name_",
+  "_node_ip_",
+  "container.image.name",
+  "host.ip",
+  "host.name",
+  "k8s.namespace.name",
+  "k8s.pod.name",
+  "k8s.node.ip",
+  "k8s.node.name",
+  "k8s.pod.uid",
+  "_time_second_",
+  "_time_nanosecond_",
+  "time",
+  "ts",
+  "lname",
+  "log.file.path"
+] as const;
+const LOG_LEVEL_FIELD_KEYS = ["level", "severity", "lv", "log_level"] as const;
+const LOG_TIME_FIELD_KEYS = ["_time", "_time_", "_time_nanosecond_", "_time_second_", "time", "timestamp", "ts"] as const;
+const LOG_DETAIL_FIELD_PRIORITY = [
+  "tid",
+  "trace_id",
+  "traceId",
+  "span_id",
+  "spanId",
+  "msg",
+  "message",
+  "level",
+  "lv",
+  "severity",
+  "log_level",
+  "container.name",
+  "_container_name_",
+  "container_name",
+  "application",
+  "service",
+  "error",
+  "status",
+  "code",
+  "method",
+  "addr",
+  "comp",
+  "compName",
+  "cost",
+  "event",
+  "ip",
+  "name",
+  "peerIp",
+  "peerName",
+  "type",
+  "ucode"
+] as const;
+const FIELD_STATS_UNIQUE_FIELDS = ["tid"] as const;
+const DEFAULT_TIME_RANGE_MINUTES = 15;
+const ABSOLUTE_TIME_FORMAT = "YYYY-MM-DD HH:mm:ss";
+const ABSOLUTE_DAY_PRESET_RANGES = [
+  { label: "Today", dayOffset: 0 },
+  { label: "Yesterday", dayOffset: 1 }
+] as const;
+const ABSOLUTE_SPAN_PRESETS = [
+  { label: "Apply 15 minute absolute span", shortLabel: "15m", minutes: 15 },
+  { label: "Apply 1 hour absolute span", shortLabel: "1h", minutes: 60 },
+  { label: "Apply 6 hour absolute span", shortLabel: "6h", minutes: 6 * 60 },
+  { label: "Apply 24 hour absolute span", shortLabel: "24h", minutes: 24 * 60 },
+  { label: "Apply 7 day absolute span", shortLabel: "7d", minutes: 7 * 24 * 60 }
+] as const;
+const DATE_PICKER_WEEKDAY_LABELS: Record<string, string> = {
+  Sunday: "S",
+  Sun: "S",
+  Monday: "M",
+  Mon: "M",
+  Tuesday: "T",
+  Tue: "T",
+  Wednesday: "W",
+  Wed: "W",
+  Thursday: "T",
+  Thu: "T",
+  Friday: "F",
+  Fri: "F",
+  Saturday: "S",
+  Sat: "S",
+  星期日: "S",
+  星期一: "M",
+  星期二: "T",
+  星期三: "W",
+  星期四: "T",
+  星期五: "F",
+  星期六: "S"
+};
+
+type DatePickerHeaderProps = {
+  date?: moment.Moment | Date | string | number;
+  decreaseMonth: () => void;
+  increaseMonth: () => void;
+  prevMonthButtonDisabled?: boolean;
+  nextMonthButtonDisabled?: boolean;
+};
+
+function formatDatePickerWeekday(day: string) {
+  return DATE_PICKER_WEEKDAY_LABELS[day] ?? day.trim().charAt(0).toUpperCase();
+}
+
+function renderDatePickerHeader({
+  date,
+  decreaseMonth,
+  increaseMonth,
+  prevMonthButtonDisabled,
+  nextMonthButtonDisabled
+}: DatePickerHeaderProps) {
+  const headerDate = moment.isMoment(date) ? date : moment(date);
+  return (
+    <div className="cv-query-date-picker-header">
+      <button
+        type="button"
+        className="cv-query-date-picker-header__step"
+        onClick={decreaseMonth}
+        disabled={prevMonthButtonDisabled}
+        aria-label="Previous month"
+      >
+        <EuiIcon type="chevronSingleLeft" size="s" aria-hidden="true" />
+      </button>
+      <strong>{headerDate.isValid() ? headerDate.locale("en").format("MMM YYYY") : "Select month"}</strong>
+      <button
+        type="button"
+        className="cv-query-date-picker-header__step"
+        onClick={increaseMonth}
+        disabled={nextMonthButtonDisabled}
+        aria-label="Next month"
+      >
+        <EuiIcon type="chevronSingleRight" size="s" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}
+
+const LOCALIZED_EUI_DATE_PICKER_PROPS = {
+  formatWeekDay: formatDatePickerWeekday,
+  renderCustomHeader: renderDatePickerHeader,
+  previousMonthButtonLabel: "Previous month",
+  nextMonthButtonLabel: "Next month"
+};
+
+function isAbortRequestError(error: unknown) {
+  return (
+    (error instanceof Error && error.name === "AbortError") ||
+    (typeof DOMException !== "undefined" &&
+      error instanceof DOMException &&
+      error.name === "AbortError")
+  );
+}
 
 function formatCount(value: number) {
   return new Intl.NumberFormat("zh-CN").format(value);
+}
+
+function formatFieldsCount(value: number) {
+  return `${formatCount(value)} ${value === 1 ? "field" : "fields"}`;
+}
+
+function formatHitsLabel(value: number) {
+  return value === 1 ? "hit" : "hits";
+}
+
+function formatRowsLabel(value: number) {
+  return `${formatCount(value)} ${value === 1 ? "row" : "rows"}`;
+}
+
+function formatConditionCountLabel(value: number) {
+  return `${formatCount(value)} ${value === 1 ? "condition" : "conditions"}`;
 }
 
 function formatPercentage(value: number) {
@@ -142,14 +597,6 @@ function formatPercentage(value: number) {
     return "0%";
   }
   return `${value.toFixed(value >= 10 ? 1 : 2)}%`;
-}
-
-function roundUpChartAxisMax(value: number) {
-  if (value <= 10) {
-    return 10;
-  }
-  const magnitude = 10 ** Math.floor(Math.log10(value));
-  return Math.ceil(value / magnitude) * magnitude;
 }
 
 function formatDateTimeLocalValue(date: Date) {
@@ -169,6 +616,19 @@ function buildDefaultTimeRange() {
 }
 
 function buildInitialTimeRangeFromSearchParams(searchParams: URLSearchParams) {
+  const startTimeText = searchParams.get("startTime") || "";
+  const endTimeText = searchParams.get("endTime") || "";
+  if (startTimeText && endTimeText) {
+    const startDate = new Date(startTimeText.includes("T") ? startTimeText : startTimeText.replace(" ", "T"));
+    const endDate = new Date(endTimeText.includes("T") ? endTimeText : endTimeText.replace(" ", "T"));
+    if (
+      !Number.isNaN(startDate.getTime()) &&
+      !Number.isNaN(endDate.getTime()) &&
+      endDate.getTime() > startDate.getTime()
+    ) {
+      return [startDate, endDate] as [Date, Date];
+    }
+  }
   const start = Number(searchParams.get("start") || searchParams.get("st") || "");
   const end = Number(searchParams.get("end") || searchParams.get("et") || "");
   if (!Number.isFinite(start) || !Number.isFinite(end) || start <= 0 || end <= start) {
@@ -189,6 +649,9 @@ function writeTimeRangeToURL(range: QueryDateRange) {
   } else {
     url.searchParams.delete("start");
     url.searchParams.delete("end");
+  }
+  if (url.searchParams.get("tab") === "relative") {
+    url.searchParams.delete("tab");
   }
   const next = `${url.pathname}${url.search}${url.hash}`;
   const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
@@ -227,16 +690,48 @@ function writeSelectedTableToURL({
   }
 }
 
+function writeResultPaginationToURL(page: number, pageSize: number) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  const url = new URL(window.location.href);
+  if (page > 1) {
+    url.searchParams.set("page", String(page));
+  } else {
+    url.searchParams.delete("page");
+  }
+  if (pageSize > 0 && pageSize !== QUERY_PAGE_SIZE_OPTIONS[0]) {
+    url.searchParams.set("size", String(pageSize));
+  } else {
+    url.searchParams.delete("size");
+  }
+  const next = `${url.pathname}${url.search}${url.hash}`;
+  const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  if (next !== current) {
+    window.history.replaceState(window.history.state, "", next);
+  }
+}
+
 function readPositiveIntSearchParam(searchParams: URLSearchParams, key: string) {
   const value = Number(searchParams.get(key) || "");
   return Number.isInteger(value) && value > 0 ? value : undefined;
 }
 
-function buildRecentMinutesTimeRange(minutes: number) {
+function buildEndingNowTimeRange(minutes: number) {
   const end = new Date(Date.now());
   end.setSeconds(0, 0);
   const start = new Date(end.getTime() - minutes * 60 * 1000);
   return [start, end] as [Date, Date];
+}
+
+function buildDayOffsetTimeRange(dayOffset: number) {
+  const start = moment().subtract(dayOffset, "day").startOf("day");
+  const end = start.clone().endOf("day");
+  return [start.toDate(), end.toDate()] as [Date, Date];
+}
+
+function buildDefaultAbsolutePickerRange() {
+  return buildAbsolutePickerRange(buildEndingNowTimeRange(DEFAULT_TIME_RANGE_MINUTES));
 }
 
 function toSecondRange(range: [Date, Date]) {
@@ -267,135 +762,892 @@ async function copyTextToClipboard(text: string) {
   return copied;
 }
 
-function formatTimeRangeDisplay(range: QueryDateRange) {
-  if (!range) {
-    return "Select time range";
-  }
-  const [start, end] = range;
-  const now = new Date(Date.now());
-  const endDeltaSeconds = Math.abs(end.getTime() - now.getTime()) / 1000;
-  const durationMinutes = Math.round((end.getTime() - start.getTime()) / 60_000);
-  const quickRange = QUICK_TIME_RANGES.find((item) => item.minutes === durationMinutes);
-  if (quickRange && endDeltaSeconds < 90) {
-    return quickRange.label;
-  }
-  return `${formatDateTimeLocalValue(start).replace("T", " ")} to ${formatDateTimeLocalValue(end).replace("T", " ")}`;
+function QueryEmptyState({
+  icon,
+  title,
+  description,
+  variant = "result",
+  tone = "neutral"
+}: QueryEmptyStateProps) {
+  return (
+    <div className={`cv-query-empty-state cv-query-empty-state--${variant} cv-query-empty-state--${tone}`}>
+      <span className="cv-query-empty-state__icon" aria-hidden="true">
+        {icon}
+      </span>
+      <div className="cv-query-empty-state__body">
+        <strong>{title}</strong>
+        {description ? <p>{description}</p> : null}
+      </div>
+    </div>
+  );
 }
 
-function TimeRangeDropdown({
+function QueryHistogramLoadingState() {
+  return (
+    <div className="cv-query-histogram-loading" aria-label="Loading histogram" aria-busy="true">
+      <div className="cv-query-histogram-loading__axis" aria-hidden="true" />
+      <div className="cv-query-histogram-loading__bars" aria-hidden="true">
+        {HISTOGRAM_LOADING_BARS.map((height, index) => (
+          <span
+            key={`${height}-${index}`}
+            className="cv-query-histogram-loading__bar"
+            style={{ height: `${height}%` }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function QueryResultLoadingState({ onCancel }: { onCancel?: () => void }) {
+  return (
+    <div className="cv-query-result-loading" aria-label="Loading query results" aria-busy="true">
+      <div className="cv-query-result-loading__bar">
+        <span className="cv-query-skeleton cv-query-result-loading__summary" />
+        {onCancel ? (
+          <button
+            type="button"
+            className="cv-query-result-loading__cancel"
+            aria-label="Cancel query"
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+        ) : (
+          <span className="cv-query-skeleton cv-query-result-loading__action" />
+        )}
+      </div>
+      <div className="cv-query-result-loading__table">
+        <div className="cv-query-result-loading__header" aria-hidden="true">
+          <span className="cv-query-skeleton" />
+          <span className="cv-query-skeleton" />
+          <span className="cv-query-skeleton" />
+          <span className="cv-query-skeleton" />
+          <span className="cv-query-skeleton" />
+        </div>
+        <div className="cv-query-result-loading__rows" aria-hidden="true">
+          {RESULT_LOADING_ROWS.map((row, rowIndex) => (
+            <div key={rowIndex} className="cv-query-result-loading__row">
+              {row.map((width, cellIndex) => (
+                <span
+                  key={`${rowIndex}-${cellIndex}`}
+                  className="cv-query-skeleton"
+                  style={{ width }}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function QueryFieldStatsLoadingState() {
+  return (
+    <div className="cv-query-field-stats-loading" aria-label="Loading top values" aria-busy="true">
+      {FIELD_STATS_LOADING_ROWS.map((width, index) => (
+        <div key={`${width}-${index}`} className="cv-query-field-stats-loading__row">
+          <span className="cv-query-skeleton" style={{ width }} />
+          <span className="cv-query-skeleton" />
+          <span className="cv-query-skeleton" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function HistogramIconAction({
+  label,
+  icon,
+  disabled,
+  muted,
+  ariaExpanded,
+  showLabel,
+  onClick
+}: {
+  label: string;
+  icon: string;
+  disabled?: boolean;
+  muted?: boolean;
+  ariaExpanded?: boolean;
+  showLabel?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <EuiToolTip content={label} delay="long">
+      <button
+        type="button"
+        className={[
+          "cv-query-histogram-action",
+          showLabel ? "cv-query-histogram-action--text" : "cv-query-histogram-action--icon",
+          muted ? "cv-query-histogram-action--muted" : ""
+        ]
+          .filter(Boolean)
+          .join(" ")}
+        onClick={onClick}
+        disabled={disabled}
+        aria-label={label}
+        aria-expanded={ariaExpanded}
+        title={label}
+      >
+        <EuiIcon type={icon} size="s" aria-hidden="true" />
+        {showLabel ? <span className="cv-query-histogram-action__label">{label}</span> : null}
+      </button>
+    </EuiToolTip>
+  );
+}
+
+function ResultToolbarIconAction({
+  label,
+  icon,
+  disabled,
+  loading,
+  ariaPressed,
+  ariaExpanded,
+  title,
+  showIcon = true,
+  showLabel = true,
+  onClick
+}: {
+  label: string;
+  icon: string;
+  disabled?: boolean;
+  loading?: boolean;
+  ariaPressed?: boolean;
+  ariaExpanded?: boolean;
+  title?: string;
+  showIcon?: boolean;
+  showLabel?: boolean;
+  onClick: () => void;
+}) {
+  const tooltip = title ?? label;
+  return (
+    <EuiToolTip content={tooltip} delay="long">
+      <button
+        type="button"
+        className={
+          showLabel
+            ? "cv-query-result-action cv-query-result-action--text"
+            : "cv-query-result-action cv-query-result-action--icon"
+        }
+        onClick={onClick}
+        disabled={disabled}
+        aria-label={label}
+        aria-busy={loading || undefined}
+        aria-pressed={ariaPressed}
+        aria-expanded={ariaExpanded}
+        title={tooltip}
+      >
+        {loading !== undefined ? (
+          <span
+            className={
+              loading
+                ? "cv-query-result-action__spinner cv-query-result-action__spinner--active"
+                : "cv-query-result-action__spinner"
+            }
+            aria-hidden="true"
+          />
+        ) : showIcon ? (
+          <EuiIcon type={icon} size="s" aria-hidden="true" />
+        ) : null}
+        {showLabel ? <span className="cv-query-result-action__label">{label}</span> : null}
+      </button>
+    </EuiToolTip>
+  );
+}
+
+function isGlobalMatchField(field: string) {
+  const normalized = field.trim();
+  return normalized === GLOBAL_MATCH_FIELD || normalized === LEGACY_GLOBAL_MATCH_FIELD;
+}
+
+function formatConditionFieldLabel(field: string) {
+  const normalized = field.trim();
+  if (!normalized) {
+    return "Field";
+  }
+  return isGlobalMatchField(normalized) ? GLOBAL_MATCH_DISPLAY_LABEL : normalized;
+}
+
+function formatConditionFieldInputValue(field: string) {
+  return isGlobalMatchField(field) ? GLOBAL_MATCH_DISPLAY_LABEL : field;
+}
+
+function parseConditionFieldInput(value: string) {
+  const normalized = value.trim();
+  return normalized.toLowerCase() === GLOBAL_MATCH_DISPLAY_LABEL.toLowerCase() ||
+    normalized === LEGACY_GLOBAL_MATCH_FIELD
+    ? GLOBAL_MATCH_FIELD
+    : value;
+}
+
+function normalizeFieldPickerKey(field: string) {
+  return parseConditionFieldInput(field).trim().toLowerCase();
+}
+
+function getStorageAnalysisFieldName(field: QueryStorageAnalysisField) {
+  return String(field.orderField || (field.rootName ? `${field.rootName}.${field.field}` : field.field)).trim();
+}
+
+function getStorageAnalysisValueType(field: QueryStorageAnalysisField): QueryFilterValueType {
+  return field.typ === 1 || field.typ === 2 ? "number" : "string";
+}
+
+function normalizeFieldCatalogKey(field: string) {
+  return normalizeResultColumnOptionField(field).trim().toLowerCase();
+}
+
+type FieldPickerChoice = {
+  key: string;
+  field: string;
+  label: string;
+};
+
+function buildFieldPickerChoices(value: string, options: QueryFieldPickerOption[]): FieldPickerChoice[] {
+  const normalizedValueKey = normalizeFieldPickerKey(value);
+  const seenOptions = new Set<string>();
+  const uniqueOptions = options
+    .map((item) => {
+      const key = normalizeFieldPickerKey(item.field);
+      if (!key || seenOptions.has(key)) {
+        return null;
+      }
+      seenOptions.add(key);
+      return {
+        key: `field-${item.source}-${item.field}`,
+        field: item.field,
+        label: formatConditionFieldLabel(item.field)
+      };
+    })
+    .filter(Boolean) as FieldPickerChoice[];
+  const hasCustomValue = Boolean(value.trim() && !seenOptions.has(normalizedValueKey));
+  return hasCustomValue
+    ? [
+        {
+          key: `custom-${normalizedValueKey}`,
+          field: value,
+          label: formatConditionFieldLabel(value)
+        },
+        ...uniqueOptions
+      ]
+    : uniqueOptions;
+}
+
+function FieldPickerDropdown({
   value,
+  options,
+  onSelect,
+  onClose,
+  activeIndex
+}: {
+  value: string;
+  options: QueryFieldPickerOption[];
+  onSelect: (field: string) => void;
+  onClose: () => void;
+  activeIndex?: number;
+}) {
+  const normalizedValueKey = normalizeFieldPickerKey(value);
+  const choices = buildFieldPickerChoices(value, options);
+  const clampedActiveIndex =
+    typeof activeIndex === "number" && activeIndex >= 0 && activeIndex < choices.length ? activeIndex : -1;
+
+  return (
+    <div className="cv-query-field-picker" role="listbox" aria-label="Field suggestions">
+      {choices.map((item, index) => {
+        const selected = index === clampedActiveIndex || (clampedActiveIndex < 0 && normalizeFieldPickerKey(item.field) === normalizedValueKey);
+        return (
+          <button
+            key={item.key}
+            type="button"
+            role="option"
+            aria-selected={selected}
+            className={
+              selected
+                ? "cv-query-field-picker__option cv-query-field-picker__option--active"
+                : "cv-query-field-picker__option"
+            }
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => {
+              onSelect(item.field);
+              onClose();
+            }}
+          >
+            <span className="cv-query-field-picker__name">{item.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function QueryCompactSelect<TValue extends string>({
+  value,
+  options,
+  ariaLabel,
+  className = "",
   onChange
 }: {
-  value: QueryDateRange;
-  onChange: (value: QueryDateRange) => void;
+  value: TValue;
+  options: readonly { label: string; value: TValue }[];
+  ariaLabel: string;
+  className?: string;
+  onChange: (value: TValue) => void;
 }) {
-  const [open, setOpen] = useState(false);
-  const [quickSearch, setQuickSearch] = useState("");
-  const [absoluteStart, setAbsoluteStart] = useState(value ? formatDateTimeLocalValue(value[0]) : "");
-  const [absoluteEnd, setAbsoluteEnd] = useState(value ? formatDateTimeLocalValue(value[1]) : "");
-  const label = formatTimeRangeDisplay(value);
-  const activeDurationMinutes = value ? Math.round((value[1].getTime() - value[0].getTime()) / 60_000) : null;
-  const visibleRanges = QUICK_TIME_RANGES.filter((item) =>
-    item.label.toLowerCase().includes(quickSearch.trim().toLowerCase())
+  const selectedLabel = options.find((item) => item.value === value)?.label ?? value;
+  return (
+    <EuiSuperSelect<TValue>
+      compressed
+      fullWidth
+      aria-label={`${ariaLabel}: ${selectedLabel}`}
+      title={selectedLabel}
+      className={["cv-query-compact-select", className].filter(Boolean).join(" ")}
+      itemClassName="cv-query-compact-select__item"
+      popoverProps={{
+        panelClassName: "cv-query-compact-select__panel",
+        repositionOnScroll: true
+      }}
+      valueOfSelected={value}
+      options={options.map((item) => ({
+        value: item.value,
+        inputDisplay: <span className="cv-query-compact-select__value">{item.label}</span>,
+        dropdownDisplay: <span className="cv-query-compact-select__option">{item.label}</span>
+      }))}
+      onChange={onChange}
+    />
   );
+}
 
-  useEffect(() => {
-    if (!open || !value) {
-      return;
+function formatAbsolutePickerValue(date: Date) {
+  return moment(date).format("YYYY-MM-DDTHH:mm:ss.SSSZ");
+}
+
+function formatAbsoluteTimeInput(date: Date) {
+  return moment(date).locale("en").format(ABSOLUTE_TIME_FORMAT);
+}
+
+function parseAbsoluteTimeInput(value: string) {
+  const parsed = moment(value.trim(), ABSOLUTE_TIME_FORMAT, true);
+  return parsed.isValid() ? parsed.toDate() : null;
+}
+
+function buildAbsolutePickerRange(range: [Date, Date]): QueryAbsolutePickerRange {
+  return {
+    start: formatAbsolutePickerValue(range[0]),
+    end: formatAbsolutePickerValue(range[1])
+  };
+}
+
+function buildInitialAbsolutePickerRange(
+  searchParams: URLSearchParams,
+  range: [Date, Date]
+): QueryAbsolutePickerRange {
+  const hasURLRange = Boolean(
+    (searchParams.get("start") && searchParams.get("end")) ||
+      (searchParams.get("st") && searchParams.get("et")) ||
+      (searchParams.get("startTime") && searchParams.get("endTime"))
+  );
+  return hasURLRange ? buildAbsolutePickerRange(range) : buildDefaultAbsolutePickerRange();
+}
+
+function isWholeDayDateRange(range: [Date, Date]) {
+  const start = moment(range[0]);
+  const end = moment(range[1]);
+  return (
+    start.isSame(end, "day") &&
+    start.hours() === 0 &&
+    start.minutes() === 0 &&
+    start.seconds() === 0 &&
+    end.hours() === 23 &&
+    end.minutes() === 59 &&
+    end.seconds() === 59
+  );
+}
+
+function getWholeDaySpanDays(range: [Date, Date]) {
+  const start = moment(range[0]);
+  const end = moment(range[1]);
+  if (
+    start.hours() !== 0 ||
+    start.minutes() !== 0 ||
+    start.seconds() !== 0 ||
+    end.hours() !== 23 ||
+    end.minutes() !== 59 ||
+    end.seconds() !== 59 ||
+    end.isBefore(start)
+  ) {
+    return null;
+  }
+  return end.clone().startOf("day").diff(start.clone().startOf("day"), "days") + 1;
+}
+
+function parseAbsolutePickerRange(range: QueryAbsolutePickerRange) {
+  const start = moment.parseZone(range.start);
+  const end = moment.parseZone(range.end);
+  if (!start.isValid() || !end.isValid() || start.valueOf() >= end.valueOf()) {
+    return null;
+  }
+  return [start.toDate(), end.toDate()] as [Date, Date];
+}
+
+function getTimeRangeButtonLabel(parsedRange: QueryDateRange) {
+  if (parsedRange) {
+    const start = moment(parsedRange[0]).locale("en");
+    const end = moment(parsedRange[1]).locale("en");
+    if (isWholeDayDateRange(parsedRange)) {
+      return start.isSame(moment(), "day") ? "Today" : start.format("MMM D, YYYY");
     }
-    setAbsoluteStart(formatDateTimeLocalValue(value[0]));
-    setAbsoluteEnd(formatDateTimeLocalValue(value[1]));
-  }, [open, value]);
+    const hasSeconds = start.seconds() !== 0 || end.seconds() !== 0;
+    const startFormat = hasSeconds ? "MM/DD HH:mm:ss" : "MM/DD HH:mm";
+    const endFormat = start.isSame(end, "day")
+      ? hasSeconds ? "HH:mm:ss" : "HH:mm"
+      : hasSeconds ? "MM/DD HH:mm:ss" : "MM/DD HH:mm";
+    return `${start.format(startFormat)} - ${end.format(endFormat)}`;
+  }
+  return "Select time range";
+}
 
-  function applyQuickRange(range: QuickTimeRange) {
-    onChange(buildRecentMinutesTimeRange(range.minutes));
-    setOpen(false);
+function formatDurationSecondsLabel(durationSeconds: number) {
+  if (durationSeconds < 60) {
+    return `${durationSeconds}s`;
+  }
+  if (durationSeconds < 60 * 60) {
+    return `${Math.round(durationSeconds / 60)}m`;
+  }
+  if (durationSeconds < 24 * 60 * 60) {
+    return `${Math.round(durationSeconds / 60 / 60)}h`;
+  }
+  return `${Math.round(durationSeconds / 60 / 60 / 24)}d`;
+}
+
+function getTimeRangeDurationLabel(range: QueryDateRange) {
+  if (!range) {
+    return "Invalid time range";
+  }
+  return formatDurationSecondsLabel(Math.max(1, Math.round((range[1].getTime() - range[0].getTime()) / 1000)));
+}
+
+function cloneDateRange(range: QueryDateRange): [Date, Date] | null {
+  if (!range) {
+    return null;
+  }
+  return [new Date(range[0]), new Date(range[1])];
+}
+
+function isSameSecondDateRange(left: QueryDateRange, right: QueryDateRange) {
+  if (!left || !right) {
+    return false;
+  }
+  return (
+    Math.floor(left[0].getTime() / 1000) === Math.floor(right[0].getTime() / 1000) &&
+    Math.floor(left[1].getTime() / 1000) === Math.floor(right[1].getTime() / 1000)
+  );
+}
+
+function TimeRangeAbsolutePicker({
+  value,
+  onChange,
+  isLoading
+}: {
+  value: QueryAbsolutePickerRange;
+  onChange: (pickerRange: QueryAbsolutePickerRange, dateRange: QueryDateRange) => void;
+  isLoading?: boolean;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [rangeError, setRangeError] = useState("");
+  const [absoluteDraft, setAbsoluteDraft] = useState(() => {
+    const initialRange = parseAbsolutePickerRange(value) ?? buildDefaultTimeRange();
+    return {
+      start: initialRange[0],
+      end: initialRange[1]
+    };
+  });
+  const [absoluteInputDraft, setAbsoluteInputDraft] = useState(() => {
+    const initialRange = parseAbsolutePickerRange(value) ?? buildDefaultTimeRange();
+    return {
+      start: formatAbsoluteTimeInput(initialRange[0]),
+      end: formatAbsoluteTimeInput(initialRange[1])
+    };
+  });
+  const [activeAbsoluteField, setActiveAbsoluteField] = useState<TimeRangeAbsoluteField | null>(null);
+  const parsedRange = useMemo(() => parseAbsolutePickerRange(value), [value.start, value.end]);
+  const buttonLabel = useMemo(() => getTimeRangeButtonLabel(parsedRange), [parsedRange]);
+  const draftDurationLabel = useMemo(() => {
+    const nextStart = parseAbsoluteTimeInput(absoluteInputDraft.start);
+    const nextEnd = parseAbsoluteTimeInput(absoluteInputDraft.end);
+    if (!nextStart || !nextEnd || nextEnd.getTime() <= nextStart.getTime()) {
+      return "Invalid time range";
+    }
+    return getTimeRangeDurationLabel([nextStart, nextEnd]);
+  }, [absoluteInputDraft.end, absoluteInputDraft.start]);
+  function syncDraftsFromValue() {
+    const nextParsedRange = parseAbsolutePickerRange(value) ?? buildDefaultTimeRange();
+    setAbsoluteDraft({
+      start: nextParsedRange[0],
+      end: nextParsedRange[1]
+    });
+    setAbsoluteInputDraft({
+      start: formatAbsoluteTimeInput(nextParsedRange[0]),
+      end: formatAbsoluteTimeInput(nextParsedRange[1])
+    });
+    setActiveAbsoluteField(null);
+    setRangeError("");
+  }
+
+  function openPicker() {
+    syncDraftsFromValue();
+    setIsOpen(true);
+  }
+
+  function closePicker() {
+    syncDraftsFromValue();
+    setIsOpen(false);
+  }
+
+  function applyDateRange(nextDateRange: [Date, Date], closeAfterApply = true) {
+    const nextPickerRange = buildAbsolutePickerRange(nextDateRange);
+    setRangeError("");
+    onChange(nextPickerRange, nextDateRange);
+    setAbsoluteDraft({
+      start: nextDateRange[0],
+      end: nextDateRange[1]
+    });
+    setAbsoluteInputDraft({
+      start: formatAbsoluteTimeInput(nextDateRange[0]),
+      end: formatAbsoluteTimeInput(nextDateRange[1])
+    });
+    if (closeAfterApply) {
+      setIsOpen(false);
+    }
   }
 
   function applyAbsoluteRange() {
-    const start = new Date(absoluteStart);
-    const end = new Date(absoluteEnd);
-    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) || start.getTime() >= end.getTime()) {
+    const nextStart = parseAbsoluteTimeInput(absoluteInputDraft.start);
+    const nextEnd = parseAbsoluteTimeInput(absoluteInputDraft.end);
+    if (!nextStart || !nextEnd) {
+      setRangeError("Enter a valid absolute time");
       return;
     }
-    onChange([start, end]);
-    setOpen(false);
+    if (nextEnd.getTime() <= nextStart.getTime()) {
+      setRangeError("End time must be after start time");
+      return;
+    }
+    setAbsoluteDraft({ start: nextStart, end: nextEnd });
+    setAbsoluteInputDraft({
+      start: formatAbsoluteTimeInput(nextStart),
+      end: formatAbsoluteTimeInput(nextEnd)
+    });
+    applyDateRange([nextStart, nextEnd]);
   }
 
+  function updateAbsoluteField(field: TimeRangeAbsoluteField, date: Date) {
+    setActiveAbsoluteField(field);
+    setRangeError("");
+    setAbsoluteDraft((current) => ({
+      ...current,
+      [field]: date
+    }));
+    setAbsoluteInputDraft((current) => ({
+      ...current,
+      [field]: formatAbsoluteTimeInput(date)
+    }));
+  }
+
+  function activateAbsoluteField(field: TimeRangeAbsoluteField) {
+    setActiveAbsoluteField(field);
+    setRangeError("");
+  }
+
+  function updateAbsoluteFieldText(field: TimeRangeAbsoluteField, nextValue: string) {
+    setActiveAbsoluteField(field);
+    setAbsoluteInputDraft((current) => ({
+      ...current,
+      [field]: nextValue
+    }));
+    if (rangeError) {
+      setRangeError("");
+    }
+  }
+
+  function commitAbsoluteFieldText(field: TimeRangeAbsoluteField) {
+    const nextDate = parseAbsoluteTimeInput(absoluteInputDraft[field]);
+    if (!nextDate) {
+      setRangeError(`Enter a valid ${field} time`);
+      return;
+    }
+    updateAbsoluteField(field, nextDate);
+  }
+
+  function shiftTimeWindow(direction: -1 | 1) {
+    if (!parsedRange) {
+      setRangeError("Cannot shift an invalid time range");
+      return;
+    }
+    const wholeDaySpanDays = getWholeDaySpanDays(parsedRange);
+    if (wholeDaySpanDays) {
+      const nextStart = moment(parsedRange[0]).add(direction * wholeDaySpanDays, "days").startOf("day");
+      const nextEnd = nextStart.clone().add(wholeDaySpanDays - 1, "days").endOf("day");
+      const nextRange = [nextStart.toDate(), nextEnd.toDate()] as [Date, Date];
+      onChange(buildAbsolutePickerRange(nextRange), nextRange);
+      return;
+    }
+    const duration = parsedRange[1].getTime() - parsedRange[0].getTime();
+    const nextRange = [
+      new Date(parsedRange[0].getTime() + direction * duration),
+      new Date(parsedRange[1].getTime() + direction * duration)
+    ] as [Date, Date];
+    onChange(buildAbsolutePickerRange(nextRange), nextRange);
+  }
+
+  function isDayPresetSelected(dayOffset: number) {
+    if (!parsedRange || !isWholeDayDateRange(parsedRange)) {
+      return false;
+    }
+    return moment(parsedRange[0]).isSame(moment().subtract(dayOffset, "day"), "day");
+  }
+
+  function isAbsoluteSpanSelected(minutes: number) {
+    if (!parsedRange) {
+      return false;
+    }
+    const expectedMs = minutes * 60 * 1000;
+    const durationMs = parsedRange[1].getTime() - parsedRange[0].getTime();
+    const endDeltaMs = Math.abs(Date.now() - parsedRange[1].getTime());
+    return Math.abs(durationMs - expectedMs) < 2000 && endDeltaMs < 2 * 60 * 1000;
+  }
+
+  function handleAbsoluteFieldClick(field: TimeRangeAbsoluteField, event: MouseEvent<HTMLDivElement>) {
+    if ((event.target as HTMLElement).closest("button")) {
+      return;
+    }
+    activateAbsoluteField(field);
+  }
+
+  const absoluteControls = (
+    <div className="cv-query-time-absolute-block">
+      <div className="cv-query-time-preset-row" aria-label="Absolute time shortcuts">
+        <div className="cv-query-time-absolute-presets" aria-label="Absolute day presets">
+          {ABSOLUTE_DAY_PRESET_RANGES.map((item) => {
+            const selected = isDayPresetSelected(item.dayOffset);
+            return (
+              <button
+                key={item.dayOffset}
+                type="button"
+                className={
+                  selected
+                    ? "cv-query-time-absolute-preset cv-query-time-absolute-preset--active"
+                    : "cv-query-time-absolute-preset"
+                }
+                onClick={() => applyDateRange(buildDayOffsetTimeRange(item.dayOffset))}
+                aria-label={item.label}
+                aria-pressed={selected}
+              >
+                {item.label}
+              </button>
+            );
+          })}
+        </div>
+        <span className="cv-query-time-preset-row__separator" aria-hidden="true" />
+        <div className="cv-query-time-quick-grid" aria-label="Absolute span presets">
+          {ABSOLUTE_SPAN_PRESETS.map((item) => {
+            const selected = isAbsoluteSpanSelected(item.minutes);
+            return (
+              <button
+                key={item.minutes}
+                type="button"
+                className={selected ? "cv-query-time-quick cv-query-time-quick--active" : "cv-query-time-quick"}
+                onClick={() => applyDateRange(buildEndingNowTimeRange(item.minutes))}
+                aria-label={item.label}
+                title={item.label}
+                aria-pressed={selected}
+              >
+                {item.shortLabel ?? item.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <div className="cv-query-time-absolute-range" aria-label="Absolute time range">
+        <div
+          className={
+            activeAbsoluteField === "start"
+              ? "cv-query-time-absolute-field cv-query-time-absolute-field--active"
+              : "cv-query-time-absolute-field"
+          }
+          role="group"
+          aria-label="Absolute start time field"
+          onClick={(event) => handleAbsoluteFieldClick("start", event)}
+        >
+          <span className="cv-query-time-absolute-label">
+            <span>From</span>
+          </span>
+          <div className="cv-query-time-absolute-input-wrap">
+            <EuiFieldText
+              aria-label="Absolute start time"
+              className="cv-query-time-absolute-input"
+              value={absoluteInputDraft.start}
+              onFocus={() => activateAbsoluteField("start")}
+              onChange={(event) => updateAbsoluteFieldText("start", event.target.value)}
+              onBlur={() => commitAbsoluteFieldText("start")}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  commitAbsoluteFieldText("start");
+                }
+              }}
+              placeholder={ABSOLUTE_TIME_FORMAT}
+              compressed
+              fullWidth
+            />
+          </div>
+        </div>
+        <div
+          className={
+            activeAbsoluteField === "end"
+              ? "cv-query-time-absolute-field cv-query-time-absolute-field--active"
+              : "cv-query-time-absolute-field"
+          }
+          role="group"
+          aria-label="Absolute end time field"
+          onClick={(event) => handleAbsoluteFieldClick("end", event)}
+        >
+          <span className="cv-query-time-absolute-label">
+            <span>To</span>
+          </span>
+          <div className="cv-query-time-absolute-input-wrap">
+            <EuiFieldText
+              aria-label="Absolute end time"
+              className="cv-query-time-absolute-input"
+              value={absoluteInputDraft.end}
+              onFocus={() => activateAbsoluteField("end")}
+              onChange={(event) => updateAbsoluteFieldText("end", event.target.value)}
+              onBlur={() => commitAbsoluteFieldText("end")}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  commitAbsoluteFieldText("end");
+                }
+              }}
+              placeholder={ABSOLUTE_TIME_FORMAT}
+              compressed
+              fullWidth
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
   return (
-    <div className="cv-query-time-range">
+    <div className="cv-query-time-picker">
       <button
         type="button"
-        className={`cv-query-time-range__trigger${open ? " cv-query-time-range__trigger--open" : ""}`}
-        onClick={() => setOpen((current) => !current)}
-        aria-haspopup="dialog"
-        aria-expanded={open}
-        aria-label={`时间范围 ${label}`}
+        className="cv-query-time-step"
+        onClick={() => shiftTimeWindow(-1)}
+        disabled={!parsedRange || isLoading}
+        aria-label="Previous time range"
+        title="Previous time range"
       >
-        <span className="cv-query-time-range__icon" aria-hidden="true">◷</span>
-        <span>{label}</span>
-        <span className="cv-query-time-range__chevron" aria-hidden="true">⌄</span>
+        <EuiIcon type="chevronSingleLeft" size="s" aria-hidden="true" />
       </button>
-      {open ? (
-        <div className="cv-query-time-popover" role="dialog" aria-label="选择时间范围">
-          <section className="cv-query-time-popover__absolute">
-            <h2>Absolute time range</h2>
-            <label className="cv-query-time-field">
-              <span>From</span>
-              <input
-                type="datetime-local"
-                value={absoluteStart}
-                onChange={(event) => setAbsoluteStart(event.target.value)}
-                aria-label="From"
-              />
-            </label>
-            <label className="cv-query-time-field">
-              <span>To</span>
-              <input
-                type="datetime-local"
-                value={absoluteEnd}
-                onChange={(event) => setAbsoluteEnd(event.target.value)}
-                aria-label="To"
-              />
-            </label>
-            <button type="button" className="cv-query-time-popover__apply" onClick={applyAbsoluteRange}>
-              Apply time range
+      <EuiPopover
+        anchorPosition="downCenter"
+        button={
+          <button
+            type="button"
+            className={isLoading ? "cv-query-time-button cv-query-time-button--loading" : "cv-query-time-button"}
+            onClick={() => (isOpen ? closePicker() : openPicker())}
+            aria-label={`Time range: ${buttonLabel}`}
+            aria-expanded={isOpen}
+            aria-haspopup="dialog"
+          >
+            <EuiIcon type="calendar" size="s" aria-hidden="true" className="cv-query-time-button__icon" />
+            <span className="cv-query-time-button__label">{buttonLabel}</span>
+          </button>
+        }
+        closePopover={closePicker}
+        display="block"
+        isOpen={isOpen}
+        ownFocus={false}
+        panelClassName={
+          activeAbsoluteField ? "cv-query-time-popover-panel cv-query-time-popover-panel--wide" : "cv-query-time-popover-panel"
+        }
+        panelPaddingSize="none"
+        repositionOnScroll
+      >
+        <div
+          className={
+            activeAbsoluteField ? "cv-query-time-popover cv-query-time-popover--calendar-open" : "cv-query-time-popover"
+          }
+          role="dialog"
+          aria-label="Select time range"
+        >
+          <div className="cv-query-time-section cv-query-time-section--quick">
+            <div className="cv-query-time-body">
+              <div className="cv-query-time-body__controls cv-query-time-body__controls--absolute-first">
+                {absoluteControls}
+              </div>
+              {activeAbsoluteField ? (
+                <div className="cv-query-time-absolute-calendar">
+                  <EuiDatePicker
+                    {...LOCALIZED_EUI_DATE_PICKER_PROPS}
+                    inline
+                    shadow={false}
+                    selected={moment(absoluteDraft[activeAbsoluteField]).locale("en")}
+                    onChange={(date) => {
+                      if (!date?.isValid()) {
+                        setRangeError(`Select a valid ${activeAbsoluteField} time`);
+                        return;
+                      }
+                      updateAbsoluteField(activeAbsoluteField, date.toDate());
+                    }}
+                    maxDate={activeAbsoluteField === "start" ? moment(absoluteDraft.end).locale("en") : undefined}
+                    minDate={activeAbsoluteField === "end" ? moment(absoluteDraft.start).locale("en") : undefined}
+                    dateFormat={ABSOLUTE_TIME_FORMAT}
+                    timeFormat="HH:mm"
+                    timeIntervals={1}
+                    showTimeSelect
+                    calendarClassName="cv-query-date-picker-calendar cv-query-date-picker-calendar--inline"
+                    compressed
+                    locale="en"
+                  />
+                </div>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="cv-query-time-popover__footer">
+            <div
+              className="cv-query-time-popover__hint"
+              role={rangeError ? "alert" : undefined}
+              aria-label={rangeError ? undefined : `Duration ${draftDurationLabel}`}
+            >
+              {rangeError || (draftDurationLabel === "Invalid time range" ? "" : `Span ${draftDurationLabel}`)}
+            </div>
+            <button type="button" className="cv-secondary-button" onClick={closePicker}>
+              Cancel
             </button>
-            <div className="cv-query-time-popover__recent">
-              <strong>Recently used absolute ranges</strong>
-              <span>{value ? `${formatClientDateTime(value[0])} to ${formatClientDateTime(value[1])}` : "No range selected"}</span>
-            </div>
-            <div className="cv-query-time-popover__footer">
-              <span>Browser Time</span>
-              <strong>China, CST</strong>
-            </div>
-          </section>
-          <section className="cv-query-time-popover__quick">
-            <label className="cv-query-time-search">
-              <span aria-hidden="true">⌕</span>
-              <input
-                value={quickSearch}
-                onChange={(event) => setQuickSearch(event.target.value)}
-                placeholder="Search quick ranges"
-                aria-label="Search quick ranges"
-              />
-            </label>
-            <div className="cv-query-time-popover__quick-list">
-              {visibleRanges.map((range) => {
-                const isActive = activeDurationMinutes === range.minutes;
-                return (
-                  <button
-                    key={range.label}
-                    type="button"
-                    className={`cv-query-time-popover__quick-item${isActive ? " cv-query-time-popover__quick-item--active" : ""}`}
-                    onClick={() => applyQuickRange(range)}
-                  >
-                    {range.label}
-                  </button>
-                );
-              })}
-            </div>
-          </section>
+            <button
+              type="button"
+              className="cv-action-button"
+              onClick={applyAbsoluteRange}
+            >
+              Update
+            </button>
+          </div>
+        </div>
+      </EuiPopover>
+      <button
+        type="button"
+        className="cv-query-time-step"
+        onClick={() => shiftTimeWindow(1)}
+        disabled={!parsedRange || isLoading}
+        aria-label="Next time range"
+        title="Next time range"
+      >
+        <EuiIcon type="chevronSingleRight" size="s" aria-hidden="true" />
+      </button>
+      {rangeError ? (
+        <div className="cv-query-time-error" role="alert">
+          {rangeError}
         </div>
       ) : null}
     </div>
@@ -654,6 +1906,47 @@ function stripAnsi(value: string) {
   return value.replace(/\u001b\[[0-9;]*m/g, "");
 }
 
+function dateFromTimestampMilliseconds(milliseconds: number) {
+  if (!Number.isFinite(milliseconds)) {
+    return null;
+  }
+  const date = new Date(milliseconds);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function toDateFromNumericTimestamp(value: number) {
+  const absoluteValue = Math.abs(value);
+  if (absoluteValue < 100_000_000_000) {
+    return dateFromTimestampMilliseconds(value * 1000);
+  }
+  if (absoluteValue < 100_000_000_000_000) {
+    return dateFromTimestampMilliseconds(value);
+  }
+  if (absoluteValue < 100_000_000_000_000_000) {
+    return dateFromTimestampMilliseconds(value / 1000);
+  }
+  return dateFromTimestampMilliseconds(value / 1_000_000);
+}
+
+function toDateFromIntegerTimestampText(value: string) {
+  if (!/^-?\d+$/.test(value)) {
+    return null;
+  }
+  const timestamp = BigInt(value);
+  const absoluteTimestamp = timestamp < 0n ? -timestamp : timestamp;
+  let milliseconds: bigint;
+  if (absoluteTimestamp < 100_000_000_000n) {
+    milliseconds = timestamp * 1000n;
+  } else if (absoluteTimestamp < 100_000_000_000_000n) {
+    milliseconds = timestamp;
+  } else if (absoluteTimestamp < 100_000_000_000_000_000n) {
+    milliseconds = timestamp / 1000n;
+  } else {
+    milliseconds = timestamp / 1_000_000n;
+  }
+  return dateFromTimestampMilliseconds(Number(milliseconds));
+}
+
 function toDateFromLogValue(value: unknown) {
   if (value === undefined || value === null || value === "") {
     return null;
@@ -662,12 +1955,14 @@ function toDateFromLogValue(value: unknown) {
     return value;
   }
   if (typeof value === "number") {
-    const milliseconds = Math.abs(value) < 10_000_000_000 ? value * 1000 : value;
-    const date = new Date(milliseconds);
-    return Number.isNaN(date.getTime()) ? null : date;
+    return toDateFromNumericTimestamp(value);
   }
   if (typeof value === "string") {
     const text = value.trim();
+    const integerTimestampDate = toDateFromIntegerTimestampText(text);
+    if (integerTimestampDate) {
+      return integerTimestampDate;
+    }
     const numeric = Number(text);
     if (text && Number.isFinite(numeric)) {
       return toDateFromLogValue(numeric);
@@ -687,22 +1982,274 @@ function formatClientDateTime(value: unknown) {
   if (!date) {
     return value === undefined || value === null || value === "" ? "-" : String(value);
   }
-  return date.toLocaleString("zh-CN", { hour12: false });
+  return moment(date).locale("en").format(ABSOLUTE_TIME_FORMAT);
 }
 
-function formatTimeAxisLabel(value: unknown) {
+function formatHistogramTickLabel(value: unknown, spanSeconds: number) {
   const date = toDateFromLogValue(value);
   if (!date) {
     return String(value ?? "-");
   }
-  return date.toLocaleString("zh-CN", {
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false
-  });
+  const normalizedDate = moment(date).locale("en");
+  if (spanSeconds > 2 * 365 * 24 * 60 * 60) {
+    return normalizedDate.format("YYYY");
+  }
+  if (spanSeconds > 90 * 24 * 60 * 60) {
+    return normalizedDate.format("MMM YYYY");
+  }
+  if (spanSeconds > 7 * 24 * 60 * 60) {
+    return normalizedDate.format("MMM D");
+  }
+  if (spanSeconds > 24 * 60 * 60) {
+    return normalizedDate.format("MMM D HH:mm");
+  }
+  return normalizedDate.format("HH:mm");
 }
+
+function formatHistogramCountTickLabel(value: unknown) {
+  const count = Number(value);
+  if (!Number.isFinite(count) || count === 0) {
+    return "";
+  }
+  return formatCount(count);
+}
+
+function formatHistogramTooltipDate(value: number) {
+  return moment.unix(value).locale("en").format("MMM D, YYYY HH:mm:ss");
+}
+
+function formatHistogramTooltipRange(from: number, to: number) {
+  return `${formatHistogramTooltipDate(from)} - ${formatHistogramTooltipDate(to)}`;
+}
+
+function HistogramTooltip({ values, header }: CustomTooltipProps<HistogramChartDatum>) {
+  const datum = values.find((item) => item.datum)?.datum;
+  const count = Number(datum?.count ?? values[0]?.markValue ?? 0);
+  const title = datum
+    ? formatHistogramTooltipRange(datum.from, datum.to)
+    : header?.formattedValue ?? "-";
+
+  return (
+    <div className="cv-query-histogram-tooltip">
+      <div className="cv-query-histogram-tooltip__range">{title}</div>
+      <div className="cv-query-histogram-tooltip__metric">
+        <span className="cv-query-histogram-tooltip__dot" aria-hidden="true" />
+        <strong>{formatCount(count)}</strong>
+        <span>{formatHitsLabel(count)}</span>
+      </div>
+    </div>
+  );
+}
+
+function formatHistogramBucketSizeLabel(intervalMs: number) {
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+    return "";
+  }
+  const seconds = Math.round(intervalMs / 1000);
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  if (seconds < 60 * 60) {
+    return `${Math.round(seconds / 60)}m`;
+  }
+  if (seconds < 24 * 60 * 60) {
+    return `${Math.round(seconds / (60 * 60))}h`;
+  }
+  return `${Math.round(seconds / (24 * 60 * 60))}d`;
+}
+
+function getHistogramBucketIntervalMs(data: HistogramChartDatum[]) {
+  if (data.length <= 1) {
+    const item = data[0];
+    return item ? Math.max(0, item.to - item.from) * 1000 : 0;
+  }
+  const intervals = data
+    .slice(1)
+    .map((item, index) => Math.max(0, item.from - data[index].from) * 1000)
+    .filter((interval) => interval > 0)
+    .sort((left, right) => left - right);
+  return intervals[Math.floor(intervals.length / 2)] ?? 0;
+}
+
+function getHistogramSpanMs(data: HistogramChartDatum[], fallbackRange?: QueryDateRange) {
+  const first = data[0];
+  const last = data[data.length - 1];
+  if (first && last) {
+    return Math.max(0, last.to * 1000 - first.from * 1000);
+  }
+  if (!fallbackRange) {
+    return 0;
+  }
+  return Math.max(0, fallbackRange[1].getTime() - fallbackRange[0].getTime());
+}
+
+function getAutoHistogramIntervalMs(data: HistogramChartDatum[], rawIntervalMs: number, fallbackRange?: QueryDateRange) {
+  const spanMs = fallbackRange
+    ? Math.max(0, fallbackRange[1].getTime() - fallbackRange[0].getTime())
+    : getHistogramSpanMs(data, fallbackRange);
+  if (spanMs <= 0) {
+    return rawIntervalMs;
+  }
+  const targetIntervalMs = Math.ceil(spanMs / HISTOGRAM_AUTO_TARGET_BARS);
+  const minimumIntervalMs = Math.max(rawIntervalMs, targetIntervalMs);
+  const preferredInterval = HISTOGRAM_INTERVAL_OPTIONS.find(
+    (option) => option.milliseconds && option.milliseconds >= minimumIntervalMs
+  );
+  return preferredInterval?.milliseconds ?? minimumIntervalMs;
+}
+
+function aggregateHistogramData(data: HistogramChartDatum[], intervalMs: number, anchorMs?: number) {
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0 || data.length <= 1) {
+    return data;
+  }
+  const anchor = Number.isFinite(anchorMs) ? Number(anchorMs) : data[0].from * 1000;
+  const buckets = new Map<number, HistogramChartDatum>();
+  data.forEach((item) => {
+    const itemStartMs = item.from * 1000;
+    const bucketStartMs = anchor + Math.floor((itemStartMs - anchor) / intervalMs) * intervalMs;
+    const bucketEndMs = bucketStartMs + intervalMs;
+    const current = buckets.get(bucketStartMs);
+    if (current) {
+      current.count += item.count;
+      current.from = Math.min(current.from, Math.floor(bucketStartMs / 1000));
+      current.to = Math.max(current.to, Math.ceil(bucketEndMs / 1000), item.to);
+      return;
+    }
+    buckets.set(bucketStartMs, {
+      x: bucketStartMs,
+      count: item.count,
+      from: Math.floor(bucketStartMs / 1000),
+      to: Math.max(Math.ceil(bucketEndMs / 1000), item.to)
+    });
+  });
+  return Array.from(buckets.values()).sort((left, right) => left.from - right.from);
+}
+
+function buildLoadedLogsHistogramData(
+  rows: NormalizedLogRow[],
+  range: QueryDateRange,
+  intervalMs: number
+): HistogramChartDatum[] {
+  if (!range || rows.length === 0 || !Number.isFinite(intervalMs) || intervalMs <= 0) {
+    return [];
+  }
+  const startMs = range[0].getTime();
+  const endMs = range[1].getTime();
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) {
+    return [];
+  }
+  const bucketCount = Math.ceil((endMs - startMs) / intervalMs);
+  if (bucketCount <= 0 || bucketCount > 160) {
+    return [];
+  }
+  const buckets = Array.from({ length: bucketCount }, (_, index) => {
+    const bucketStartMs = startMs + index * intervalMs;
+    const bucketEndMs = Math.min(endMs, bucketStartMs + intervalMs);
+    return {
+      x: bucketStartMs,
+      count: 0,
+      from: Math.floor(bucketStartMs / 1000),
+      to: Math.ceil(bucketEndMs / 1000)
+    };
+  });
+  rows.forEach((row) => {
+    const timeMs = getLogRowTimeMs(row);
+    if (timeMs === null || timeMs < startMs || timeMs > endMs) {
+      return;
+    }
+    const index = Math.min(bucketCount - 1, Math.max(0, Math.floor((timeMs - startMs) / intervalMs)));
+    const bucket = buckets[index];
+    if (bucket) {
+      bucket.count += 1;
+    }
+  });
+  return buckets.some((item) => item.count > 0) ? buckets : [];
+}
+
+function findHistogramSelectionFromExtent(data: HistogramChartDatum[], extent: [number, number] | undefined) {
+  if (!extent || data.length === 0) {
+    return null;
+  }
+  const fromMs = Math.min(extent[0], extent[1]);
+  const toMs = Math.max(extent[0], extent[1]);
+  if (!Number.isFinite(fromMs) || !Number.isFinite(toMs) || toMs <= fromMs) {
+    return null;
+  }
+  const startIndex = data.findIndex((item) => item.to * 1000 > fromMs);
+  if (startIndex === -1) {
+    return null;
+  }
+  let endIndex = startIndex;
+  for (let index = data.length - 1; index >= startIndex; index -= 1) {
+    if (data[index].from * 1000 < toMs) {
+      endIndex = index;
+      break;
+    }
+  }
+  return {
+    anchorIndex: startIndex,
+    hoverIndex: endIndex
+  };
+}
+
+function clampHistogramSelectionPercent(value: number) {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(100, Math.max(0, value));
+}
+
+type HistogramSelectionOverlayProps = {
+  range: HistogramSelectionRange;
+  style?: CSSProperties;
+  disabled?: boolean;
+  onZoom: () => void;
+  onCancel: () => void;
+};
+
+export const HistogramSelectionOverlay = forwardRef<HTMLDivElement, HistogramSelectionOverlayProps>(
+  function HistogramSelectionOverlay({ range, style, disabled = false, onZoom, onCancel }, ref) {
+    function handleKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        onCancel();
+        return;
+      }
+      if (event.key !== "Enter" && event.key !== " ") {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      if (!disabled) {
+        onZoom();
+      }
+    }
+
+    function handleClick(event: MouseEvent<HTMLDivElement>) {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!disabled) {
+        onZoom();
+      }
+    }
+
+    return (
+      <div
+        ref={ref}
+        role="button"
+        tabIndex={0}
+        className="cv-query-histogram__selection-overlay"
+        style={style}
+        aria-label={`Selected histogram range: ${formatCount(range.count)} ${formatHitsLabel(range.count)}, ${formatHistogramTooltipRange(range.from, range.to)}`}
+        aria-disabled={disabled}
+        title="Click or press Enter to zoom in. Press Escape to cancel."
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+      />
+    );
+  }
+);
 
 function isPresentLogValue(value: unknown) {
   if (value === undefined || value === null || value === "") {
@@ -710,12 +2257,12 @@ function isPresentLogValue(value: unknown) {
   }
   if (typeof value === "string") {
     const text = value.trim().toLowerCase();
-    return text !== "[null]" && text !== "null" && text !== "nil";
+    return text !== "" && text !== "[null]" && text !== "null" && text !== "nil";
   }
   return true;
 }
 
-function firstPresentValue(row: Record<string, unknown>, keys: string[]) {
+function firstPresentValue(row: Record<string, unknown>, keys: readonly string[]) {
   for (const key of keys) {
     const value = row[key];
     if (isPresentLogValue(value)) {
@@ -725,16 +2272,62 @@ function firstPresentValue(row: Record<string, unknown>, keys: string[]) {
   return undefined;
 }
 
+function firstPresentEntry(row: Record<string, unknown>, keys: readonly string[]) {
+  for (const key of keys) {
+    const value = row[key];
+    if (isPresentLogValue(value)) {
+      return { key, value };
+    }
+  }
+  return null;
+}
+
+function normalizeLogLevelText(value: unknown) {
+  return stripAnsi(String(value ?? "")).trim().toLowerCase();
+}
+
+function buildLoadedFieldStatsItems(rows: NormalizedLogRow[], displayField: string, fieldRef: QueryFieldRef, limit = 10) {
+  const counts = new Map<string, number>();
+  rows.forEach((row) => {
+    const value =
+      row.parsed[fieldRef.fieldKey] ??
+      row.parsed[fieldRef.path] ??
+      row.parsed[displayField] ??
+      (fieldRef.fieldKey === row.levelField || displayField === "level" ? row.levelText : undefined) ??
+      (displayField === "msg" ? row.messageText : undefined);
+    if (!isPresentLogValue(value) || (value && typeof value === "object")) {
+      return;
+    }
+    const text = formatLogDetailValue(value).trim();
+    if (!text || text === "—" || text.length > 256) {
+      return;
+    }
+    counts.set(text, (counts.get(text) ?? 0) + 1);
+  });
+  const total = Array.from(counts.values()).reduce((sum, count) => sum + count, 0);
+  const items = Array.from(counts.entries())
+    .sort(([leftValue, leftCount], [rightValue, rightCount]) => rightCount - leftCount || leftValue.localeCompare(rightValue))
+    .slice(0, limit)
+    .map(([value, count]) => ({
+      value,
+      count,
+      percentage: total > 0 ? (count / total) * 100 : 0
+    }));
+  return { total, items };
+}
+
 function normalizeLogRow(row: Record<string, unknown>): NormalizedLogRow {
   const parsed = parseNestedJsonFields(row);
   const merged = { ...row, ...parsed };
-  const timeValue = firstPresentValue(merged, ["_time", "_time_", "_time_second_", "time", "timestamp", "ts"]);
-  const levelValue = firstPresentValue(merged, ["level", "severity", "lv", "log_level"]);
+  const timeValue = firstPresentValue(merged, LOG_TIME_FIELD_KEYS);
+  const levelEntry = firstPresentEntry(merged, LOG_LEVEL_FIELD_KEYS);
+  const levelValue = levelEntry?.value;
   const messageValue = firstPresentValue(merged, ["message", "msg", "content", "body", "_raw_log_"]);
   return {
     original: row,
     parsed: merged,
     timeText: formatClientDateTime(timeValue),
+    levelField: levelEntry?.key,
     levelText: levelValue === undefined ? "-" : String(levelValue),
     messageText: messageValue === undefined ? JSON.stringify(row) : String(messageValue)
   };
@@ -745,6 +2338,26 @@ function formatConditionSummaryValue(value: unknown) {
     return "";
   }
   return String(value);
+}
+
+function getLogLevelTone(value: string) {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized || normalized === "—" || normalized === "-") {
+    return "";
+  }
+  if (["fatal", "panic", "critical", "crit", "error", "err"].some((item) => normalized.includes(item))) {
+    return "error";
+  }
+  if (["warning", "warn"].some((item) => normalized.includes(item))) {
+    return "warning";
+  }
+  if (["info", "notice"].some((item) => normalized.includes(item))) {
+    return "info";
+  }
+  if (["debug", "trace", "verbose"].some((item) => normalized.includes(item))) {
+    return "debug";
+  }
+  return "default";
 }
 
 function formatLogDetailValue(value: unknown) {
@@ -818,12 +2431,55 @@ function canCreateConditionFromDetailValue(field: string, value: unknown) {
   return String(value).trim().length > 0 && String(value).trim().length <= 256;
 }
 
+function isUniqueFieldStatsField(field: string) {
+  const normalized = field.trim().toLowerCase();
+  return FIELD_STATS_UNIQUE_FIELDS.includes(normalized as (typeof FIELD_STATS_UNIQUE_FIELDS)[number]);
+}
+
+function isTimeFieldStatsField(field: string) {
+  const normalized = field
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  if (LOG_TIME_FIELD_KEYS.includes(normalized as (typeof LOG_TIME_FIELD_KEYS)[number])) {
+    return true;
+  }
+  const segments = normalized.split(/[.[\]/]+/).filter(Boolean);
+  return segments.some((segment) => {
+    const trimmed = segment.replace(/^_+|_+$/g, "");
+    if (!trimmed) {
+      return false;
+    }
+    return (
+      trimmed === "date" ||
+      /^time(_[a-z0-9]+)?$/.test(trimmed) ||
+      /(^|_)(time|ts|timestamp|datetime|date)(_|$)/.test(trimmed) ||
+      /^(created|updated|start|end|event|log|ingest|receive|received)_at$/.test(trimmed)
+    );
+  });
+}
+
+function canShowFieldStatsForField(field: string) {
+  return Boolean(field) && !/^_?raw/i.test(field) && !isUniqueFieldStatsField(field) && !isTimeFieldStatsField(field);
+}
+
 function canOpenFieldStats(field: string, value: unknown) {
-  return Boolean(field) && !/^_?raw/i.test(field) && !(value && typeof value === "object");
+  return canShowFieldStatsForField(field) && !(value && typeof value === "object");
 }
 
 function canStartAIAnalysisFromField(field: string, value: unknown) {
   return canCreateConditionFromDetailValue(field, value);
+}
+
+function isUnsupportedLogContentQueryError(message: string) {
+  return (
+    (message.includes("未配置日志内容字段") &&
+      (message.includes("全局匹配") || message.includes("日志内容字段查询"))) ||
+    (message.includes("no log content field") && message.includes("All fields"))
+  );
 }
 
 function createDetailConditionValue(value: unknown) {
@@ -852,9 +2508,36 @@ function createTypedDetailConditionValue(value: unknown, valueType: QueryFilterV
   return { value: String(sample.value), valueType };
 }
 
+const RAW_LOG_DETAIL_KEYS = ["_raw_log_", "_raw_log", "_raw", "raw_log", "raw", "rawLogJson"];
+const LOG_DETAIL_MESSAGE_FIELD_KEYS = ["message", "msg", "content", "body"] as const;
+
 function isRawLogDetailParent(parentKey: string) {
   const normalized = parentKey.trim().toLowerCase();
-  return normalized === "_raw_log_" || normalized === "_raw_log" || normalized === "raw_log";
+  return RAW_LOG_DETAIL_KEYS.some((key) => key.toLowerCase() === normalized);
+}
+
+function getLogDetailMessageText(row: NormalizedLogRow) {
+  const messageEntry = getLogDetailMessageEntry(row);
+  const text = formatLogDetailValue(messageEntry.value);
+  const normalized = text.trim();
+  return normalized && normalized !== "—" ? normalized : row.messageText;
+}
+
+function getLogDetailMessageEntry(row: NormalizedLogRow) {
+  return firstPresentEntry(row.parsed, LOG_DETAIL_MESSAGE_FIELD_KEYS) ?? { key: "message", value: row.messageText };
+}
+
+function getVisibleLogDetailEntries(row: NormalizedLogRow) {
+  return Object.entries(row.parsed)
+    .filter(([, value]) => isPresentLogValue(value))
+    .sort(([left], [right]) => compareLogDetailFields(left, right));
+}
+
+function isPromotedLogDetailMessageField(key: string, value: unknown, detailMessageText: string) {
+  if (!LOG_DETAIL_MESSAGE_FIELD_KEYS.includes(key as (typeof LOG_DETAIL_MESSAGE_FIELD_KEYS)[number])) {
+    return false;
+  }
+  return formatLogDetailValue(value).trim() === detailMessageText.trim();
 }
 
 function scalarJsonEntries(parentKey: string, value: unknown) {
@@ -911,7 +2594,8 @@ function scalarJsonEntries(parentKey: string, value: unknown) {
 }
 
 function isLogTimeField(field: string) {
-  return /^_time(_[a-z]+)?_$/.test(field) || field === "time" || field === "timestamp" || field === "ts";
+  const normalized = field.trim().toLowerCase();
+  return /^_time(_[a-z]+)?_$/.test(normalized) || normalized === "time" || normalized === "timestamp" || normalized === "ts";
 }
 
 function formatDateTimeForQuery(date: Date) {
@@ -952,15 +2636,7 @@ function createDetailTimeRangeConditions(field: string, value: unknown): QueryFi
 }
 
 function getLogRowTimeMs(row: NormalizedLogRow) {
-  const value = firstPresentValue(row.parsed, [
-    "_time",
-    "_time_",
-    "_time_nanosecond_",
-    "_time_second_",
-    "time",
-    "timestamp",
-    "ts"
-  ]);
+  const value = firstPresentValue(row.parsed, LOG_TIME_FIELD_KEYS);
   return toDateFromLogValue(value)?.getTime() ?? null;
 }
 
@@ -1007,7 +2683,17 @@ function readResultColumnKeys(storageKey: string) {
     const parsed = raw ? (JSON.parse(raw) as unknown) : null;
     if (Array.isArray(parsed)) {
       const keys = parsed.map((item) => String(item)).filter(Boolean);
-      return keys.length > 0 ? keys : [...DEFAULT_RESULT_COLUMN_KEYS];
+      return normalizeLegacyResultColumnKeys(keys);
+    }
+    if (parsed && typeof parsed === "object") {
+      const record = parsed as { version?: unknown; keys?: unknown };
+      if (record.version === RESULT_COLUMN_STORAGE_VERSION && Array.isArray(record.keys)) {
+        const keys = normalizeResultColumnKeys(record.keys.map((item) => String(item)).filter(Boolean));
+        return keys.length > 0 ? keys : [...DEFAULT_RESULT_COLUMN_KEYS];
+      }
+      if (Array.isArray(record.keys)) {
+        return normalizeLegacyResultColumnKeys(record.keys.map((item) => String(item)).filter(Boolean));
+      }
     }
   } catch {
     return [...DEFAULT_RESULT_COLUMN_KEYS];
@@ -1015,11 +2701,252 @@ function readResultColumnKeys(storageKey: string) {
   return [...DEFAULT_RESULT_COLUMN_KEYS];
 }
 
+function normalizeResultColumnKey(key: string) {
+  return key === LEGACY_CONTAINER_NAME_RESULT_COLUMN_KEY ? CONTAINER_NAME_RESULT_COLUMN_KEY : key;
+}
+
+function normalizeResultColumnKeys(keys: string[]) {
+  return Array.from(new Set(keys.map((key) => normalizeResultColumnKey(key)).filter(Boolean)));
+}
+
+function normalizeLegacyResultColumnKeys(keys: string[]) {
+  const normalizedKeys = normalizeResultColumnKeys(keys);
+  if (normalizedKeys.length === 0) {
+    return [...DEFAULT_RESULT_COLUMN_KEYS];
+  }
+  if (
+    normalizedKeys.length === LEGACY_DEFAULT_RESULT_COLUMN_KEYS.length &&
+    normalizedKeys.every((key, index) => key === LEGACY_DEFAULT_RESULT_COLUMN_KEYS[index])
+  ) {
+    return [...DEFAULT_RESULT_COLUMN_KEYS];
+  }
+  const defaultSet = new Set<string>(DEFAULT_RESULT_COLUMN_KEYS);
+  const customKeys = normalizedKeys.filter(
+    (key) => !defaultSet.has(key) && !isBuiltinResultFieldAlias(key) && !isLowPriorityResultField(key)
+  );
+  return Array.from(new Set([...DEFAULT_RESULT_COLUMN_KEYS, ...customKeys]));
+}
+
+function getFieldPriorityIndex(field: string) {
+  const index = RESULT_COLUMN_FIELD_PRIORITY.indexOf(field as (typeof RESULT_COLUMN_FIELD_PRIORITY)[number]);
+  return index >= 0 ? index : Number.POSITIVE_INFINITY;
+}
+
+function getMetaFieldPriorityIndex(field: string) {
+  const index = RESULT_COLUMN_META_FIELD_PRIORITY.indexOf(field as (typeof RESULT_COLUMN_META_FIELD_PRIORITY)[number]);
+  return index >= 0 ? index : Number.POSITIVE_INFINITY;
+}
+
+function getLogDetailFieldPriorityIndex(field: string) {
+  const index = LOG_DETAIL_FIELD_PRIORITY.indexOf(field as (typeof LOG_DETAIL_FIELD_PRIORITY)[number]);
+  return index >= 0 ? index : Number.POSITIVE_INFINITY;
+}
+
+function isLowPriorityResultField(field: string) {
+  return getMetaFieldPriorityIndex(field) !== Number.POSITIVE_INFINITY;
+}
+
+function isBuiltinResultFieldAlias(field: string) {
+  return RESULT_BUILTIN_FIELD_ALIASES.includes(field as (typeof RESULT_BUILTIN_FIELD_ALIASES)[number]);
+}
+
+function normalizeResultColumnOptionField(field: string) {
+  return normalizeResultColumnKey(field);
+}
+
+function compareResultFieldColumns(left: string, right: string) {
+  const leftIsMeta = isLowPriorityResultField(left);
+  const rightIsMeta = isLowPriorityResultField(right);
+  if (leftIsMeta !== rightIsMeta) {
+    return leftIsMeta ? 1 : -1;
+  }
+  const leftPriority = leftIsMeta ? getMetaFieldPriorityIndex(left) : getFieldPriorityIndex(left);
+  const rightPriority = rightIsMeta ? getMetaFieldPriorityIndex(right) : getFieldPriorityIndex(right);
+  if (leftPriority !== rightPriority) {
+    return leftPriority - rightPriority;
+  }
+  return left.localeCompare(right);
+}
+
+function compareLogDetailFields(left: string, right: string) {
+  const leftPriority = getLogDetailFieldPriorityIndex(left);
+  const rightPriority = getLogDetailFieldPriorityIndex(right);
+  if (leftPriority !== rightPriority) {
+    return leftPriority - rightPriority;
+  }
+  const leftIsMeta = isLowPriorityResultField(left);
+  const rightIsMeta = isLowPriorityResultField(right);
+  if (leftIsMeta !== rightIsMeta) {
+    return leftIsMeta ? 1 : -1;
+  }
+  if (leftIsMeta && rightIsMeta) {
+    return getMetaFieldPriorityIndex(left) - getMetaFieldPriorityIndex(right);
+  }
+  return left.localeCompare(right);
+}
+
+function getResultColumnLayoutClass(columnKey: string) {
+  if (columnKey === "__time" || isLogTimeField(columnKey)) {
+    return "cv-query-result-col--time";
+  }
+  if (columnKey === "__level" || ["level", "lv", "severity", "log_level"].includes(columnKey)) {
+    return "cv-query-result-col--level";
+  }
+  if (["tid", "trace_id", "traceId", "span_id", "spanId"].includes(columnKey)) {
+    return "cv-query-result-col--id";
+  }
+  if (
+    columnKey === "__message" ||
+    ["msg", "message", "content", "body"].includes(columnKey) ||
+    columnKey.toLowerCase().includes("message")
+  ) {
+    return "cv-query-result-col--message";
+  }
+  if (["error", "exception", "stack", "stacktrace", "trace"].includes(columnKey.toLowerCase())) {
+    return "cv-query-result-col--wide";
+  }
+  if (isLowPriorityResultField(columnKey)) {
+    return "cv-query-result-col--meta";
+  }
+  return "cv-query-result-col--field";
+}
+
+function getResultColumnTextMaxLength(columnKey: string) {
+  const layoutClass = getResultColumnLayoutClass(columnKey);
+  if (layoutClass === "cv-query-result-col--message") {
+    return 220;
+  }
+  if (layoutClass === "cv-query-result-col--wide") {
+    return 180;
+  }
+  return 96;
+}
+
+function getResultColumnMinWidth(columnKey: string) {
+  const layoutClass = getResultColumnLayoutClass(columnKey);
+  if (layoutClass === "cv-query-result-col--time") {
+    return 132;
+  }
+  if (layoutClass === "cv-query-result-col--level") {
+    return 64;
+  }
+  if (layoutClass === "cv-query-result-col--id") {
+    return 96;
+  }
+  if (layoutClass === "cv-query-result-col--message") {
+    return 220;
+  }
+  if (layoutClass === "cv-query-result-col--wide") {
+    return 160;
+  }
+  if (normalizeResultColumnKey(columnKey) === CONTAINER_NAME_RESULT_COLUMN_KEY) {
+    return 176;
+  }
+  return 104;
+}
+
+function getResultColumnMaxWidth(columnKey: string) {
+  const layoutClass = getResultColumnLayoutClass(columnKey);
+  if (layoutClass === "cv-query-result-col--message" || layoutClass === "cv-query-result-col--wide") {
+    return 720;
+  }
+  return 520;
+}
+
+function getDefaultResultColumnWidth(columnKey: string) {
+  const layoutClass = getResultColumnLayoutClass(columnKey);
+  if (layoutClass === "cv-query-result-col--time") {
+    return 152;
+  }
+  if (layoutClass === "cv-query-result-col--level") {
+    return 78;
+  }
+  if (layoutClass === "cv-query-result-col--id") {
+    return 136;
+  }
+  if (layoutClass === "cv-query-result-col--message") {
+    return 360;
+  }
+  if (normalizeResultColumnKey(columnKey) === CONTAINER_NAME_RESULT_COLUMN_KEY) {
+    return 180;
+  }
+  if (columnKey === "error") {
+    return 196;
+  }
+  if (layoutClass === "cv-query-result-col--wide") {
+    return 220;
+  }
+  return 156;
+}
+
+function clampResultColumnWidth(columnKey: string, width: number) {
+  if (!Number.isFinite(width)) {
+    return getDefaultResultColumnWidth(columnKey);
+  }
+  return Math.round(Math.max(getResultColumnMinWidth(columnKey), Math.min(getResultColumnMaxWidth(columnKey), width)));
+}
+
+function getResultColumnWidth(columnKey: string, widths?: Record<string, number>) {
+  const customWidth = widths?.[columnKey];
+  if (customWidth !== undefined) {
+    return clampResultColumnWidth(columnKey, customWidth);
+  }
+  return getDefaultResultColumnWidth(columnKey);
+}
+
 function writeResultColumnKeys(storageKey: string, columnKeys: string[]) {
   if (typeof window === "undefined") {
     return;
   }
-  window.localStorage.setItem(storageKey, JSON.stringify(columnKeys));
+  window.localStorage.setItem(
+    storageKey,
+    JSON.stringify({
+      version: RESULT_COLUMN_STORAGE_VERSION,
+      keys: columnKeys
+    })
+  );
+}
+
+function readResultColumnWidths(storageKey: string) {
+  if (typeof window === "undefined") {
+    return {};
+  }
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    const parsed = raw ? (JSON.parse(raw) as unknown) : null;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return Object.entries(parsed as Record<string, unknown>).reduce<Record<string, number>>((result, [key, value]) => {
+      const normalizedKey = normalizeResultColumnKey(key);
+      const width = Number(value);
+      if (normalizedKey && Number.isFinite(width)) {
+        result[normalizedKey] = width;
+      }
+      return result;
+    }, {});
+  } catch {
+    return {};
+  }
+}
+
+function writeResultColumnWidths(storageKey: string, widths: Record<string, number>) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  const normalized = Object.entries(widths).reduce<Record<string, number>>((result, [key, value]) => {
+    const normalizedKey = normalizeResultColumnKey(key);
+    const width = Number(value);
+    if (normalizedKey && Number.isFinite(width)) {
+      result[normalizedKey] = width;
+    }
+    return result;
+  }, {});
+  if (Object.keys(normalized).length === 0) {
+    window.localStorage.removeItem(storageKey);
+    return;
+  }
+  window.localStorage.setItem(storageKey, JSON.stringify(normalized));
 }
 
 function readOpenLogTabs(storageKey: string): Array<Pick<OpenLogTab, "databaseName" | "tableName">> {
@@ -1067,7 +2994,7 @@ function writeOpenLogTabs(storageKey: string, tabs: OpenLogTab[]) {
 function createConditionDraft(): QueryFilterCondition {
   return {
     id: `cond_modal_${Date.now()}_${Math.random().toString(16).slice(2)}`,
-    field: "全局匹配",
+    field: GLOBAL_MATCH_FIELD,
     operator: "like",
     value: "",
     valueType: "string"
@@ -1085,11 +3012,29 @@ const queryOperatorOptions = [
   { label: "not like", value: "not like" }
 ] as const;
 
-const queryValueTypeOptions = [
-  { label: "字符串", value: "string" },
-  { label: "数字", value: "number" },
-  { label: "时间", value: "datetime" }
+const EMPTY_QUERY_PREVIEW = "No filters";
+const INVALID_QUERY_PREVIEW_PREFIX = "Invalid filter";
+const linkQueryWindowOptions = [
+  { label: "±1 minute", value: "1" },
+  { label: "±5 minutes", value: "5" },
+  { label: "±15 minutes", value: "15" },
+  { label: "±30 minutes", value: "30" }
 ] as const;
+
+function getCompatibleOperatorOptions(field: string, valueType: QueryFilterValueType) {
+  if (isGlobalMatchField(field)) {
+    return queryOperatorOptions.filter((item) => item.value === "like" || item.value === "not like");
+  }
+  if (valueType === "string") {
+    return queryOperatorOptions;
+  }
+  return queryOperatorOptions.filter((item) => item.value !== "like" && item.value !== "not like");
+}
+
+function normalizeConditionOperator(field: string, operator: QueryFilterCondition["operator"], valueType: QueryFilterValueType) {
+  const operatorOptions = getCompatibleOperatorOptions(field, valueType);
+  return operatorOptions.some((item) => item.value === operator) ? operator : operatorOptions[0].value;
+}
 
 function TraceSpanRow({
   node,
@@ -1153,7 +3098,7 @@ function TraceSpanRow({
             <span>{node.raw.spanId}</span>
           </div>
           <div>
-            <strong>开始</strong>
+            <strong>Start</strong>
             <span>{node.raw.startTime ? formatClientDateTime(node.raw.startTime) : "—"}</span>
           </div>
           {tags.length > 0 ? (
@@ -1212,13 +3157,13 @@ function TraceTimeline({ groups }: { groups: TraceGroup[] }) {
     return null;
   }
   return (
-    <section className="cv-query-trace-panel" aria-label="Trace 链路">
+    <section className="cv-query-trace-panel" aria-label="Trace links">
       <div className="cv-query-trace-panel__header">
         <div>
-          <strong>Trace 链路</strong>
-          <span>按 `_key` / traceId 分组，使用 Jaeger JSON 渲染 span 树</span>
+          <strong>Trace links</strong>
+          <span>Grouped by `_key` / traceId and rendered from Jaeger JSON</span>
         </div>
-        <span>{groups.length} 条链路</span>
+        <span>{groups.length} {groups.length === 1 ? "trace" : "traces"}</span>
       </div>
       <div className="cv-query-trace-groups">
         {groups.map((group) => (
@@ -1285,6 +3230,10 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
   const initialPage = useMemo(() => readPositiveIntSearchParam(initialSearchParams, "page"), [initialSearchParams]);
   const initialPageSize = useMemo(() => readPositiveIntSearchParam(initialSearchParams, "size"), [initialSearchParams]);
   const [timeRange, setTimeRange] = useState<QueryDateRange>(defaultRange);
+  const [absolutePickerRange, setAbsolutePickerRange] = useState<QueryAbsolutePickerRange>(() =>
+    buildInitialAbsolutePickerRange(initialSearchParams, defaultRange)
+  );
+  const [timeRangeHistory, setTimeRangeHistory] = useState<Array<[Date, Date]>>([]);
   const startTime = timeRange ? formatDateTimeLocalValue(timeRange[0]) : "";
   const endTime = timeRange ? formatDateTimeLocalValue(timeRange[1]) : "";
   const workspace = useQueryWorkspace(startTime, endTime, initialTreeTarget, {
@@ -1293,36 +3242,51 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
   });
   const [feedbackMessage, setFeedbackMessage] = useState("");
   const [shareLoading, setShareLoading] = useState(false);
-  const [resultColumnSelectorOpen, setResultColumnSelectorOpen] = useState(false);
+  const [fieldCatalogOpen, setFieldCatalogOpen] = useState(false);
+  const [fieldCatalogSearch, setFieldCatalogSearch] = useState("");
+  const [activeFieldCatalogGroupKey, setActiveFieldCatalogGroupKey] = useState<QueryFieldCatalogGroupKey>("log");
   const [resultColumnKeys, setResultColumnKeys] = useState<string[]>([...DEFAULT_RESULT_COLUMN_KEYS]);
-  const [expandedLogIndex, setExpandedLogIndex] = useState<number | null>(null);
+  const [resultColumnWidths, setResultColumnWidths] = useState<Record<string, number>>({});
+  const [resultColumnMenuKey, setResultColumnMenuKey] = useState<string | null>(null);
+  const [draggedResultColumnKey, setDraggedResultColumnKey] = useState<string | null>(null);
+  const [resultColumnDropTargetKey, setResultColumnDropTargetKey] = useState<string | null>(null);
+  const [activeResultColumnResize, setActiveResultColumnResize] = useState<{
+    key: string;
+    startX: number;
+    startWidth: number;
+  } | null>(null);
+  const [expandedLogIndexes, setExpandedLogIndexes] = useState<Set<number>>(() => new Set());
   const [expandedLogDisplayMode, setExpandedLogDisplayMode] = useState<"fields" | "json">("fields");
+  const [expandedLogNestedKeys, setExpandedLogNestedKeys] = useState<Set<string>>(() => new Set());
+  const [expandedLogMetadataIndexes, setExpandedLogMetadataIndexes] = useState<Set<number>>(() => new Set());
+  const [resultBulkExpandLoading, setResultBulkExpandLoading] = useState(false);
   const [conditionModalOpen, setConditionModalOpen] = useState(false);
   const [conditionModalMode, setConditionModalMode] = useState<QueryConditionModalMode>("create");
   const [conditionDraft, setConditionDraft] = useState<QueryFilterCondition | null>(null);
+  const [inlineConditionDraft, setInlineConditionDraft] = useState<QueryFilterCondition>(() => createConditionDraft());
   const [fieldPickerOpen, setFieldPickerOpen] = useState(false);
   const [saveQueryModalOpen, setSaveQueryModalOpen] = useState(false);
   const [saveQueryName, setSaveQueryName] = useState("");
   const [savedQueryMenuOpen, setSavedQueryMenuOpen] = useState(false);
+  const [savedQuerySearch, setSavedQuerySearch] = useState("");
   const [queryHistoryMenuOpen, setQueryHistoryMenuOpen] = useState(false);
+  const [queryHistorySearch, setQueryHistorySearch] = useState("");
+  const [queryPreviewOpen, setQueryPreviewOpen] = useState(false);
+  const [sourcePickerOpen, setSourcePickerOpen] = useState(false);
+  const [sourceSearch, setSourceSearch] = useState("");
+  const [queryInputFocused, setQueryInputFocused] = useState(false);
+  const [filterComposerOpen, setFilterComposerOpen] = useState(false);
+  const [inlineFieldPickerOpen, setInlineFieldPickerOpen] = useState(false);
+  const [inlineFieldPickerActiveIndex, setInlineFieldPickerActiveIndex] = useState(0);
   const [linkQueryAnchor, setLinkQueryAnchor] = useState<LinkQueryAnchor | null>(null);
   const [linkQueryWindowMinutes, setLinkQueryWindowMinutes] = useState(5);
   const [linkQuerySelectedTableIds, setLinkQuerySelectedTableIds] = useState<number[]>([]);
   const [tableAutoQueryRequest, setTableAutoQueryRequest] = useState<TableAutoQueryRequest | null>(null);
   const [openLogTabs, setOpenLogTabs] = useState<OpenLogTab[]>([]);
   const [conditionsByLogTab, setConditionsByLogTab] = useState<Record<number, QueryFilterCondition[]>>({});
-  const [fieldStatsState, setFieldStatsState] = useState<{
-    field: string;
-    fieldRef: QueryFieldRef;
-    loading: boolean;
-    data: QueryFieldStatsResponse | null;
-    error: string;
-  } | null>(null);
-  const [fieldStatsConfirmState, setFieldStatsConfirmState] = useState<{
-    fieldRef: QueryFieldRef;
-    value: string;
-    actionText: string;
-  } | null>(null);
+  const [fieldStatsState, setFieldStatsState] = useState<QueryFieldStatsState | null>(null);
+  const [inlineFieldStatsByKey, setInlineFieldStatsByKey] = useState<Record<string, QueryFieldStatsState>>({});
+  const [expandedInlineFieldStatsKeys, setExpandedInlineFieldStatsKeys] = useState<Set<string>>(() => new Set());
   const [createDatabaseInstance, setCreateDatabaseInstance] = useState<QuerySourceInstance | null>(null);
   const [accessLogLibraryState, setAccessLogLibraryState] = useState<{
     instance: QuerySourceInstance | null;
@@ -1343,7 +3307,7 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
     x: number;
     y: number;
   }>({
-    ariaLabel: "节点操作",
+    ariaLabel: "Node actions",
     items: [],
     x: 0,
     y: 0
@@ -1361,17 +3325,324 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
   const conditionRestoreTargetRef = useRef<number | null>(null);
   const openLogTabsRestoredRef = useRef(false);
   const openLogTabsHydratingRef = useRef(false);
+  const resultStackRef = useRef<HTMLDivElement | null>(null);
+  const resultTableHeaderScrollRef = useRef<HTMLDivElement | null>(null);
+  const resultTableScrollRef = useRef<HTMLDivElement | null>(null);
+  const queryUtilityActionsRef = useRef<HTMLDivElement | null>(null);
+  const fieldCatalogRef = useRef<HTMLDivElement | null>(null);
+  const fieldStatsPanelRef = useRef<HTMLElement | null>(null);
+  const fieldStatsAbortControllerRef = useRef<AbortController | null>(null);
+  const inlineFieldStatsAbortControllersRef = useRef<Map<string, AbortController>>(new Map());
+  const resultBulkExpandTimerRef = useRef<number | null>(null);
+  const resultBulkExpandFinishTimerRef = useRef<number | null>(null);
+  const linkQueryPanelRef = useRef<HTMLElement | null>(null);
+  const fieldCatalogSearchInputRef = useRef<HTMLInputElement | null>(null);
+  const inlineConditionValueInputRef = useRef<HTMLInputElement | null>(null);
+  const conditionModalBackdropPressedRef = useRef(false);
+  const filterComposerRef = useRef<HTMLDivElement | null>(null);
+  const queryHistorySearchInputRef = useRef<HTMLInputElement | null>(null);
+  const savedQuerySearchInputRef = useRef<HTMLInputElement | null>(null);
+  const sourceSearchInputRef = useRef<HTMLInputElement | null>(null);
+  const sourcePickerRef = useRef<HTMLDivElement | null>(null);
+  const inlineFieldPickerRef = useRef<HTMLLabelElement | null>(null);
+  const histogramSelectionOverlayRef = useRef<HTMLDivElement | null>(null);
+  const histogramSelectionRef = useRef<HistogramSelection | null>(null);
+  const [histogramSelection, setHistogramSelection] = useState<HistogramSelection | null>(null);
+  const [histogramCollapsed, setHistogramCollapsed] = useState(false);
+  const [histogramInterval, setHistogramInterval] = useState<HistogramIntervalValue>("auto");
 
-  const chartMax = useMemo(
-    () => workspace.charts.reduce((max, item) => Math.max(max, item.count), 0) || 1,
-    [workspace.charts]
-  );
-  const chartAxisMax = useMemo(() => roundUpChartAxisMax(chartMax), [chartMax]);
+  useEffect(() => {
+    document.documentElement.classList.add(QUERY_OVERSCROLL_GUARD_CLASS);
+    document.body.classList.add(QUERY_OVERSCROLL_GUARD_CLASS);
+
+    function handleDocumentWheel(event: globalThis.WheelEvent) {
+      if (shouldGuardHorizontalWheel(event)) {
+        event.preventDefault();
+      }
+    }
+
+    document.addEventListener("wheel", handleDocumentWheel, { capture: true, passive: false });
+    return () => {
+      document.removeEventListener("wheel", handleDocumentWheel, { capture: true });
+      document.documentElement.classList.remove(QUERY_OVERSCROLL_GUARD_CLASS);
+      document.body.classList.remove(QUERY_OVERSCROLL_GUARD_CLASS);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (
+      !queryHistoryMenuOpen &&
+      !savedQueryMenuOpen &&
+      !fieldCatalogOpen &&
+      !sourcePickerOpen &&
+      !filterComposerOpen &&
+      !inlineFieldPickerOpen &&
+      !fieldStatsState &&
+      !linkQueryAnchor
+    ) {
+      return;
+    }
+
+    function handleDocumentPointerDown(event: PointerEvent) {
+      const target = event.target as Node | null;
+      if (
+        (queryHistoryMenuOpen || savedQueryMenuOpen) &&
+        target instanceof Element &&
+        !queryUtilityActionsRef.current?.contains(target) &&
+        !target.closest(".cv-query-saved__popover-panel")
+      ) {
+        setQueryHistoryMenuOpen(false);
+        setSavedQueryMenuOpen(false);
+      }
+      if (
+        fieldCatalogOpen &&
+        target instanceof Element &&
+        !fieldCatalogRef.current?.contains(target) &&
+        !target.closest(".cv-query-fields-panel__popover-panel")
+      ) {
+        closeFieldCatalogPanel();
+      }
+      if (
+        sourcePickerOpen &&
+        target instanceof Element &&
+        !sourcePickerRef.current?.contains(target) &&
+        !target.closest(".cv-query-source-popover-panel") &&
+        !target.closest(".cv-context-menu")
+      ) {
+        setSourcePickerOpen(false);
+        closeInstanceContextMenu();
+      }
+      if (inlineFieldPickerOpen && target instanceof Element && !inlineFieldPickerRef.current?.contains(target)) {
+        setInlineFieldPickerOpen(false);
+      }
+      if (
+        filterComposerOpen &&
+        target instanceof Element &&
+        !filterComposerRef.current?.contains(target) &&
+        !target.closest(".cv-query-filter-composer-popover-panel") &&
+        !target.closest(".cv-query-compact-select__panel")
+      ) {
+        cancelInlineCondition();
+      }
+      if (fieldStatsState && target instanceof Element && !fieldStatsPanelRef.current?.contains(target)) {
+        closeFieldStatsModal();
+      }
+      if (linkQueryAnchor && target instanceof Element && !linkQueryPanelRef.current?.contains(target)) {
+        closeLinkQueryModal();
+      }
+    }
+
+    function handleDocumentKeyDown(event: globalThis.KeyboardEvent) {
+      if (event.key !== "Escape") {
+        return;
+      }
+      setQueryHistoryMenuOpen(false);
+      setSavedQueryMenuOpen(false);
+      closeFieldCatalogPanel();
+      setSourcePickerOpen(false);
+      if (filterComposerOpen) {
+        cancelInlineCondition();
+      }
+      closeFieldStatsModal();
+      closeLinkQueryModal();
+      closeInstanceContextMenu();
+    }
+
+    document.addEventListener("pointerdown", handleDocumentPointerDown, true);
+    document.addEventListener("keydown", handleDocumentKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handleDocumentPointerDown, true);
+      document.removeEventListener("keydown", handleDocumentKeyDown);
+    };
+  }, [
+    fieldStatsState,
+    fieldCatalogOpen,
+    filterComposerOpen,
+    inlineFieldPickerOpen,
+    linkQueryAnchor,
+    queryHistoryMenuOpen,
+    savedQueryMenuOpen,
+    sourcePickerOpen
+  ]);
+
+  useEffect(() => {
+    if (!filterComposerOpen) {
+      return;
+    }
+    const focusTimer = window.setTimeout(() => {
+      inlineConditionValueInputRef.current?.focus();
+    }, 0);
+    return () => window.clearTimeout(focusTimer);
+  }, [filterComposerOpen]);
 
   const normalizedLogRows = useMemo(
     () => (workspace.logs?.logs ?? []).map((row) => normalizeLogRow(row)),
     [workspace.logs]
   );
+  const rawHistogramChartData = useMemo<HistogramChartDatum[]>(
+    () =>
+      workspace.charts.map((item) => ({
+        x: item.from * 1000,
+        count: item.count,
+        from: item.from,
+        to: item.to
+      })),
+    [workspace.charts]
+  );
+  const rawHistogramBucketIntervalMs = useMemo(
+    () => getHistogramBucketIntervalMs(rawHistogramChartData),
+    [rawHistogramChartData]
+  );
+  const autoHistogramIntervalMs = useMemo(
+    () => getAutoHistogramIntervalMs(rawHistogramChartData, rawHistogramBucketIntervalMs, timeRange),
+    [rawHistogramBucketIntervalMs, rawHistogramChartData, timeRange]
+  );
+  const autoHistogramBucketSizeLabel = useMemo(
+    () => formatHistogramBucketSizeLabel(autoHistogramIntervalMs),
+    [autoHistogramIntervalMs]
+  );
+  const availableHistogramIntervalOptions = useMemo(() => {
+    if (rawHistogramBucketIntervalMs <= 0) {
+      return HISTOGRAM_INTERVAL_OPTIONS;
+    }
+    return HISTOGRAM_INTERVAL_OPTIONS.filter(
+      (option) => !option.milliseconds || option.milliseconds >= rawHistogramBucketIntervalMs
+    );
+  }, [rawHistogramBucketIntervalMs]);
+  useEffect(() => {
+    if (availableHistogramIntervalOptions.some((option) => option.value === histogramInterval)) {
+      return;
+    }
+    setHistogramInterval("auto");
+    clearHistogramSelection();
+  }, [availableHistogramIntervalOptions, histogramInterval]);
+  const selectedHistogramIntervalOption = useMemo(
+    () =>
+      HISTOGRAM_INTERVAL_OPTIONS.find((option) => option.value === histogramInterval) ??
+      HISTOGRAM_INTERVAL_OPTIONS[0],
+    [histogramInterval]
+  );
+  const effectiveHistogramIntervalMs =
+    histogramInterval === "auto"
+      ? autoHistogramIntervalMs
+      : selectedHistogramIntervalOption.milliseconds ?? rawHistogramBucketIntervalMs;
+  const loadedLogsHistogramChartData = useMemo(
+    () => buildLoadedLogsHistogramData(normalizedLogRows, timeRange, effectiveHistogramIntervalMs),
+    [effectiveHistogramIntervalMs, normalizedLogRows, timeRange]
+  );
+  const shouldUseLoadedLogsHistogram =
+    loadedLogsHistogramChartData.length > 0 &&
+    (rawHistogramChartData.length <= 1 || !rawHistogramChartData.some((item) => item.count > 0));
+  const baseHistogramChartData = shouldUseLoadedLogsHistogram
+    ? loadedLogsHistogramChartData
+    : rawHistogramChartData;
+  const histogramChartData = useMemo<HistogramChartDatum[]>(() => {
+    if (!effectiveHistogramIntervalMs || effectiveHistogramIntervalMs <= rawHistogramBucketIntervalMs) {
+      return baseHistogramChartData;
+    }
+    return aggregateHistogramData(baseHistogramChartData, effectiveHistogramIntervalMs, timeRange?.[0].getTime());
+  }, [baseHistogramChartData, effectiveHistogramIntervalMs, rawHistogramBucketIntervalMs, timeRange]);
+  const histogramBucketIntervalMs = useMemo(
+    () => getHistogramBucketIntervalMs(histogramChartData),
+    [histogramChartData]
+  );
+  const histogramBucketSizeLabel = useMemo(
+    () => formatHistogramBucketSizeLabel(histogramBucketIntervalMs),
+    [histogramBucketIntervalMs]
+  );
+  const histogramXDomain = useMemo(() => {
+    const first = histogramChartData[0];
+    const last = histogramChartData[histogramChartData.length - 1];
+    const rangeStartMs = timeRange?.[0].getTime();
+    const rangeEndMs = timeRange?.[1].getTime();
+    if (
+      typeof rangeStartMs === "number" &&
+      typeof rangeEndMs === "number" &&
+      Number.isFinite(rangeStartMs) &&
+      Number.isFinite(rangeEndMs) &&
+      rangeEndMs > rangeStartMs
+    ) {
+      return {
+        min: Number(rangeStartMs),
+        max: Number(rangeEndMs),
+        minInterval: histogramBucketIntervalMs || undefined
+      };
+    }
+    if (!first || !last) {
+      return undefined;
+    }
+    return {
+      min: first.from * 1000,
+      max: last.to * 1000,
+      minInterval: histogramBucketIntervalMs || undefined
+    };
+  }, [histogramBucketIntervalMs, histogramChartData, timeRange]);
+  const chartSpanSeconds = useMemo(() => {
+    if (timeRange) {
+      return Math.max(0, Math.round((timeRange[1].getTime() - timeRange[0].getTime()) / 1000));
+    }
+    const first = histogramChartData[0];
+    const last = histogramChartData[histogramChartData.length - 1];
+    return first && last ? Math.max(0, last.to - first.from) : 0;
+  }, [histogramChartData, timeRange]);
+  const chartTotalCount = useMemo(
+    () => histogramChartData.reduce((total, item) => total + item.count, 0),
+    [histogramChartData]
+  );
+  const histogramSelectionRange = useMemo(() => {
+    if (!histogramSelection || histogramChartData.length === 0) {
+      return null;
+    }
+    const startIndex = Math.max(0, Math.min(histogramSelection.anchorIndex, histogramSelection.hoverIndex));
+    const endIndex = Math.min(
+      histogramChartData.length - 1,
+      Math.max(histogramSelection.anchorIndex, histogramSelection.hoverIndex)
+    );
+    const startBucket = histogramChartData[startIndex];
+    const endBucket = histogramChartData[endIndex];
+    if (!startBucket || !endBucket) {
+      return null;
+    }
+    return {
+      startIndex,
+      endIndex,
+      from: startBucket.from,
+      to: endBucket.to,
+      count: histogramChartData
+        .slice(startIndex, endIndex + 1)
+        .reduce((total, item) => total + item.count, 0)
+    };
+  }, [histogramChartData, histogramSelection]);
+  const histogramSelectionOverlayStyle = useMemo(() => {
+    if (!histogramSelectionRange || !histogramXDomain || histogramXDomain.max <= histogramXDomain.min) {
+      return undefined;
+    }
+    const domainMin = histogramXDomain.min;
+    const domainSpan = histogramXDomain.max - histogramXDomain.min;
+    const startPercent = clampHistogramSelectionPercent(
+      ((histogramSelectionRange.from * 1000 - domainMin) / domainSpan) * 100
+    );
+    const endPercent = clampHistogramSelectionPercent(
+      ((histogramSelectionRange.to * 1000 - domainMin) / domainSpan) * 100
+    );
+    const left = Math.min(startPercent, endPercent);
+    const right = Math.max(startPercent, endPercent);
+    return {
+      left: `${left}%`,
+      width: `${Math.max(0.5, right - left)}%`
+    };
+  }, [histogramSelectionRange, histogramXDomain]);
+  const histogramChartKey = histogramSelectionRange
+    ? `selected:${histogramInterval}:${histogramSelectionRange.from}:${histogramSelectionRange.to}`
+    : `idle:${histogramInterval}:${histogramXDomain?.min ?? "none"}:${histogramXDomain?.max ?? "none"}:${histogramChartData.length}`;
+
+  useEffect(() => {
+    if (!histogramSelectionRange) {
+      return;
+    }
+    histogramSelectionOverlayRef.current?.focus({ preventScroll: true });
+  }, [histogramSelectionRange]);
+
   const traceGroups = useMemo(
     () => buildTraceGroups(workspace.logs?.logs ?? [], workspace.logs?.isTrace),
     [workspace.logs]
@@ -1395,8 +3666,26 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
   }, []);
 
   useEffect(() => {
-    setExpandedLogIndex(null);
+    setExpandedLogIndexes(new Set());
     setExpandedLogDisplayMode("fields");
+    setExpandedLogNestedKeys(new Set());
+    setExpandedLogMetadataIndexes(new Set());
+    clearResultBulkExpandTimers();
+    setResultBulkExpandLoading(false);
+    clearInlineFieldStats();
+  }, [workspace.logs]);
+
+  useEffect(() => () => clearResultBulkExpandTimers(), []);
+  useEffect(() => () => {
+    abortFieldStatsRequest();
+    abortAllInlineFieldStatsRequests();
+  }, []);
+
+  useEffect(() => {
+    if (!workspace.logs) {
+      return;
+    }
+    resetResultTableHorizontalScroll();
   }, [workspace.logs]);
 
   useEffect(() => {
@@ -1418,22 +3707,32 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
   ]);
 
   useEffect(() => {
+    writeResultPaginationToURL(workspace.page, workspace.pageSize);
+  }, [workspace.page, workspace.pageSize]);
+
+  useEffect(() => {
     if (initialQueryStartedRef.current || tableAutoQueryRequest || !workspace.selectedTableId) {
       return;
     }
     initialQueryStartedRef.current = true;
     const hasURLRange = Boolean(
       (initialSearchParams.get("start") && initialSearchParams.get("end")) ||
-        (initialSearchParams.get("st") && initialSearchParams.get("et"))
+        (initialSearchParams.get("st") && initialSearchParams.get("et")) ||
+        (initialSearchParams.get("startTime") && initialSearchParams.get("endTime"))
     );
-    const range = hasURLRange && timeRange ? timeRange : buildRecentMinutesTimeRange(15);
-    setTimeRange(range);
+    const range = hasURLRange && timeRange ? timeRange : buildEndingNowTimeRange(DEFAULT_TIME_RANGE_MINUTES);
+    applyTimeRange(range, buildAbsolutePickerRange(range));
     void workspace.runQuery(initialPage ?? 1, toSecondRange(range));
   }, [initialPage, initialSearchParams, tableAutoQueryRequest, timeRange, workspace.selectedTableId]);
 
   useEffect(() => {
     setLinkQueryAnchor(null);
   }, [workspace.selectedInstanceId]);
+
+  useEffect(() => {
+    setTimeRangeHistory([]);
+    clearHistogramSelection();
+  }, [workspace.selectedTableId]);
 
   useEffect(() => {
     setConditionsByLogTab({});
@@ -1523,6 +3822,50 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
   }, [feedbackMessage]);
 
   useEffect(() => {
+    if (!fieldCatalogOpen) {
+      setFieldCatalogSearch("");
+      return;
+    }
+    const focusTimer = window.setTimeout(() => {
+      fieldCatalogSearchInputRef.current?.focus();
+    }, 0);
+    return () => window.clearTimeout(focusTimer);
+  }, [fieldCatalogOpen]);
+
+  useEffect(() => {
+    if (!queryHistoryMenuOpen) {
+      setQueryHistorySearch("");
+      return;
+    }
+    const focusTimer = window.setTimeout(() => {
+      queryHistorySearchInputRef.current?.focus();
+    }, 0);
+    return () => window.clearTimeout(focusTimer);
+  }, [queryHistoryMenuOpen]);
+
+  useEffect(() => {
+    if (!savedQueryMenuOpen) {
+      setSavedQuerySearch("");
+      return;
+    }
+    const focusTimer = window.setTimeout(() => {
+      savedQuerySearchInputRef.current?.focus();
+    }, 0);
+    return () => window.clearTimeout(focusTimer);
+  }, [savedQueryMenuOpen]);
+
+  useEffect(() => {
+    if (!sourcePickerOpen) {
+      setSourceSearch("");
+      return;
+    }
+    const focusTimer = window.setTimeout(() => {
+      sourceSearchInputRef.current?.focus();
+    }, 0);
+    return () => window.clearTimeout(focusTimer);
+  }, [sourcePickerOpen]);
+
+  useEffect(() => {
     if (!tableAutoQueryRequest) {
       return;
     }
@@ -1554,32 +3897,377 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
     ].join(":");
     return `${RESULT_COLUMN_STORAGE_PREFIX}:${userKey}:${scope}`;
   }, [workspace.selectedDatabase, workspace.selectedInstanceId, workspace.selectedTable]);
+  const resultColumnWidthStorageKey = `${resultColumnStorageKey}:widths`;
 
   useEffect(() => {
     setResultColumnKeys(readResultColumnKeys(resultColumnStorageKey));
   }, [resultColumnStorageKey]);
 
+  useEffect(() => {
+    setResultColumnWidths(readResultColumnWidths(resultColumnWidthStorageKey));
+  }, [resultColumnWidthStorageKey]);
+
   const resultColumnOptions = useMemo(() => {
     const fields = new Set<string>();
-    normalizedLogRows.forEach((row) => {
-      Object.keys(row.parsed).forEach((key) => fields.add(key));
+    DEFAULT_RESULT_COLUMN_KEYS.forEach((key) => {
+      if (!key.startsWith("__")) {
+        fields.add(key);
+      }
     });
+    workspace.suggestionFieldOptions.forEach((item) => {
+      if (!isGlobalMatchField(item.field)) {
+        fields.add(normalizeResultColumnOptionField(item.field));
+      }
+    });
+    normalizedLogRows.forEach((row) => {
+      Object.keys(row.parsed).forEach((key) => fields.add(normalizeResultColumnOptionField(key)));
+    });
+    const levelColumnLabel =
+      LOG_LEVEL_FIELD_KEYS.find((field) => fields.has(normalizeResultColumnOptionField(field))) ??
+      LOG_LEVEL_FIELD_KEYS.find((field) => normalizedLogRows.some((row) => isPresentLogValue(row.parsed[field]))) ??
+      "level";
     const builtinColumns: QueryResultColumn[] = [
-      { key: "__time", label: "时间", kind: "builtin" },
-      { key: "__level", label: "级别", kind: "builtin" },
-      { key: "__message", label: "内容", kind: "builtin" }
+      { key: "__time", label: "time", kind: "builtin" },
+      { key: "__level", label: levelColumnLabel, kind: "builtin" },
+      { key: "__message", label: "msg", kind: "builtin" }
     ];
     const fieldColumns = Array.from(fields)
-      .sort((left, right) => left.localeCompare(right))
+      .filter((field) => !isBuiltinResultFieldAlias(field))
+      .sort(compareResultFieldColumns)
       .map((field) => ({ key: field, label: field, kind: "field" as const }));
     return [...builtinColumns, ...fieldColumns];
-  }, [normalizedLogRows]);
+  }, [normalizedLogRows, workspace.suggestionFieldOptions]);
 
   const visibleResultColumns = useMemo(() => {
     const optionMap = new Map(resultColumnOptions.map((item) => [item.key, item]));
     const columns = resultColumnKeys.map((key) => optionMap.get(key)).filter(Boolean) as QueryResultColumn[];
     return columns.length > 0 ? columns : resultColumnOptions.slice(0, 3);
   }, [resultColumnKeys, resultColumnOptions]);
+  const resultTableMinWidth = useMemo(
+    () =>
+      RESULT_TABLE_TOGGLE_COLUMN_WIDTH +
+      visibleResultColumns.reduce((total, column) => total + getResultColumnWidth(column.key, resultColumnWidths), 0),
+    [resultColumnWidths, visibleResultColumns]
+  );
+
+  useEffect(() => {
+    const headerScroll = resultTableHeaderScrollRef.current;
+    const bodyScroll = resultTableScrollRef.current;
+    if (!headerScroll || !bodyScroll) {
+      return;
+    }
+    headerScroll.scrollLeft = bodyScroll.scrollLeft;
+  }, [resultTableMinWidth]);
+
+  useEffect(() => {
+    if (!activeResultColumnResize) {
+      return;
+    }
+
+    function handleMouseMove(event: globalThis.MouseEvent) {
+      event.preventDefault();
+      if (!activeResultColumnResize) {
+        return;
+      }
+      updateResultColumnWidth(
+        activeResultColumnResize.key,
+        activeResultColumnResize.startWidth + event.clientX - activeResultColumnResize.startX
+      );
+    }
+
+    function handleMouseUp() {
+      setActiveResultColumnResize(null);
+    }
+
+    document.body.classList.add("cv-query-resizing-column");
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+    return () => {
+      document.body.classList.remove("cv-query-resizing-column");
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [activeResultColumnResize, resultColumnWidthStorageKey]);
+
+  const fieldCatalogGroups = useMemo<QueryFieldCatalogGroup[]>(() => {
+    const search = fieldCatalogSearch.trim().toLowerCase();
+    const visibleColumnKeys = new Set(visibleResultColumns.map((item) => item.key));
+    const columnOptionsByKey = new Map(resultColumnOptions.map((item) => [item.key, item]));
+    const findSampleValue = (field: string) => {
+      for (const row of normalizedLogRows) {
+        const value = row.parsed[field];
+        if (isPresentLogValue(value)) {
+          return value;
+        }
+      }
+      return "";
+    };
+    const buildItem = (
+      field: string,
+      group: QueryFieldCatalogGroupKey,
+      valueType: QueryFilterValueType,
+      sampleValue: unknown = "",
+      seen: Set<string>
+    ): QueryFieldCatalogItem | null => {
+      const normalizedField = normalizeResultColumnOptionField(field);
+      const key = normalizeFieldCatalogKey(normalizedField);
+      if (!normalizedField || seen.has(key) || isGlobalMatchField(normalizedField)) {
+        return null;
+      }
+      seen.add(key);
+      const sample = isPresentLogValue(sampleValue) ? sampleValue : findSampleValue(normalizedField);
+      const fieldRef = buildQueryFieldRef(
+        {
+          id: `field_catalog_${group}_${key}`,
+          field: normalizedField,
+          operator: "=",
+          value: "",
+          valueType
+        },
+        workspace.analysisFields
+      );
+      const columnOption = columnOptionsByKey.get(normalizedField);
+      const label = columnOption?.label ?? normalizedField;
+      return {
+        key: `${group}:${normalizedField}`,
+        field: normalizedField,
+        label,
+        group,
+        columnKey: columnOption?.key ?? normalizedField,
+        valueType,
+        sampleValue: sample,
+        fieldRef,
+        canToggleColumn: Boolean(columnOption?.kind === "field"),
+        isColumnVisible: visibleColumnKeys.has(columnOption?.key ?? normalizedField),
+        canShowTopValues: canShowFieldStatsForField(normalizedField) && !(sample && typeof sample === "object")
+      };
+    };
+    const buildStorageItems = (fields: QueryStorageAnalysisField[], group: QueryFieldCatalogGroupKey) => {
+      const seen = new Set<string>();
+      return fields
+        .map((item) => buildItem(getStorageAnalysisFieldName(item), group, getStorageAnalysisValueType(item), "", seen))
+        .filter((item): item is QueryFieldCatalogItem => Boolean(item));
+    };
+    const baseItems = buildStorageItems(workspace.analysisFields.baseFields, "base");
+    const logItems = buildStorageItems(workspace.analysisFields.logFields, "log");
+    const parsedFields = Array.from(
+      normalizedLogRows.reduce<Set<string>>((acc, row) => {
+        Object.entries(row.parsed).forEach(([field, value]) => {
+          if (
+            isPresentLogValue(value) &&
+            !isLogTimeField(field) &&
+            !isBuiltinResultFieldAlias(field) &&
+            !field.startsWith("__")
+          ) {
+            acc.add(normalizeResultColumnOptionField(field));
+          }
+        });
+        return acc;
+      }, new Set<string>())
+    ).sort(compareResultFieldColumns);
+    const allFieldMetadata = new Map<string, { field: string; valueType: QueryFilterValueType; sampleValue: unknown }>();
+    const addAllField = (field: string, valueType: QueryFilterValueType, sampleValue: unknown = "") => {
+      const normalizedField = normalizeResultColumnOptionField(field);
+      const key = normalizeFieldCatalogKey(normalizedField);
+      if (!normalizedField || allFieldMetadata.has(key) || isGlobalMatchField(normalizedField)) {
+        return;
+      }
+      allFieldMetadata.set(key, { field: normalizedField, valueType, sampleValue });
+    };
+    workspace.analysisFields.logFields.forEach((item) => {
+      addAllField(getStorageAnalysisFieldName(item), getStorageAnalysisValueType(item));
+    });
+    workspace.analysisFields.baseFields.forEach((item) => {
+      addAllField(getStorageAnalysisFieldName(item), getStorageAnalysisValueType(item));
+    });
+    parsedFields.forEach((field) => {
+      const sample = findSampleValue(field);
+      addAllField(field, createDetailConditionValue(sample).valueType, sample);
+    });
+    const allSeen = new Set<string>();
+    const allItems = Array.from(allFieldMetadata.values())
+      .sort((fieldA, fieldB) => compareResultFieldColumns(fieldA.field, fieldB.field))
+      .map((metadata) => {
+        const sample = isPresentLogValue(metadata.sampleValue) ? metadata.sampleValue : findSampleValue(metadata.field);
+        return buildItem(metadata.field, "all", metadata.valueType, sample, allSeen);
+      })
+      .filter((item): item is QueryFieldCatalogItem => Boolean(item));
+    const filterItems = (items: QueryFieldCatalogItem[]) =>
+      search
+        ? items.filter((item) =>
+            `${item.label} ${item.field} ${item.group} ${item.valueType}`.toLowerCase().includes(search)
+          )
+        : items;
+    return [
+      { key: "log", title: "Log Fields", items: filterItems(logItems) },
+      { key: "base", title: "Base Fields", items: filterItems(baseItems) },
+      { key: "all", title: "All Fields", items: filterItems(allItems) }
+    ];
+  }, [
+    fieldCatalogSearch,
+    normalizedLogRows,
+    resultColumnOptions,
+    visibleResultColumns,
+    workspace.analysisFields
+  ]);
+  const visibleFieldCatalogCount = useMemo(
+    () => fieldCatalogGroups.find((group) => group.key === "all")?.items.length ?? 0,
+    [fieldCatalogGroups]
+  );
+  const activeFieldCatalogGroup =
+    fieldCatalogGroups.find((group) => group.key === activeFieldCatalogGroupKey) ?? fieldCatalogGroups[0];
+
+  useEffect(() => {
+    if (!fieldCatalogOpen) {
+      return;
+    }
+    const activeGroup = fieldCatalogGroups.find((group) => group.key === activeFieldCatalogGroupKey);
+    if ((activeGroup?.items.length ?? 0) > 0 || visibleFieldCatalogCount === 0) {
+      return;
+    }
+    const firstGroupWithItems = fieldCatalogGroups.find((group) => group.items.length > 0);
+    if (firstGroupWithItems) {
+      setActiveFieldCatalogGroupKey(firstGroupWithItems.key);
+    }
+  }, [activeFieldCatalogGroupKey, fieldCatalogGroups, fieldCatalogOpen, visibleFieldCatalogCount]);
+
+  useEffect(() => {
+    if (resultColumnMenuKey && !visibleResultColumns.some((column) => column.key === resultColumnMenuKey)) {
+      setResultColumnMenuKey(null);
+    }
+  }, [resultColumnMenuKey, visibleResultColumns]);
+
+  const queryPreview = useMemo(() => {
+    try {
+      return workspace.buildQueryText().trim() || EMPTY_QUERY_PREVIEW;
+    } catch (error) {
+      return `${INVALID_QUERY_PREVIEW_PREFIX}: ${error instanceof Error ? error.message : "Check filters"}`;
+    }
+  }, [workspace.queryText, workspace.conditions, workspace.analysisFields]);
+  const canShowQueryPreview = Boolean(workspace.queryText.trim() || workspace.conditions.length > 0);
+  const canUseQueryPreview =
+    queryPreview !== EMPTY_QUERY_PREVIEW && !queryPreview.startsWith(INVALID_QUERY_PREVIEW_PREFIX);
+
+  useEffect(() => {
+    if (!canShowQueryPreview && queryPreviewOpen) {
+      setQueryPreviewOpen(false);
+    }
+  }, [canShowQueryPreview, queryPreviewOpen]);
+
+  function applyTimeRange(range: [Date, Date], pickerRange?: QueryAbsolutePickerRange) {
+    setTimeRange(range);
+    setAbsolutePickerRange(pickerRange ?? buildAbsolutePickerRange(range));
+  }
+
+  function applyAbsolutePickerRange(pickerRange: QueryAbsolutePickerRange, dateRange: QueryDateRange) {
+    setAbsolutePickerRange(pickerRange);
+    setTimeRangeHistory([]);
+    clearHistogramSelection();
+    if (!dateRange) {
+      return;
+    }
+    setTimeRange(dateRange);
+    void workspace.runQuery(1, toSecondRange(dateRange));
+  }
+
+  function applyHistogramTimeRange(range: [Date, Date]) {
+    const previousRange = cloneDateRange(timeRange);
+    if (previousRange && !isSameSecondDateRange(previousRange, range)) {
+      setTimeRangeHistory((current) => [...current, previousRange].slice(-8));
+    }
+    applyTimeRange(range);
+    void workspace.runQuery(1, toSecondRange(range));
+  }
+
+  function restorePreviousHistogramTimeRange() {
+    const previousRange = timeRangeHistory[timeRangeHistory.length - 1];
+    if (!previousRange) {
+      return;
+    }
+    const nextRange = cloneDateRange(previousRange);
+    if (!nextRange) {
+      return;
+    }
+    setTimeRangeHistory((current) => current.slice(0, -1));
+    clearHistogramSelection();
+    applyTimeRange(nextRange, buildAbsolutePickerRange(nextRange));
+    void workspace.runQuery(1, toSecondRange(nextRange));
+  }
+
+  function setHistogramSelectionDraft(selection: HistogramSelection | null) {
+    histogramSelectionRef.current = selection;
+    setHistogramSelection(selection);
+  }
+
+  function clearHistogramSelection() {
+    histogramSelectionRef.current = null;
+    setHistogramSelection(null);
+  }
+
+  function changeHistogramInterval(value: HistogramIntervalValue) {
+    setHistogramInterval(value);
+    clearHistogramSelection();
+  }
+
+  function applyHistogramBucketRange(startIndex: number, endIndex: number) {
+    const normalizedStart = Math.max(0, Math.min(startIndex, endIndex));
+    const normalizedEnd = Math.min(histogramChartData.length - 1, Math.max(startIndex, endIndex));
+    const startBucket = histogramChartData[normalizedStart];
+    const endBucket = histogramChartData[normalizedEnd];
+    if (!startBucket || !endBucket || endBucket.to <= startBucket.from) {
+      return;
+    }
+    applyHistogramTimeRange([new Date(startBucket.from * 1000), new Date(endBucket.to * 1000)]);
+  }
+
+  function applyHistogramSelectionRange() {
+    if (!histogramSelectionRange) {
+      return;
+    }
+    const { startIndex, endIndex } = histogramSelectionRange;
+    clearHistogramSelection();
+    applyHistogramBucketRange(startIndex, endIndex);
+  }
+
+  function zoomOutHistogramTimeRange() {
+    const currentRange = cloneDateRange(timeRange);
+    if (!currentRange) {
+      return;
+    }
+    const startMs = currentRange[0].getTime();
+    const endMs = currentRange[1].getTime();
+    const spanMs = Math.max(60_000, endMs - startMs);
+    const nextRange: [Date, Date] = [
+      new Date(startMs - spanMs / 2),
+      new Date(endMs + spanMs / 2)
+    ];
+    clearHistogramSelection();
+    applyHistogramTimeRange(nextRange);
+  }
+
+  function selectHistogramBucket(index: number) {
+    if (!histogramChartData[index]) {
+      return;
+    }
+    setHistogramSelectionDraft({ anchorIndex: index, hoverIndex: index });
+  }
+
+  function handleHistogramBrushEnd(brushArea: { x?: [number, number] }) {
+    const nextSelection = findHistogramSelectionFromExtent(histogramChartData, brushArea.x);
+    if (!nextSelection) {
+      return;
+    }
+    setHistogramSelectionDraft(nextSelection);
+  }
+
+  function handleHistogramElementClick(elements: Array<[unknown]>) {
+    const datum = (elements[0]?.[0] as { datum?: HistogramChartDatum } | undefined)?.datum;
+    if (!datum) {
+      return;
+    }
+    const index = histogramChartData.findIndex((item) => item.from === datum.from && item.to === datum.to);
+    selectHistogramBucket(index);
+  }
 
   function parseProfileTime(value: string) {
     const date = new Date(value.includes("T") ? value : value.replace(" ", "T"));
@@ -1587,7 +4275,7 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
   }
 
   function openSaveQueryModal() {
-    setSaveQueryName(queryPreview && queryPreview !== "无条件" ? truncate(queryPreview, 32) : "");
+    setSaveQueryName(queryPreview && queryPreview !== EMPTY_QUERY_PREVIEW ? truncate(queryPreview, 32) : "");
     setSaveQueryModalOpen(true);
   }
 
@@ -1597,11 +4285,11 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
         startTime,
         endTime
       });
-      setFeedbackMessage("已保存到收藏查询");
+      setFeedbackMessage("Query saved");
       setSaveQueryModalOpen(false);
       setSavedQueryMenuOpen(true);
     } catch (error) {
-      setFeedbackMessage(error instanceof Error ? error.message : "保存查询失败");
+      setFeedbackMessage(error instanceof Error ? error.message : "Save query failed");
     }
   }
 
@@ -1610,19 +4298,54 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
     const end = parseProfileTime(profile.timeRange.endTime);
     const nextRange = start && end ? ([start, end] as [Date, Date]) : timeRange;
     if (nextRange) {
-      setTimeRange(nextRange);
+      applyTimeRange(nextRange);
     }
     workspace.applyFilterProfile(profile);
     setSavedQueryMenuOpen(false);
     void workspace.runQuery(1, nextRange ? toSecondRange(nextRange) : undefined, profile.conditions);
   }
 
+  function convertConditionsToManualSql() {
+    const nextQuery = queryPreview.trim();
+    if (!nextQuery || !canUseQueryPreview) {
+      return;
+    }
+    workspace.setQueryText(nextQuery);
+    workspace.setConditions([]);
+    workspace.setActiveConditionId(null);
+    setFilterComposerOpen(false);
+    setInlineFieldPickerOpen(false);
+    setFeedbackMessage("");
+  }
+
+  async function copyQueryPreview() {
+    if (!canUseQueryPreview) {
+      return;
+    }
+    const copied = await copyTextToClipboard(queryPreview);
+    setFeedbackMessage(copied ? "SQL copied" : "Copy SQL failed");
+  }
+
+  async function copyExpandedLog(row: NormalizedLogRow) {
+    const copied = await copyTextToClipboard(formatLogJsonPreview(row));
+    setFeedbackMessage(copied ? "Log copied" : "Copy log failed");
+  }
+
+  async function copyLogDetailValue(field: string, value: unknown) {
+    const text = formatLogDetailValue(value).trim();
+    if (!text || text === "—") {
+      return;
+    }
+    const copied = await copyTextToClipboard(text);
+    setFeedbackMessage(copied ? `${field} copied` : `Copy ${field} failed`);
+  }
+
   async function deleteSavedFilterProfile(id: number, name: string) {
     try {
       await workspace.deleteSavedFilterProfile(id);
-      setFeedbackMessage(`已删除收藏 ${name}`);
+      setFeedbackMessage(`Deleted saved query ${name}`);
     } catch (error) {
-      setFeedbackMessage(error instanceof Error ? error.message : "删除收藏失败");
+      setFeedbackMessage(error instanceof Error ? error.message : "Delete saved query failed");
     }
   }
 
@@ -1635,17 +4358,20 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
       const shareUrl = new URL(window.location.href);
       shareUrl.pathname = buildShareRouteHref(undefined, window.location.pathname);
       shareUrl.hash = "";
-      if (queryPreview && queryPreview !== "无条件" && !queryPreview.includes("不合法")) {
+      if (queryPreview && queryPreview !== EMPTY_QUERY_PREVIEW && !queryPreview.startsWith(INVALID_QUERY_PREVIEW_PREFIX)) {
         shareUrl.searchParams.set("query", queryPreview);
+        shareUrl.searchParams.set("kw", queryPreview);
       } else {
         shareUrl.searchParams.delete("query");
+        shareUrl.searchParams.delete("kw");
       }
-      if (startTime) {
-        shareUrl.searchParams.set("startTime", startTime);
+      if (timeRange) {
+        const { st, et } = toSecondRange(timeRange);
+        shareUrl.searchParams.set("start", String(st));
+        shareUrl.searchParams.set("end", String(et));
       }
-      if (endTime) {
-        shareUrl.searchParams.set("endTime", endTime);
-      }
+      shareUrl.searchParams.delete("startTime");
+      shareUrl.searchParams.delete("endTime");
       if (workspace.selectedTableId) {
         shareUrl.searchParams.set("tid", String(workspace.selectedTableId));
       }
@@ -1659,34 +4385,460 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
       }
       const shortUrl = await createQueryShareShortUrl({ originUrl: shareUrl.toString() });
       const copied = await copyTextToClipboard(shortUrl);
-      setFeedbackMessage(copied ? "分享短链已复制" : `分享短链已生成：${shortUrl}`);
+      setFeedbackMessage(copied ? "Share link copied" : `Share link created: ${shortUrl}`);
     } catch (error) {
-      setFeedbackMessage(error instanceof Error ? error.message : "分享失败，请稍后重试");
+      setFeedbackMessage(error instanceof Error ? error.message : "Share failed");
     } finally {
       setShareLoading(false);
     }
   }
 
   function updateResultColumnKeys(nextKeys: string[]) {
-    const uniqueKeys = Array.from(new Set(nextKeys));
+    const uniqueKeys = normalizeResultColumnKeys(nextKeys);
     const normalizedKeys = uniqueKeys.length > 0 ? uniqueKeys : [...DEFAULT_RESULT_COLUMN_KEYS];
     setResultColumnKeys(normalizedKeys);
     writeResultColumnKeys(resultColumnStorageKey, normalizedKeys);
   }
 
-  function toggleResultColumn(columnKey: string) {
-    const nextKeys = resultColumnKeys.includes(columnKey)
-      ? resultColumnKeys.filter((key) => key !== columnKey)
-      : [...resultColumnKeys, columnKey];
-    updateResultColumnKeys(nextKeys);
+  function toggleLogDetailColumn(columnKey: string, label = columnKey) {
+    const visibleKeys = visibleResultColumns.map((column) => column.key);
+    if (visibleKeys.includes(columnKey)) {
+      if (visibleKeys.length <= 1) {
+        setFeedbackMessage("Keep at least one column");
+        return;
+      }
+      updateResultColumnKeys(visibleKeys.filter((key) => key !== columnKey));
+      setFeedbackMessage("");
+      return;
+    }
+    updateResultColumnKeys([...visibleKeys, columnKey]);
+    setFeedbackMessage("");
+  }
+
+  function resetResultTableHorizontalScroll() {
+    resultTableScrollRef.current?.scrollTo?.({ left: 0 });
+    resultTableHeaderScrollRef.current?.scrollTo?.({ left: 0 });
+    if (resultTableScrollRef.current) {
+      resultTableScrollRef.current.scrollLeft = 0;
+    }
+    if (resultTableHeaderScrollRef.current) {
+      resultTableHeaderScrollRef.current.scrollLeft = 0;
+    }
   }
 
   function resetResultColumns() {
     updateResultColumnKeys([...DEFAULT_RESULT_COLUMN_KEYS]);
+    setResultColumnWidths({});
+    writeResultColumnWidths(resultColumnWidthStorageKey, {});
+  }
+
+  function hideResultColumn(columnKey: string) {
+    const currentKeys = visibleResultColumns.map((column) => column.key);
+    if (currentKeys.length <= 1) {
+      setFeedbackMessage("Keep at least one column");
+      return;
+    }
+    updateResultColumnKeys(currentKeys.filter((key) => key !== columnKey));
+  }
+
+  function moveResultColumn(sourceKey: string, targetKey: string) {
+    if (!sourceKey || sourceKey === targetKey) {
+      return;
+    }
+    const currentKeys = visibleResultColumns.map((column) => column.key);
+    const sourceIndex = currentKeys.indexOf(sourceKey);
+    const targetIndex = currentKeys.indexOf(targetKey);
+    if (sourceIndex < 0 || targetIndex < 0) {
+      return;
+    }
+    const nextKeys = [...currentKeys];
+    const [movedKey] = nextKeys.splice(sourceIndex, 1);
+    nextKeys.splice(targetIndex, 0, movedKey);
+    updateResultColumnKeys(nextKeys);
+  }
+
+  function moveResultColumnByOffset(columnKey: string, offset: -1 | 1) {
+    const currentKeys = visibleResultColumns.map((column) => column.key);
+    const currentIndex = currentKeys.indexOf(columnKey);
+    const targetKey = currentKeys[currentIndex + offset];
+    if (currentIndex < 0 || !targetKey) {
+      return;
+    }
+    moveResultColumn(columnKey, targetKey);
+    setResultColumnMenuKey(null);
+  }
+
+  function handleResultColumnDragStart(event: DragEvent<HTMLTableCellElement>, columnKey: string) {
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData("text/plain", columnKey);
+    setDraggedResultColumnKey(columnKey);
+  }
+
+  function handleResultColumnDragOver(event: DragEvent<HTMLTableCellElement>, columnKey: string) {
+    if (draggedResultColumnKey === columnKey) {
+      return;
+    }
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+    if (draggedResultColumnKey) {
+      setResultColumnDropTargetKey(columnKey);
+    }
+  }
+
+  function handleResultColumnDrop(event: DragEvent<HTMLTableCellElement>, columnKey: string) {
+    event.preventDefault();
+    const sourceKey = event.dataTransfer.getData("text/plain") || draggedResultColumnKey;
+    if (sourceKey) {
+      moveResultColumn(sourceKey, columnKey);
+    }
+    setDraggedResultColumnKey(null);
+    setResultColumnDropTargetKey(null);
+  }
+
+  function finishResultColumnDrag() {
+    setDraggedResultColumnKey(null);
+    setResultColumnDropTargetKey(null);
+  }
+
+  function updateResultColumnWidth(columnKey: string, width: number) {
+    const nextWidth = clampResultColumnWidth(columnKey, width);
+    setResultColumnWidths((current) => {
+      if (current[columnKey] === nextWidth) {
+        return current;
+      }
+      const next = {
+        ...current,
+        [columnKey]: nextWidth
+      };
+      writeResultColumnWidths(resultColumnWidthStorageKey, next);
+      return next;
+    });
+  }
+
+  function startResultColumnResize(event: MouseEvent<HTMLButtonElement>, columnKey: string) {
+    if (event.button !== 0) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    setResultColumnMenuKey(null);
+    finishResultColumnDrag();
+    setActiveResultColumnResize({
+      key: columnKey,
+      startX: event.clientX,
+      startWidth: getResultColumnWidth(columnKey, resultColumnWidths)
+    });
+  }
+
+  function handleResultColumnPointerDown(event: MouseEvent<HTMLTableCellElement>, columnKey: string) {
+    if (event.button !== 0) {
+      return;
+    }
+    setDraggedResultColumnKey(columnKey);
+    setResultColumnDropTargetKey(null);
+  }
+
+  function handleResultColumnPointerEnter(columnKey: string) {
+    if (!draggedResultColumnKey || draggedResultColumnKey === columnKey) {
+      return;
+    }
+    setResultColumnDropTargetKey(columnKey);
+  }
+
+  function handleResultColumnPointerUp(columnKey: string) {
+    if (draggedResultColumnKey && draggedResultColumnKey !== columnKey) {
+      moveResultColumn(draggedResultColumnKey, columnKey);
+    }
+    finishResultColumnDrag();
+  }
+
+  function changeResultPageSize(nextPageSize: number) {
+    if (nextPageSize === workspace.pageSize || workspace.loading) {
+      return;
+    }
+    workspace.setPageSize(nextPageSize);
+    void workspace.runQuery(1, timeRange ? toSecondRange(timeRange) : undefined, undefined, undefined, nextPageSize);
+  }
+
+  function goToResultPage(nextPage: number) {
+    if (workspace.loading || nextPage < 1 || nextPage === workspace.page) {
+      return;
+    }
+    void workspace.runQuery(nextPage, timeRange ? toSecondRange(timeRange) : undefined);
+  }
+
+  function handleResultTableBodyScroll(event: UIEvent<HTMLDivElement>) {
+    if (resultTableHeaderScrollRef.current) {
+      resultTableHeaderScrollRef.current.scrollLeft = event.currentTarget.scrollLeft;
+    }
+  }
+
+  function handleResultTableHeaderWheel(event: WheelEvent<HTMLDivElement>) {
+    const delta = event.deltaX || (event.shiftKey ? event.deltaY : 0);
+    if (!resultTableScrollRef.current || !delta) {
+      return;
+    }
+    event.preventDefault();
+    resultTableScrollRef.current.scrollLeft += delta;
+    if (resultTableHeaderScrollRef.current) {
+      resultTableHeaderScrollRef.current.scrollLeft = resultTableScrollRef.current.scrollLeft;
+    }
+  }
+
+  function renderResultTableColGroup() {
+    return (
+      <colgroup>
+        <col className="cv-query-result-col--toggle" style={{ width: RESULT_TABLE_TOGGLE_COLUMN_WIDTH }} />
+        {visibleResultColumns.map((column) => (
+          <col
+            key={column.key}
+            className={`cv-query-result-col ${getResultColumnLayoutClass(column.key)}`}
+            style={{ width: getResultColumnWidth(column.key, resultColumnWidths) }}
+          />
+        ))}
+      </colgroup>
+    );
+  }
+
+  function renderResultTableHeader() {
+    return (
+      <thead>
+        <tr>
+          <th scope="col" className="cv-query-result-table__toggle-header" aria-label="Log detail toggle" />
+          {visibleResultColumns.map((column, columnIndex) => {
+            const isDragging = draggedResultColumnKey === column.key;
+            const isDropTarget =
+              Boolean(draggedResultColumnKey) &&
+              draggedResultColumnKey !== column.key &&
+              resultColumnDropTargetKey === column.key;
+            const columnConditionField = getResultColumnConditionField(column);
+            const canShowColumnTopValues =
+              column.key !== "__time" && canShowFieldStatsForField(columnConditionField);
+            const columnMenuOpen = resultColumnMenuKey === column.key;
+            const canMoveColumnLeft = columnIndex > 0;
+            const canMoveColumnRight = columnIndex < visibleResultColumns.length - 1;
+            return (
+              <th
+                key={column.key}
+                scope="col"
+                draggable
+                className={
+                  [
+                    "cv-query-result-table__header",
+                    getResultColumnLayoutClass(column.key),
+                    isDragging ? "cv-query-result-table__header--dragging" : "",
+                    isDropTarget ? "cv-query-result-table__header--drop-target" : ""
+                  ]
+                    .filter(Boolean)
+                    .join(" ")
+                }
+                onDragStart={(event) => handleResultColumnDragStart(event, column.key)}
+                onDragOver={(event) => handleResultColumnDragOver(event, column.key)}
+                onMouseDown={(event) => handleResultColumnPointerDown(event, column.key)}
+                onMouseEnter={() => handleResultColumnPointerEnter(column.key)}
+                onMouseUp={() => handleResultColumnPointerUp(column.key)}
+                onDragLeave={() => {
+                  if (resultColumnDropTargetKey === column.key) {
+                    setResultColumnDropTargetKey(null);
+                  }
+                }}
+                onDrop={(event) => handleResultColumnDrop(event, column.key)}
+                onDragEnd={finishResultColumnDrag}
+              >
+                <div className="cv-query-result-header-cell">
+                  <span className="cv-query-result-header-cell__grab" aria-hidden="true" />
+                  <span className="cv-query-result-header-cell__label-menu">
+                    <EuiPopover
+                      anchorPosition="downLeft"
+                      button={
+                        <button
+                          type="button"
+                          className="cv-query-result-header-cell__label-button"
+                          aria-expanded={columnMenuOpen}
+                          aria-haspopup="menu"
+                          title={column.label}
+                          draggable={false}
+                          onMouseDown={(event) => event.stopPropagation()}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            setResultColumnMenuKey((current) => (current === column.key ? null : column.key));
+                          }}
+                        >
+                          <span>{column.label}</span>
+                          <EuiIcon type="arrowDown" size="s" aria-hidden="true" />
+                        </button>
+                      }
+                      closePopover={() => setResultColumnMenuKey(null)}
+                      isOpen={columnMenuOpen}
+                      ownFocus={false}
+                      panelClassName="cv-query-result-column-menu-panel"
+                      panelPaddingSize="none"
+                      repositionOnScroll
+                    >
+                      <div
+                        className="cv-query-result-column-menu"
+                        role="menu"
+                        aria-label={`${column.label} column actions`}
+                        onMouseDown={(event) => event.stopPropagation()}
+                        onClick={(event) => event.stopPropagation()}
+                      >
+                        <div className="cv-query-result-column-menu__title" title={column.label}>
+                          {column.label}
+                        </div>
+                        {columnConditionField ? (
+                          <button
+                            type="button"
+                            role="menuitem"
+                            className="cv-query-result-column-menu__item"
+                            onClick={() => startResultColumnFilter(column)}
+                          >
+                            <EuiIcon type="filterInclude" size="s" aria-hidden="true" />
+                            <span>Add condition</span>
+                          </button>
+                        ) : null}
+                        {canShowColumnTopValues ? (
+                          <button
+                            type="button"
+                            role="menuitem"
+                            className="cv-query-result-column-menu__item"
+                            onClick={() => showResultColumnTopValues(column)}
+                          >
+                            <EuiIcon type="stats" size="s" aria-hidden="true" />
+                            <span>Top values</span>
+                          </button>
+                        ) : null}
+                        {columnConditionField || canShowColumnTopValues ? (
+                          <div className="cv-query-result-column-menu__separator" role="separator" />
+                        ) : null}
+                        <button
+                          type="button"
+                          role="menuitem"
+                          className="cv-query-result-column-menu__item"
+                          disabled={!canMoveColumnLeft}
+                          onClick={() => {
+                            setResultColumnMenuKey(null);
+                            moveResultColumnByOffset(column.key, -1);
+                          }}
+                        >
+                          <EuiIcon type="arrowLeft" size="s" aria-hidden="true" />
+                          <span>Move left</span>
+                        </button>
+                        <button
+                          type="button"
+                          role="menuitem"
+                          className="cv-query-result-column-menu__item"
+                          disabled={!canMoveColumnRight}
+                          onClick={() => {
+                            setResultColumnMenuKey(null);
+                            moveResultColumnByOffset(column.key, 1);
+                          }}
+                        >
+                          <EuiIcon type="arrowRight" size="s" aria-hidden="true" />
+                          <span>Move right</span>
+                        </button>
+                        <div className="cv-query-result-column-menu__separator" role="separator" />
+                        <button
+                          type="button"
+                          role="menuitem"
+                          className="cv-query-result-column-menu__item"
+                          onClick={() => {
+                            setResultColumnMenuKey(null);
+                            hideResultColumn(column.key);
+                          }}
+                        >
+                          <EuiIcon type="minusInCircle" size="s" aria-hidden="true" />
+                          <span>Hide column</span>
+                        </button>
+                      </div>
+                    </EuiPopover>
+                  </span>
+                  <button
+                    type="button"
+                    className="cv-query-result-header-cell__resize"
+                    aria-label={`Resize ${column.label} column`}
+                    title={`Resize ${column.label} column`}
+                    draggable={false}
+                    onMouseDown={(event) => startResultColumnResize(event, column.key)}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                    }}
+                  >
+                    <span aria-hidden="true" />
+                  </button>
+                </div>
+              </th>
+            );
+          })}
+        </tr>
+      </thead>
+    );
+  }
+
+  function abortFieldStatsRequest() {
+    fieldStatsAbortControllerRef.current?.abort();
+    fieldStatsAbortControllerRef.current = null;
+  }
+
+  function abortInlineFieldStatsRequest(itemKey: string) {
+    const abortController = inlineFieldStatsAbortControllersRef.current.get(itemKey);
+    abortController?.abort();
+    inlineFieldStatsAbortControllersRef.current.delete(itemKey);
+  }
+
+  function abortAllInlineFieldStatsRequests() {
+    inlineFieldStatsAbortControllersRef.current.forEach((abortController) => abortController.abort());
+    inlineFieldStatsAbortControllersRef.current.clear();
   }
 
   function closeFieldStatsModal() {
+    abortFieldStatsRequest();
     setFieldStatsState(null);
+  }
+
+  function clearInlineFieldStats() {
+    abortAllInlineFieldStatsRequests();
+    setInlineFieldStatsByKey({});
+    setExpandedInlineFieldStatsKeys(new Set());
+  }
+
+  function closeAllFieldStats() {
+    closeFieldStatsModal();
+    clearInlineFieldStats();
+  }
+
+  function collapseInlineFieldStats(itemKey: string) {
+    const statsState = inlineFieldStatsByKey[itemKey];
+    if (statsState?.loading) {
+      abortInlineFieldStatsRequest(itemKey);
+      setInlineFieldStatsByKey((current) => {
+        const next = { ...current };
+        delete next[itemKey];
+        return next;
+      });
+    }
+    setExpandedInlineFieldStatsKeys((current) => {
+      const next = new Set(current);
+      next.delete(itemKey);
+      return next;
+    });
+  }
+
+  function closeFieldCatalogPanel() {
+    setFieldCatalogOpen(false);
+    abortAllInlineFieldStatsRequests();
+    setInlineFieldStatsByKey((current) =>
+      Object.fromEntries(Object.entries(current).filter(([, statsState]) => !statsState.loading))
+    );
+    setExpandedInlineFieldStatsKeys((current) => {
+      const next = new Set(current);
+      Object.entries(inlineFieldStatsByKey).forEach(([itemKey, statsState]) => {
+        if (statsState.loading) {
+          next.delete(itemKey);
+        }
+      });
+      return next;
+    });
   }
 
   function buildRawLogFieldStatsRef(field: string, sampleValue: unknown) {
@@ -1716,19 +4868,28 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
     );
   }
 
-  async function openFieldStatsModal(
+  function buildFieldStatsRequestContext(
     field: string,
     sampleValue: unknown,
     preferRawLog = false,
     explicitFieldRef?: QueryFieldRef
   ) {
-    if (!workspace.selectedTableId || !timeRange) {
-      setFeedbackMessage("请先选择日志表和时间范围");
-      return;
+    const fieldStatsRange = workspace.lastRunSnapshot?.range ?? (timeRange ? toSecondRange(timeRange) : null);
+    if (!workspace.selectedTableId || !fieldStatsRange) {
+      setFeedbackMessage("Select a log table and time range first");
+      return null;
     }
-    if (!field || /^_?raw/i.test(field)) {
-      setFeedbackMessage("原始日志字段不适合做值分布统计");
-      return;
+    const explicitFieldKey = explicitFieldRef?.fieldKey ?? "";
+    if (!canShowFieldStatsForField(field) || (explicitFieldKey && !canShowFieldStatsForField(explicitFieldKey))) {
+      const feedbackField = explicitFieldKey || field;
+      setFeedbackMessage(
+        isUniqueFieldStatsField(field) || isUniqueFieldStatsField(explicitFieldKey)
+          ? `${feedbackField} is unique and cannot show top values`
+          : isTimeFieldStatsField(field) || isTimeFieldStatsField(explicitFieldKey)
+          ? `${feedbackField} is time-related and cannot show top values`
+          : "Raw log fields cannot show top values"
+      );
+      return null;
     }
     const sample = createDetailConditionValue(sampleValue);
     const catalogFieldRef =
@@ -1748,36 +4909,188 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
       (preferRawLog && !(catalogFieldRef.source === "column" && catalogFieldRef.isAccelerated)
         ? buildRawLogFieldStatsRef(field, sampleValue)
         : catalogFieldRef);
-    const range = toSecondRange(timeRange);
-    setFieldStatsState({ field, fieldRef, loading: true, data: null, error: "" });
-    try {
-      const data = await getQueryFieldStats({
+    return {
+      field,
+      fieldRef,
+      request: {
         tid: workspace.selectedTableId,
-        st: range.st,
-        et: range.et,
+        st: fieldStatsRange.st,
+        et: fieldStatsRange.et,
         page: 1,
         pageSize: workspace.pageSize,
-        conditions: buildStructuredConditions(workspace.conditions, workspace.analysisFields),
+        conditions:
+          workspace.lastRunSnapshot?.conditions ??
+          buildStructuredConditions(workspace.conditions, workspace.analysisFields),
         sorts: [],
         displayFields: [],
         field: fieldRef,
         limit: 10
+      }
+    };
+  }
+
+  async function openFieldStatsModal(
+    field: string,
+    sampleValue: unknown,
+    preferRawLog = false,
+    explicitFieldRef?: QueryFieldRef
+  ) {
+    const context = buildFieldStatsRequestContext(field, sampleValue, preferRawLog, explicitFieldRef);
+    if (!context) {
+      return;
+    }
+    abortFieldStatsRequest();
+    const abortController = new AbortController();
+    fieldStatsAbortControllerRef.current = abortController;
+    setFieldStatsState({
+      field: context.field,
+      fieldRef: context.fieldRef,
+      loading: true,
+      data: null,
+      error: ""
+    });
+    try {
+      const data = await getQueryFieldStats(
+        context.request,
+        { signal: abortController.signal }
+      );
+      if (fieldStatsAbortControllerRef.current !== abortController) {
+        return;
+      }
+      fieldStatsAbortControllerRef.current = null;
+      setFieldStatsState({
+        field: context.field,
+        fieldRef: context.fieldRef,
+        loading: false,
+        data,
+        error: ""
       });
-      setFieldStatsState({ field, fieldRef, loading: false, data, error: "" });
     } catch (error) {
-      const message = error instanceof Error ? error.message : "字段统计失败";
-      setFieldStatsState({ field, fieldRef, loading: false, data: null, error: message });
+      if (fieldStatsAbortControllerRef.current !== abortController) {
+        return;
+      }
+      fieldStatsAbortControllerRef.current = null;
+      if (abortController.signal.aborted || isAbortRequestError(error)) {
+        setFieldStatsState(null);
+        return;
+      }
+      const message = error instanceof Error ? error.message : "Failed to load field stats";
+      setFieldStatsState({
+        field: context.field,
+        fieldRef: context.fieldRef,
+        loading: false,
+        data: null,
+        error: message
+      });
+    }
+  }
+
+  async function openInlineFieldStats(item: QueryFieldCatalogItem) {
+    const context = buildFieldStatsRequestContext(item.label, item.sampleValue, false, item.fieldRef);
+    if (!context) {
+      return;
+    }
+    abortInlineFieldStatsRequest(item.key);
+    const abortController = new AbortController();
+    inlineFieldStatsAbortControllersRef.current.set(item.key, abortController);
+    setExpandedInlineFieldStatsKeys((current) => {
+      const next = new Set(current);
+      next.add(item.key);
+      return next;
+    });
+    setInlineFieldStatsByKey((current) => ({
+      ...current,
+      [item.key]: {
+        field: context.field,
+        fieldRef: context.fieldRef,
+        loading: true,
+        data: null,
+        error: ""
+      }
+    }));
+    try {
+      const data = await getQueryFieldStats(context.request, { signal: abortController.signal });
+      if (inlineFieldStatsAbortControllersRef.current.get(item.key) !== abortController) {
+        return;
+      }
+      inlineFieldStatsAbortControllersRef.current.delete(item.key);
+      setInlineFieldStatsByKey((current) => ({
+        ...current,
+        [item.key]: {
+          field: context.field,
+          fieldRef: context.fieldRef,
+          loading: false,
+          data,
+          error: ""
+        }
+      }));
+    } catch (error) {
+      if (inlineFieldStatsAbortControllersRef.current.get(item.key) !== abortController) {
+        return;
+      }
+      inlineFieldStatsAbortControllersRef.current.delete(item.key);
+      if (abortController.signal.aborted || isAbortRequestError(error)) {
+        setInlineFieldStatsByKey((current) => {
+          const next = { ...current };
+          delete next[item.key];
+          return next;
+        });
+        setExpandedInlineFieldStatsKeys((current) => {
+          const next = new Set(current);
+          next.delete(item.key);
+          return next;
+        });
+        return;
+      }
+      const message = error instanceof Error ? error.message : "Failed to load field stats";
+      setInlineFieldStatsByKey((current) => ({
+        ...current,
+        [item.key]: {
+          field: context.field,
+          fieldRef: context.fieldRef,
+          loading: false,
+          data: null,
+          error: message
+        }
+      }));
     }
   }
 
   function toggleExpandedLog(index: number) {
-    setExpandedLogIndex((current) => {
-      if (current === index) {
-        setExpandedLogDisplayMode("fields");
-        return null;
+    setExpandedLogIndexes((current) => {
+      const next = new Set(current);
+      if (next.has(index)) {
+        next.delete(index);
+      } else {
+        resetResultTableHorizontalScroll();
+        next.add(index);
       }
-      setExpandedLogDisplayMode("fields");
-      return index;
+      return next;
+    });
+  }
+
+  function toggleExpandedLogNestedField(rowIndex: number, fieldKey: string) {
+    const nestedKey = `${rowIndex}:${fieldKey}`;
+    setExpandedLogNestedKeys((current) => {
+      const next = new Set(current);
+      if (next.has(nestedKey)) {
+        next.delete(nestedKey);
+      } else {
+        next.add(nestedKey);
+      }
+      return next;
+    });
+  }
+
+  function toggleExpandedLogMetadata(index: number) {
+    setExpandedLogMetadataIndexes((current) => {
+      const next = new Set(current);
+      if (next.has(index)) {
+        next.delete(index);
+      } else {
+        next.add(index);
+      }
+      return next;
     });
   }
 
@@ -1789,6 +5102,12 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
       rawValue = row.levelText;
     } else if (column.key === "__message") {
       rawValue = row.messageText;
+    } else if (normalizeResultColumnKey(column.key) === CONTAINER_NAME_RESULT_COLUMN_KEY) {
+      rawValue = firstPresentValue(row.parsed, [
+        CONTAINER_NAME_RESULT_COLUMN_KEY,
+        LEGACY_CONTAINER_NAME_RESULT_COLUMN_KEY,
+        "container_name"
+      ]);
     } else {
       rawValue = row.parsed[column.key];
     }
@@ -1799,12 +5118,18 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
     };
   }
 
-  function addConditionFromLogDetail(field: string, value: unknown) {
+  function applyConditionsAndRun(nextConditions: QueryFilterCondition[], activeConditionId: string | null) {
+    workspace.setConditions(nextConditions);
+    workspace.setActiveConditionId(activeConditionId);
+    void workspace.runQuery(1, timeRange ? toSecondRange(timeRange) : undefined, nextConditions);
+  }
+
+  function addConditionFromLogDetail(field: string, value: unknown, operator: "=" | "!=" = "=") {
     if (!canCreateConditionFromDetailValue(field, value)) {
       return;
     }
     const fieldRef = buildDetailFieldRef(field, value);
-    if (fieldRef.valueType === "datetime" && isLogTimeField(fieldRef.fieldKey)) {
+    if (operator === "=" && fieldRef.valueType === "datetime" && isLogTimeField(fieldRef.fieldKey)) {
       const timeConditions = createDetailTimeRangeConditions(field, value);
       if (timeConditions.length > 0) {
         const existingRange = timeConditions.every((nextCondition) =>
@@ -1825,12 +5150,11 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
                 String(condition.value) === String(timeConditions[0].value)
             )?.id ?? null
           );
-          setFeedbackMessage(`已存在时间范围 ${field}`);
+          setFeedbackMessage(`Time range already exists for ${field}`);
           return;
         }
-        workspace.setConditions([...workspace.conditions, ...timeConditions]);
-        workspace.setActiveConditionId(timeConditions[0].id);
-        setFeedbackMessage(`已添加时间范围 ${field} ${timeConditions[0].value} - ${timeConditions[1].value}`);
+        applyConditionsAndRun([...workspace.conditions, ...timeConditions], timeConditions[0].id);
+        setFeedbackMessage("");
         return;
       }
     }
@@ -1839,31 +5163,30 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
       fieldRef.valueType === "number" || fieldRef.valueType === "datetime" ? fieldRef.valueType : "string"
     );
     if (!conditionValue) {
-      setFeedbackMessage(`${field} 的值无法按数字条件加入查询`);
+      setFeedbackMessage(`${field} cannot be added as a numeric condition`);
       return;
     }
     const existingCondition = workspace.conditions.find(
       (condition) =>
         condition.field === field &&
-        condition.operator === "=" &&
+        condition.operator === operator &&
         condition.valueType === conditionValue.valueType &&
         String(condition.value) === String(conditionValue.value)
     );
     if (existingCondition) {
       workspace.setActiveConditionId(existingCondition.id);
-      setFeedbackMessage(`已存在条件 ${field} = ${conditionValue.value}`);
+      setFeedbackMessage(`Condition already exists: ${field} ${operator} ${conditionValue.value}`);
       return;
     }
     const nextCondition: QueryFilterCondition = {
       id: `cond_detail_${Date.now()}_${Math.random().toString(16).slice(2)}`,
       field,
-      operator: "=",
+      operator,
       value: conditionValue.value,
       valueType: conditionValue.valueType
     };
-    workspace.setConditions([...workspace.conditions, nextCondition]);
-    workspace.setActiveConditionId(nextCondition.id);
-    setFeedbackMessage(`已添加条件 ${field} = ${conditionValue.value}`);
+    applyConditionsAndRun([...workspace.conditions, nextCondition], nextCondition.id);
+    setFeedbackMessage("");
   }
 
   function addGlobalMatchFromLogDetailValue(value: string) {
@@ -1872,74 +5195,53 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
       return;
     }
     const existingCondition = workspace.conditions.find(
-      (condition) => condition.field === "全局匹配" && String(condition.value) === text
+      (condition) => isGlobalMatchField(condition.field) && String(condition.value) === text
     );
     if (existingCondition) {
       workspace.setActiveConditionId(existingCondition.id);
-      setFeedbackMessage(`已存在全局匹配 ${text}`);
+      setFeedbackMessage(`${GLOBAL_MATCH_DISPLAY_LABEL} already exists: ${text}`);
       return;
     }
     const nextCondition: QueryFilterCondition = {
       id: `cond_detail_global_${Date.now()}_${Math.random().toString(16).slice(2)}`,
-      field: "全局匹配",
+      field: GLOBAL_MATCH_FIELD,
       operator: "like",
       value: text,
       valueType: "string"
     };
-    workspace.setConditions([...workspace.conditions, nextCondition]);
-    workspace.setActiveConditionId(nextCondition.id);
-    setFeedbackMessage(`已添加全局匹配 ${text}`);
+    applyConditionsAndRun([...workspace.conditions, nextCondition], nextCondition.id);
+    setFeedbackMessage("");
   }
 
-  function addConditionFromFieldStatsValue(fieldRef: QueryFieldRef, value: string) {
-    if (fieldRef.source === "tag_path") {
-      addConditionFromLogDetail(fieldRef.fieldKey, value);
+  function addConditionFromFieldStatsValue(
+    fieldRef: QueryFieldRef,
+    value: string,
+    operator: "=" | "!=" = "=",
+    conditionField?: string
+  ) {
+    const directConditionField =
+      conditionField ??
+      (fieldRef.source === "tag_path" || (fieldRef.source === "column" && fieldRef.isAccelerated)
+        ? fieldRef.fieldKey
+        : "");
+    if (directConditionField) {
+      addConditionFromLogDetail(directConditionField, value, operator);
+      closeAllFieldStats();
       return;
     }
-    if (fieldRef.source !== "column" || !fieldRef.isAccelerated) {
-      addGlobalMatchFromLogDetailValue(value);
-      return;
-    }
-    addConditionFromLogDetail(fieldRef.fieldKey, value);
-  }
-
-  function requestAddConditionFromFieldStatsValue(fieldRef: QueryFieldRef, value: string) {
-    setFieldStatsConfirmState({
-      fieldRef,
-      value,
-      actionText:
-        fieldRef.source === "tag_path" || (fieldRef.source === "column" && fieldRef.isAccelerated)
-          ? `${fieldRef.fieldKey} = ${value}`
-          : `全局匹配：${value}`
-    });
-  }
-
-  async function copyFieldStatsConfirmText() {
-    if (!fieldStatsConfirmState) {
-      return;
-    }
-    const copied = await copyTextToClipboard(fieldStatsConfirmState.actionText);
-    setFeedbackMessage(copied ? "已复制完整条件" : "复制失败，请手动选择条件内容");
-  }
-
-  function confirmAddConditionFromFieldStatsValue() {
-    if (!fieldStatsConfirmState) {
-      return;
-    }
-    addConditionFromFieldStatsValue(fieldStatsConfirmState.fieldRef, fieldStatsConfirmState.value);
-    setFieldStatsConfirmState(null);
-    closeFieldStatsModal();
+    addGlobalMatchFromLogDetailValue(value);
+    closeAllFieldStats();
   }
 
   function openLinkQueryModal(row: NormalizedLogRow, field: string, value: unknown) {
     const text = formatLogDetailValue(value).trim();
     const timeMs = getLogRowTimeMs(row);
     if (!text || text === "—") {
-      setFeedbackMessage("链路查询需要一个有效的字段值");
+      setFeedbackMessage("Correlation requires a valid field value");
       return;
     }
     if (!timeMs) {
-      setFeedbackMessage("当前日志缺少可识别时间，无法创建链路查询窗口");
+      setFeedbackMessage("Current log has no recognizable time for correlation");
       return;
     }
     setLinkQueryAnchor({ field, value: text, timeMs });
@@ -1949,6 +5251,159 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
 
   function closeLinkQueryModal() {
     setLinkQueryAnchor(null);
+  }
+
+  function renderLogDetailFieldActions(
+    row: NormalizedLogRow,
+    displayField: string,
+    value: unknown,
+    options: {
+      conditionField?: string;
+      statsPreferRawLog?: boolean;
+      statsFieldRef?: QueryFieldRef;
+    } = {}
+  ) {
+    const conditionField = options.conditionField ?? displayField;
+    const displayValue = formatLogDetailValue(value);
+    const canCopyValue = isPresentLogValue(value) && displayValue.trim() !== "—";
+    const canUseCondition = canCreateConditionFromDetailValue(conditionField, value);
+    const canUseStats = canOpenFieldStats(displayField, value);
+    const canUseAnalysis = canStartAIAnalysisFromField(conditionField, value);
+    const detailColumnOption =
+      resultColumnOptions.find((item) => item.key === conditionField) ??
+      resultColumnOptions.find((item) => item.key === displayField);
+    const canToggleColumn = Boolean(detailColumnOption && detailColumnOption.kind === "field");
+    const detailColumnVisible = detailColumnOption
+      ? visibleResultColumns.some((column) => column.key === detailColumnOption.key)
+      : false;
+    const hasActions = canCopyValue || canUseCondition || canUseStats || canUseAnalysis || canToggleColumn;
+
+    if (!hasActions) {
+      return null;
+    }
+
+    return (
+      <span className="cv-query-detail__row-actions" aria-label={`${displayField} field actions`}>
+        {canUseCondition ? (
+          <>
+            <EuiToolTip content={`Filter for ${conditionField} = ${displayValue}`}>
+              <button
+                type="button"
+                className="cv-query-detail__icon-button cv-query-detail__icon-button--quick"
+                aria-label={`Filter for ${conditionField} = ${displayValue}`}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  addConditionFromLogDetail(conditionField, value);
+                }}
+              >
+                <EuiIcon type="filterInclude" size="s" aria-hidden="true" />
+              </button>
+            </EuiToolTip>
+            <EuiToolTip content={`Filter out ${conditionField} = ${displayValue}`}>
+              <button
+                type="button"
+                className="cv-query-detail__icon-button cv-query-detail__icon-button--quick"
+                aria-label={`Filter out ${conditionField} = ${displayValue}`}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  addConditionFromLogDetail(conditionField, value, "!=");
+                }}
+              >
+                <EuiIcon type="filterExclude" size="s" aria-hidden="true" />
+              </button>
+            </EuiToolTip>
+          </>
+        ) : null}
+        {canCopyValue ? (
+          <EuiToolTip content={`Copy ${displayField} value`}>
+            <button
+              type="button"
+              className="cv-query-detail__icon-button cv-query-detail__icon-button--secondary"
+              aria-label={`Copy ${displayField} value`}
+              onClick={(event) => {
+                event.stopPropagation();
+                void copyLogDetailValue(displayField, value);
+              }}
+            >
+              <EuiIcon type="copyClipboard" size="s" aria-hidden="true" />
+            </button>
+          </EuiToolTip>
+        ) : null}
+        {canToggleColumn && detailColumnOption ? (
+          <EuiToolTip content={detailColumnVisible ? `Remove ${detailColumnOption.label} column` : `Add ${detailColumnOption.label} column`}>
+            <button
+              type="button"
+              className="cv-query-detail__icon-button cv-query-detail__icon-button--secondary"
+              aria-label={detailColumnVisible ? `Remove ${detailColumnOption.label} column` : `Add ${detailColumnOption.label} column`}
+              onClick={(event) => {
+                event.stopPropagation();
+                toggleLogDetailColumn(detailColumnOption.key, detailColumnOption.label);
+              }}
+            >
+              <EuiIcon type={detailColumnVisible ? "minusInCircle" : "listAdd"} size="s" aria-hidden="true" />
+            </button>
+          </EuiToolTip>
+        ) : null}
+        {canUseStats ? (
+          <EuiToolTip content={`View top values for ${displayField}`}>
+            <button
+              type="button"
+              className="cv-query-detail__icon-button cv-query-detail__icon-button--secondary"
+              aria-label={`View top values for ${displayField}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                void openFieldStatsModal(displayField, value, options.statsPreferRawLog, options.statsFieldRef);
+              }}
+            >
+              <EuiIcon type="stats" size="s" aria-hidden="true" />
+            </button>
+          </EuiToolTip>
+        ) : null}
+        {canUseAnalysis ? (
+          <EuiToolTip content={`Correlate logs by ${conditionField}`}>
+            <button
+              type="button"
+              className="cv-query-detail__icon-button cv-query-detail__icon-button--secondary"
+              aria-label={`Correlate logs by ${conditionField}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                openLinkQueryModal(row, conditionField, value);
+              }}
+            >
+              <EuiIcon type="timelineWithArrow" size="s" aria-hidden="true" />
+            </button>
+          </EuiToolTip>
+        ) : null}
+      </span>
+    );
+  }
+
+  function renderLogDetailFieldCell(
+    row: NormalizedLogRow,
+    displayField: string,
+    value: unknown,
+    options: {
+      title?: string;
+      conditionField?: string;
+      statsPreferRawLog?: boolean;
+      statsFieldRef?: QueryFieldRef;
+    } = {}
+  ) {
+    return (
+      <strong className="cv-query-detail__field-cell" title={options.title ?? displayField}>
+        <span className="cv-query-detail__key-text">{displayField}</span>
+        {renderLogDetailFieldActions(row, displayField, value, options)}
+      </strong>
+    );
+  }
+
+  function renderLogDetailValueCell(value: unknown) {
+    const displayValue = formatLogDetailValue(value);
+    return (
+      <span className="cv-query-detail__value-text" title={displayValue}>
+        {displayValue}
+      </span>
+    );
   }
 
   function toggleLinkQueryTable(tableId: number) {
@@ -1963,7 +5418,7 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
     }
     const targets = linkQueryTableOptions.filter((item) => linkQuerySelectedTableIds.includes(item.id));
     if (targets.length === 0) {
-      setFeedbackMessage("请至少选择一张日志表");
+      setFeedbackMessage("Select at least one log table");
       return;
     }
     const params = new URLSearchParams();
@@ -1996,11 +5451,13 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
         ? current
         : [...current, { id: table.id, databaseName: database.name, tableName: table.name }]
     );
-    const range = buildRecentMinutesTimeRange(15);
-    setTimeRange(range);
+    const range = buildEndingNowTimeRange(DEFAULT_TIME_RANGE_MINUTES);
+    applyTimeRange(range, buildAbsolutePickerRange(range));
     workspace.setSelectedInstanceId(instance.id);
     workspace.setSelectedDatabase(database.name);
     workspace.setSelectedTable(table.name);
+    setSourcePickerOpen(false);
+    setSourceSearch("");
     setTableAutoQueryRequest({
       instanceId: instance.id,
       databaseName: database.name,
@@ -2020,7 +5477,7 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
       (item) => item.id === tab.id
     );
     if (!workspace.selectedInstance || !database || !table) {
-      setFeedbackMessage("日志表不存在或已被移除");
+      setFeedbackMessage("Log table is missing or was removed");
       setOpenLogTabs((current) => current.filter((item) => item.id !== tab.id));
       return;
     }
@@ -2047,17 +5504,17 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
   async function handleTreeRefreshSuccess(target: QuerySourceTreeTarget) {
     await workspace.refreshSourceTree(target);
     if (target.tableName) {
-      setFeedbackMessage(`已接入 ${target.databaseName}.${target.tableName}`);
+      setFeedbackMessage(`Added ${target.databaseName}.${target.tableName}`);
       return;
     }
     if (target.databaseName) {
-      setFeedbackMessage(`已定位到 ${target.databaseName}`);
+      setFeedbackMessage(`Focused ${target.databaseName}`);
     }
   }
 
   function closeInstanceContextMenu() {
     setTreeContextMenu((current) =>
-      current.items.length > 0 ? { ariaLabel: "节点操作", items: [], x: 0, y: 0 } : current
+      current.items.length > 0 ? { ariaLabel: "Node actions", items: [], x: 0, y: 0 } : current
     );
   }
 
@@ -2095,13 +5552,13 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
 
   function requestDeleteDatabase(instance: QuerySourceInstance, database: QuerySourceDatabase) {
     setConfirmState({
-      title: "删除数据库",
-      content: `确认删除数据库 ${database.name}？`,
-      confirmLabel: "删除",
+      title: "Delete database",
+      content: `Delete database ${database.name}? This action cannot be undone.`,
+      confirmLabel: "Delete",
       onConfirm: async () => {
         await deleteQueryDatabase(database.id);
         await workspace.refreshSourceTree({ instanceId: instance.id });
-        setFeedbackMessage(`已删除 ${database.name}`);
+        setFeedbackMessage(`Deleted ${database.name}`);
       }
     });
   }
@@ -2112,25 +5569,18 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
     table: QuerySourceTable
   ) {
     setConfirmState({
-      title: "删除表",
-      content: `确认删除日志表 ${table.name}？`,
-      confirmLabel: "删除",
+      title: "Delete table",
+      content: `Delete table ${table.name}? This action cannot be undone.`,
+      confirmLabel: "Delete",
       onConfirm: async () => {
         await deleteQueryTable(table.id);
         await workspace.refreshSourceTree({
           instanceId: instance.id,
           databaseName: database.name
         });
-        setFeedbackMessage(`已删除 ${table.name}`);
+        setFeedbackMessage(`Deleted ${table.name}`);
       }
     });
-  }
-
-  function openNewConditionModal() {
-    setConditionDraft(createConditionDraft());
-    setConditionModalMode("create");
-    setFieldPickerOpen(false);
-    setConditionModalOpen(true);
   }
 
   function openEditConditionModal(conditionId: string) {
@@ -2141,6 +5591,7 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
     workspace.setActiveConditionId(conditionId);
     setConditionDraft({ ...condition });
     setConditionModalMode("edit");
+    setInlineFieldPickerOpen(false);
     setFieldPickerOpen(false);
     setConditionModalOpen(true);
   }
@@ -2151,24 +5602,40 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
     setConditionDraft(null);
   }
 
+  function handleConditionModalBackdropMouseDown(event: MouseEvent<HTMLDivElement>) {
+    conditionModalBackdropPressedRef.current = event.target === event.currentTarget;
+  }
+
+  function handleConditionModalBackdropClick(event: MouseEvent<HTMLDivElement>) {
+    if (event.target === event.currentTarget && conditionModalBackdropPressedRef.current) {
+      closeConditionModal();
+    }
+    conditionModalBackdropPressedRef.current = false;
+  }
+
   function saveConditionModal() {
     if (!conditionDraft) {
       return;
     }
-    if (conditionDraft.field === "全局匹配" && workspace.analysisFields.supportsGlobalMatch === false) {
-      setFeedbackMessage("当前日志表未配置日志内容字段，不能使用全局匹配");
+    if (isGlobalMatchField(conditionDraft.field) && workspace.analysisFields.supportsGlobalMatch === false) {
+      setFeedbackMessage(`Current log table has no log content field, cannot use ${GLOBAL_MATCH_DISPLAY_LABEL}`);
       return;
     }
+    const normalizedDraft = {
+      ...conditionDraft,
+      valueType: isGlobalMatchField(conditionDraft.field) ? "string" as const : conditionDraft.valueType,
+      operator: normalizeConditionOperator(
+        conditionDraft.field,
+        conditionDraft.operator,
+        isGlobalMatchField(conditionDraft.field) ? "string" : conditionDraft.valueType
+      )
+    };
     const nextConditions =
       conditionModalMode === "create"
-        ? [...workspace.conditions, conditionDraft]
-        : workspace.conditions.map((item) => (item.id === conditionDraft.id ? conditionDraft : item));
+        ? [...workspace.conditions, normalizedDraft]
+        : workspace.conditions.map((item) => (item.id === normalizedDraft.id ? normalizedDraft : item));
     workspace.setConditions(nextConditions);
-    if (conditionModalMode === "create") {
-      workspace.setActiveConditionId(conditionDraft.id);
-    } else {
-      workspace.setActiveConditionId(conditionDraft.id);
-    }
+    workspace.setActiveConditionId(null);
     closeConditionModal();
     void workspace.runQuery(1, timeRange ? toSecondRange(timeRange) : undefined, nextConditions);
   }
@@ -2187,461 +5654,1819 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
     );
     workspace.setConditions(nextConditions);
     workspace.setActiveConditionId(condition.id);
-    setFeedbackMessage(condition.disabled ? `已启用条件 ${condition.field}` : `已禁用条件 ${condition.field}`);
+    setFeedbackMessage("");
     void workspace.runQuery(1, timeRange ? toSecondRange(timeRange) : undefined, nextConditions);
   }
 
   const activeCondition = useMemo(
-    () =>
-      workspace.conditions.find((item) => item.id === workspace.activeConditionId) ??
-      workspace.conditions[0] ??
-      null,
+    () => workspace.conditions.find((item) => item.id === workspace.activeConditionId) ?? null,
     [workspace.activeConditionId, workspace.conditions]
   );
 
-  const conditionFieldOptions = useMemo(() => workspace.suggestionFieldOptions, [workspace.suggestionFieldOptions]);
-
-  const activeFieldOption = useMemo(() => {
-    const field = String(conditionDraft ? conditionDraft.field : activeCondition?.field || "").trim();
-    if (!field) {
-      return null;
+  const conditionFieldOptions = useMemo(
+    () =>
+      ([...(workspace.suggestionFieldOptions as QueryFieldPickerOption[])]).sort((left, right) => {
+        const leftIsGlobal = isGlobalMatchField(left.field);
+        const rightIsGlobal = isGlobalMatchField(right.field);
+        if (leftIsGlobal !== rightIsGlobal) {
+          return leftIsGlobal ? -1 : 1;
+        }
+        return compareResultFieldColumns(left.field, right.field);
+      }),
+    [workspace.suggestionFieldOptions]
+  );
+  const inlineFieldPickerOptions = useMemo(() => {
+    const search = formatConditionFieldInputValue(inlineConditionDraft.field).trim().toLowerCase();
+    if (!search || isGlobalMatchField(inlineConditionDraft.field)) {
+      return conditionFieldOptions;
     }
-    return conditionFieldOptions.find((item) => item.field === field) ?? null;
-  }, [activeCondition?.field, conditionDraft?.field, conditionFieldOptions]);
+    return conditionFieldOptions.filter((item) =>
+      formatConditionFieldLabel(item.field).toLowerCase().includes(search)
+    );
+  }, [conditionFieldOptions, inlineConditionDraft.field]);
+  const inlineFieldPickerChoices = useMemo(
+    () => buildFieldPickerChoices(formatConditionFieldInputValue(inlineConditionDraft.field), inlineFieldPickerOptions),
+    [inlineConditionDraft.field, inlineFieldPickerOptions]
+  );
 
-  const isGlobalMatchDraft = conditionDraft?.field === "全局匹配";
+  useEffect(() => {
+    if (!inlineFieldPickerOpen) {
+      return;
+    }
+    setInlineFieldPickerActiveIndex((current) => {
+      if (inlineFieldPickerChoices.length === 0) {
+        return 0;
+      }
+      return Math.min(Math.max(current, 0), inlineFieldPickerChoices.length - 1);
+    });
+  }, [inlineFieldPickerChoices.length, inlineFieldPickerOpen]);
+
+  useEffect(() => {
+    if (inlineFieldPickerOpen) {
+      setInlineFieldPickerActiveIndex(0);
+    }
+  }, [inlineConditionDraft.field, inlineFieldPickerOpen]);
+
+  const inlineOperatorOptions = useMemo(() => {
+    return getCompatibleOperatorOptions(inlineConditionDraft.field, inlineConditionDraft.valueType);
+  }, [inlineConditionDraft.field, inlineConditionDraft.valueType]);
+
+  const isGlobalMatchDraft = Boolean(conditionDraft && isGlobalMatchField(conditionDraft.field));
   const isGlobalMatchUnsupported =
     isGlobalMatchDraft && workspace.analysisFields.supportsGlobalMatch === false;
+  const conditionOperatorOptions = useMemo(
+    () =>
+      conditionDraft
+        ? getCompatibleOperatorOptions(conditionDraft.field, conditionDraft.valueType)
+        : queryOperatorOptions,
+    [conditionDraft?.field, conditionDraft?.valueType]
+  );
+
+  function applyConditionFieldDefaults(
+    condition: QueryFilterCondition,
+    field: string
+  ): QueryFilterCondition {
+    const normalizedField = parseConditionFieldInput(field);
+    const matched = conditionFieldOptions.find((item) => item.field === normalizedField);
+    const nextValueType = isGlobalMatchField(normalizedField) ? "string" : matched?.valueType ?? condition.valueType;
+    let nextOperator = condition.operator;
+
+    if (isGlobalMatchField(normalizedField)) {
+      nextOperator = nextOperator === "not like" ? "not like" : "like";
+    } else if (isGlobalMatchField(condition.field) && condition.operator === "like") {
+      nextOperator = "=";
+    }
+
+    nextOperator = normalizeConditionOperator(normalizedField, nextOperator, nextValueType);
+
+    return {
+      ...condition,
+      field: normalizedField,
+      operator: nextOperator,
+      valueType: nextValueType
+    };
+  }
 
   function handleConditionDraftFieldChange(field: string) {
-    const matched = conditionFieldOptions.find((item) => item.field === field);
-    setConditionDraft((current) =>
-      current
-        ? {
-            ...current,
-            field,
-            ...(current.field === "全局匹配" && field !== "全局匹配" && current.operator === "like"
-              ? { operator: "=" as const }
-              : {}),
-            ...(matched ? { valueType: matched.valueType } : {}),
-            ...(field === "全局匹配" ? { operator: "like" as const, valueType: "string" as const } : {})
-          }
-        : current
+    setConditionDraft((current) => (current ? applyConditionFieldDefaults(current, field) : current));
+  }
+
+  function handleInlineConditionFieldChange(field: string) {
+    setInlineFieldPickerActiveIndex(0);
+    setInlineConditionDraft((current) => {
+      const next = applyConditionFieldDefaults(current, field);
+      const normalizedField = parseConditionFieldInput(field);
+      const matched = conditionFieldOptions.find((item) => item.field === normalizedField);
+      return matched || isGlobalMatchField(normalizedField) ? next : { ...next, valueType: "string" };
+    });
+  }
+
+  function selectInlineFieldPickerChoice(index: number) {
+    const choice = inlineFieldPickerChoices[index];
+    if (!choice) {
+      return;
+    }
+    handleInlineConditionFieldChange(choice.field);
+    setInlineFieldPickerOpen(false);
+    window.setTimeout(() => {
+      inlineConditionValueInputRef.current?.focus();
+    }, 0);
+  }
+
+  function handleInlineFieldPickerKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (!["ArrowDown", "ArrowUp", "Enter", "Escape"].includes(event.key)) {
+      return;
+    }
+
+    if (event.key === "Escape") {
+      if (!inlineFieldPickerOpen) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      setInlineFieldPickerOpen(false);
+      return;
+    }
+
+    if (event.key === "Enter") {
+      if (!inlineFieldPickerOpen || inlineFieldPickerChoices.length === 0) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      selectInlineFieldPickerChoice(inlineFieldPickerActiveIndex);
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    setInlineFieldPickerOpen(true);
+    setInlineFieldPickerActiveIndex((current) => {
+      const lastIndex = inlineFieldPickerChoices.length - 1;
+      if (lastIndex < 0) {
+        return 0;
+      }
+      if (!inlineFieldPickerOpen) {
+        return event.key === "ArrowUp" ? lastIndex : 0;
+      }
+      return event.key === "ArrowDown" ? Math.min(current + 1, lastIndex) : Math.max(current - 1, 0);
+    });
+  }
+
+  function findPreferredResultField(candidates: readonly string[]) {
+    const catalogMatch = candidates.find((field) => conditionFieldOptions.some((item) => item.field === field));
+    if (catalogMatch) {
+      return catalogMatch;
+    }
+    return candidates.find((field) => normalizedLogRows.some((row) => isPresentLogValue(row.parsed[field]))) ?? "";
+  }
+
+  function getResultColumnConditionField(column: QueryResultColumn) {
+    if (column.kind === "field") {
+      return column.key;
+    }
+    if (column.key === "__level") {
+      return findPreferredResultField(LOG_LEVEL_FIELD_KEYS) || normalizedLogRows.find((row) => row.levelField)?.levelField || "";
+    }
+    if (column.key === "__message") {
+      return findPreferredResultField(["msg", "message", "content", "body", "_raw_log_"]);
+    }
+    if (column.key === "__time") {
+      return findPreferredResultField(LOG_TIME_FIELD_KEYS);
+    }
+    return "";
+  }
+
+  function getResultColumnSampleValue(column: QueryResultColumn, field: string) {
+    for (const row of normalizedLogRows) {
+      if (column.key === "__time") {
+        const value = firstPresentValue(row.parsed, LOG_TIME_FIELD_KEYS);
+        if (isPresentLogValue(value)) {
+          return value;
+        }
+      } else if (column.key === "__level") {
+        if (isPresentLogValue(row.levelText) && row.levelText !== "-") {
+          return row.levelText;
+        }
+      } else if (column.key === "__message") {
+        const value = firstPresentValue(row.parsed, ["msg", "message", "content", "body", "_raw_log_"]);
+        if (isPresentLogValue(value)) {
+          return value;
+        }
+      } else if (isPresentLogValue(row.parsed[field])) {
+        return row.parsed[field];
+      }
+    }
+    return "";
+  }
+
+  function startResultColumnFilter(column: QueryResultColumn) {
+    const field = getResultColumnConditionField(column);
+    if (!field) {
+      setFeedbackMessage(`${column.label} cannot be used as a condition`);
+      return;
+    }
+    setInlineConditionDraft(applyConditionFieldDefaults(createConditionDraft(), field));
+    setQueryPreviewOpen(false);
+    setQueryHistoryMenuOpen(false);
+    setSavedQueryMenuOpen(false);
+    setFilterComposerOpen(true);
+    setInlineFieldPickerOpen(false);
+    setResultColumnMenuKey(null);
+  }
+
+  function showResultColumnTopValues(column: QueryResultColumn) {
+    const field = getResultColumnConditionField(column);
+    if (!canShowFieldStatsForField(field)) {
+      setFeedbackMessage(`${column.label} cannot show top values`);
+      return;
+    }
+    const sampleValue = getResultColumnSampleValue(column, field);
+    setResultColumnMenuKey(null);
+    void openFieldStatsModal(column.label, sampleValue, false, buildDetailFieldRef(field, sampleValue));
+  }
+
+  function buildFieldStatsView(statsState: QueryFieldStatsState): QueryFieldStatsView {
+    const unsupportedError = isUnsupportedLogContentQueryError(statsState.error);
+    const loadedStats = buildLoadedFieldStatsItems(normalizedLogRows, statsState.field, statsState.fieldRef);
+    const shouldUseLoaded =
+      !statsState.loading &&
+      (unsupportedError || (!statsState.error && statsState.data?.items.length === 0));
+    const items = statsState.data?.items.length
+      ? statsState.data.items
+      : shouldUseLoaded
+      ? loadedStats.items
+      : [];
+    const total = statsState.data?.items.length
+      ? statsState.data.total
+      : shouldUseLoaded
+      ? loadedStats.total
+      : 0;
+    const source = statsState.data?.items.length
+      ? "Full range"
+      : shouldUseLoaded && loadedStats.items.length > 0
+      ? "Current page"
+      : "";
+    return {
+      unsupportedError,
+      shouldUseLoaded,
+      items,
+      total,
+      source
+    };
+  }
+
+  function renderFieldStatsContent(statsState: QueryFieldStatsState, statsView = buildFieldStatsView(statsState)) {
+    return (
+      <div className="cv-query-field-stats">
+        {statsState.loading ? <QueryFieldStatsLoadingState /> : null}
+        {statsState.error && !statsView.unsupportedError ? (
+          <div className="cv-query-alert" role="alert">{statsState.error}</div>
+        ) : null}
+        {!statsState.loading &&
+        statsView.items.length === 0 &&
+        (statsView.unsupportedError || (!statsState.error && statsState.data?.items.length === 0)) ? (
+          <div className="cv-query-empty-text">No data</div>
+        ) : null}
+        {statsView.items.map((item) => {
+          const conditionField = statsView.shouldUseLoaded
+            ? statsState.fieldRef.fieldKey
+            : statsState.fieldRef.source === "tag_path" ||
+              (statsState.fieldRef.source === "column" && statsState.fieldRef.isAccelerated)
+            ? statsState.fieldRef.fieldKey
+            : "";
+          const targetLabel = conditionField || GLOBAL_MATCH_DISPLAY_LABEL;
+          return (
+            <div key={`${item.value}-${item.count}`} className="cv-query-field-stats__item">
+              <EuiToolTip
+                anchorClassName="cv-query-field-stats__value-anchor"
+                content={item.value}
+                display="block"
+                position="top"
+              >
+                <span className="cv-query-field-stats__value">{item.value}</span>
+              </EuiToolTip>
+              <span className="cv-query-field-stats__bar" aria-hidden="true">
+                <span style={{ width: `${Math.max(item.percentage, 1)}%` }} />
+              </span>
+              <span className="cv-query-field-stats__meta">
+                <strong>{formatPercentage(item.percentage)}</strong>
+                <span>{formatCount(item.count)}</span>
+              </span>
+              <span className="cv-query-field-stats__actions">
+                <EuiToolTip content={`Filter for ${targetLabel} = ${item.value}`}>
+                  <button
+                    type="button"
+                    className="cv-query-field-stats__action"
+                    aria-label={`Filter for ${targetLabel} = ${item.value}`}
+                    onClick={() => addConditionFromFieldStatsValue(
+                      statsState.fieldRef,
+                      item.value,
+                      "=",
+                      conditionField || undefined
+                    )}
+                  >
+                    <EuiIcon type="filterInclude" size="s" aria-hidden="true" />
+                  </button>
+                </EuiToolTip>
+                {conditionField ? (
+                  <EuiToolTip content={`Filter out ${conditionField} = ${item.value}`}>
+                    <button
+                      type="button"
+                      className="cv-query-field-stats__action"
+                      aria-label={`Filter out ${conditionField} = ${item.value}`}
+                      onClick={() => addConditionFromFieldStatsValue(
+                        statsState.fieldRef,
+                        item.value,
+                        "!=",
+                        conditionField
+                      )}
+                    >
+                      <EuiIcon type="filterExclude" size="s" aria-hidden="true" />
+                    </button>
+                  </EuiToolTip>
+                ) : null}
+                <EuiToolTip content={`Copy ${statsState.field} value`}>
+                  <button
+                    type="button"
+                    className="cv-query-field-stats__action"
+                    aria-label={`Copy ${statsState.field} value ${item.value}`}
+                    onClick={() => {
+                      void copyLogDetailValue(statsState.field, item.value);
+                    }}
+                  >
+                    <EuiIcon type="copyClipboard" size="s" aria-hidden="true" />
+                  </button>
+                </EuiToolTip>
+              </span>
+            </div>
+          );
+        })}
+      </div>
     );
   }
 
-  const queryPreview = (() => {
-    if (workspace.queryText.trim()) {
-      return workspace.queryText.trim();
+  function openFieldCatalogTopValues(item: QueryFieldCatalogItem) {
+    if (!item.canShowTopValues) {
+      return;
     }
-    try {
-      return workspace.buildQueryText() || "无条件";
-    } catch (error) {
-      return error instanceof Error ? error.message : "筛选条件不合法";
+    if (expandedInlineFieldStatsKeys.has(item.key)) {
+      collapseInlineFieldStats(item.key);
+      return;
     }
-  })();
+    if (inlineFieldStatsByKey[item.key]) {
+      setExpandedInlineFieldStatsKeys((current) => {
+        const next = new Set(current);
+        next.add(item.key);
+        return next;
+      });
+      return;
+    }
+    void openInlineFieldStats(item);
+  }
+
+  function toggleFieldCatalogColumn(item: QueryFieldCatalogItem) {
+    if (!item.canToggleColumn) {
+      return;
+    }
+    toggleLogDetailColumn(item.columnKey, item.label);
+  }
+
+  function renderFieldCatalogItem(item: QueryFieldCatalogItem) {
+    const columnActionLabel = item.isColumnVisible ? `Remove ${item.label} column` : `Add ${item.label} column`;
+    const inlineStatsState = inlineFieldStatsByKey[item.key];
+    const inlineStatsView = inlineStatsState ? buildFieldStatsView(inlineStatsState) : null;
+    const isTopValuesOpen = expandedInlineFieldStatsKeys.has(item.key);
+    return (
+      <div
+        key={item.key}
+        className={
+          isTopValuesOpen
+            ? "cv-query-fields-panel__item cv-query-fields-panel__item--expanded"
+            : "cv-query-fields-panel__item"
+        }
+      >
+        <div className="cv-query-fields-panel__item-row">
+          <button
+            type="button"
+            className={
+              item.canShowTopValues
+                ? "cv-query-fields-panel__field"
+                : "cv-query-fields-panel__field cv-query-fields-panel__field--disabled"
+            }
+            aria-label={item.canShowTopValues ? `Top values for ${item.label}` : item.label}
+            aria-disabled={!item.canShowTopValues}
+            aria-expanded={item.canShowTopValues ? isTopValuesOpen : undefined}
+            disabled={!item.canShowTopValues}
+            title={item.label}
+            onClick={() => openFieldCatalogTopValues(item)}
+          >
+            {item.canShowTopValues ? (
+              <EuiIcon
+                className="cv-query-fields-panel__field-toggle"
+                type={isTopValuesOpen ? "arrowDown" : "arrowRight"}
+                size="s"
+                aria-hidden="true"
+              />
+            ) : (
+              <span
+                className="cv-query-fields-panel__field-toggle cv-query-fields-panel__field-toggle--empty"
+                aria-hidden="true"
+              />
+            )}
+            <span className="cv-query-fields-panel__field-name">{item.label}</span>
+          </button>
+          <span className="cv-query-fields-panel__actions" aria-label={`${item.label} actions`}>
+            {item.canToggleColumn ? (
+              <EuiButtonIcon
+                aria-label={columnActionLabel}
+                className="cv-query-fields-panel__icon-button"
+                color="text"
+                iconSize="s"
+                iconType={item.isColumnVisible ? "minusInCircle" : "plusInCircle"}
+                size="xs"
+                title={columnActionLabel}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  toggleFieldCatalogColumn(item);
+                }}
+              />
+            ) : null}
+          </span>
+        </div>
+        {isTopValuesOpen ? (
+          <div
+            className="cv-query-fields-panel__stats"
+            role="region"
+            aria-label={`${inlineStatsState?.field ?? item.label} top values`}
+          >
+            <div className="cv-query-fields-panel__stats-header">
+              <span>Top values</span>
+              {inlineStatsState?.loading ? (
+                <button
+                  type="button"
+                  className="cv-query-fields-panel__stats-cancel"
+                  onClick={() => collapseInlineFieldStats(item.key)}
+                  aria-label={`Cancel ${inlineStatsState.field} top values query`}
+                >
+                  Cancel
+                </button>
+              ) : null}
+            </div>
+            {inlineStatsState ? renderFieldStatsContent(inlineStatsState, inlineStatsView ?? undefined) : null}
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  function renderFieldCatalogTabs() {
+    return (
+      <EuiTabs className="cv-query-fields-panel__tabs" size="s" expand={false} aria-label="Field groups">
+        {fieldCatalogGroups.map((group) => (
+          <EuiTab
+            key={group.key}
+            className="cv-query-fields-panel__tab"
+            isSelected={group.key === activeFieldCatalogGroupKey}
+            onClick={() => setActiveFieldCatalogGroupKey(group.key)}
+            aria-label={`${group.title} ${group.items.length}`}
+          >
+            <span>{group.title}</span>
+            <strong>{formatCount(group.items.length)}</strong>
+          </EuiTab>
+        ))}
+      </EuiTabs>
+    );
+  }
+
+  function renderFieldCatalogPanel() {
+    return (
+      <div className="cv-query-fields-panel" role="dialog" aria-label="Fields">
+        <div className="cv-query-fields-panel__header">
+          <strong>Fields</strong>
+          <span>{formatCount(visibleFieldCatalogCount)}</span>
+          <EuiButtonIcon
+            aria-label="Close fields"
+            className="cv-query-fields-panel__close"
+            color="text"
+            iconSize="s"
+            iconType="cross"
+            size="xs"
+            title="Close fields"
+            onClick={closeFieldCatalogPanel}
+          />
+        </div>
+        <div className="cv-query-fields-panel__search">
+          <EuiFieldSearch
+            compressed
+            fullWidth
+            inputRef={(node) => {
+              fieldCatalogSearchInputRef.current = node;
+            }}
+            value={fieldCatalogSearch}
+            onChange={(event) => setFieldCatalogSearch(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Escape") {
+                if (event.currentTarget.value) {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  setFieldCatalogSearch("");
+                } else {
+                  closeFieldCatalogPanel();
+                }
+              }
+            }}
+            placeholder="Search fields"
+            aria-label="Search fields"
+          />
+        </div>
+        {renderFieldCatalogTabs()}
+        <div className="cv-query-fields-panel__body">
+          {activeFieldCatalogGroup.items.length > 0 ? (
+            <div className="cv-query-fields-panel__group-list">
+              {activeFieldCatalogGroup.items.map(renderFieldCatalogItem)}
+            </div>
+          ) : (
+            <div className="cv-query-fields-panel__empty">No data</div>
+          )}
+        </div>
+        <div className="cv-query-fields-panel__footer">
+          <button type="button" className="cv-query-fields-panel__reset" onClick={resetResultColumns}>
+            Reset defaults
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  function addInlineCondition() {
+    const field = parseConditionFieldInput(inlineConditionDraft.field).trim();
+    const value = String(inlineConditionDraft.value ?? "").trim();
+    const effectiveValueType = isGlobalMatchField(field) ? "string" : inlineConditionDraft.valueType;
+    const effectiveOperator = normalizeConditionOperator(field, inlineConditionDraft.operator, effectiveValueType);
+    if (!field || !value) {
+      setFilterComposerOpen(true);
+      setFeedbackMessage("Enter a field and value");
+      return;
+    }
+    if (isGlobalMatchField(field) && workspace.analysisFields.supportsGlobalMatch === false) {
+      setFilterComposerOpen(true);
+      setFeedbackMessage(`Current log table has no log content field, cannot use ${GLOBAL_MATCH_DISPLAY_LABEL}`);
+      return;
+    }
+    if (
+      effectiveValueType !== "string" &&
+      (effectiveOperator === "like" || effectiveOperator === "not like")
+    ) {
+      setFilterComposerOpen(true);
+      setFeedbackMessage("like only supports string fields");
+      return;
+    }
+    if (effectiveValueType === "number" && !Number.isFinite(Number(value))) {
+      setFilterComposerOpen(true);
+      setFeedbackMessage(`${field} requires a numeric value`);
+      return;
+    }
+    const nextCondition: QueryFilterCondition = {
+      ...inlineConditionDraft,
+      id: `cond_inline_${Date.now()}_${Math.random().toString(16).slice(2)}`,
+      field,
+      operator: effectiveOperator,
+      valueType: effectiveValueType,
+      value
+    };
+    const nextConditions = [...workspace.conditions, nextCondition];
+    workspace.setConditions(nextConditions);
+    workspace.setActiveConditionId(null);
+    setInlineConditionDraft(createConditionDraft());
+    setFilterComposerOpen(false);
+    setInlineFieldPickerOpen(false);
+    void workspace.runQuery(1, timeRange ? toSecondRange(timeRange) : undefined, nextConditions);
+  }
+
+  function cancelInlineCondition() {
+    setInlineConditionDraft(createConditionDraft());
+    setInlineFieldPickerOpen(false);
+    setFilterComposerOpen(false);
+  }
+
+  function openInlineConditionComposer() {
+    setQueryPreviewOpen(false);
+    setQueryHistoryMenuOpen(false);
+    setSavedQueryMenuOpen(false);
+    setFieldPickerOpen(false);
+    setInlineFieldPickerActiveIndex(0);
+    setFilterComposerOpen(true);
+  }
+
+  function handleInlineConditionComposerKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.key !== "Escape") {
+      return;
+    }
+    const target = event.target as HTMLElement | null;
+    if (target?.closest(".cv-query-filter-composer__operator")) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    if (inlineFieldPickerOpen) {
+      setInlineFieldPickerOpen(false);
+      return;
+    }
+    cancelInlineCondition();
+  }
+
+  function removeConditionAndRun(conditionId: string) {
+    const nextConditions = workspace.conditions.filter((item) => item.id !== conditionId);
+    workspace.setConditions(nextConditions);
+    workspace.setActiveConditionId(nextConditions[0]?.id ?? null);
+    void workspace.runQuery(1, timeRange ? toSecondRange(timeRange) : undefined, nextConditions);
+  }
 
   function applyQueryHistoryItem(query: string) {
     workspace.applySuggestion(query);
     setQueryHistoryMenuOpen(false);
-    setFeedbackMessage("已填入最近查询");
+    setFeedbackMessage("");
+  }
+
+  function applyAutocompleteItem(query: string) {
+    workspace.setQueryText(query);
+    setQueryInputFocused(false);
+  }
+
+  function renderHistogramEmptyState() {
+    if (workspace.chartLoading) {
+      return <QueryHistogramLoadingState />;
+    }
+
+    if (!workspace.selectedTableId) {
+      return (
+        <QueryEmptyState
+          variant="histogram"
+          icon={<EuiIcon type="table" size="m" />}
+          title="No data"
+        />
+      );
+    }
+
+    if (!workspace.logs) {
+      return (
+        <QueryEmptyState
+          variant="histogram"
+          icon={<EuiIcon type="clock" size="m" />}
+          title="No data"
+        />
+      );
+    }
+
+    if (workspace.logs.logs.length > 0) {
+      return (
+        <QueryEmptyState
+          variant="histogram"
+          tone="empty"
+          icon={<EuiIcon type="visBarVertical" size="m" />}
+          title="No data"
+        />
+      );
+    }
+
+    return (
+      <QueryEmptyState
+        variant="histogram"
+        tone="empty"
+        icon={<EuiIcon type="search" size="m" />}
+        title="No data"
+      />
+    );
+  }
+
+  function renderResultEmptyState() {
+    if (workspace.loading && (!workspace.logs || workspace.logs.logs.length === 0)) {
+      return <QueryResultLoadingState onCancel={workspace.cancelQuery} />;
+    }
+
+    if (!workspace.selectedTableId) {
+      return (
+        <QueryEmptyState
+          icon={<EuiIcon type="table" size="m" />}
+          title="No data"
+        />
+      );
+    }
+
+    if (!workspace.logs) {
+      return (
+        <QueryEmptyState
+          icon={<EuiIcon type="discoverApp" size="m" />}
+          title="No data"
+        />
+      );
+    }
+
+    return (
+      <QueryEmptyState
+        tone="empty"
+        icon={<EuiIcon type="search" size="m" />}
+        title="No data"
+      />
+    );
+  }
+
+  const resultLoadedCount = workspace.logs?.logs.length ?? 0;
+  const currentResultPage = Math.max(1, workspace.page);
+  const resultRangeStart = resultLoadedCount > 0 ? (currentResultPage - 1) * workspace.pageSize + 1 : 0;
+  const resultRangeEnd =
+    resultLoadedCount > 0
+      ? (currentResultPage - 1) * workspace.pageSize + resultLoadedCount
+      : 0;
+  const resultKnownTotalCount = workspace.logs ? Math.max(workspace.logs.count, chartTotalCount) : 0;
+  const hasResultKnownTotal = resultKnownTotalCount > 0;
+  const resultTotalCount =
+    workspace.logs && hasResultKnownTotal
+      ? Math.max(resultKnownTotalCount, resultRangeEnd)
+      : resultLoadedCount;
+  const resultTotalPages =
+    workspace.logs && hasResultKnownTotal
+      ? Math.max(1, Math.ceil(resultTotalCount / workspace.pageSize))
+      : null;
+  const resultHasPreviousPage = workspace.logs !== null && currentResultPage > 1;
+  const resultHasNextPage =
+    workspace.logs !== null &&
+    (hasResultKnownTotal
+      ? currentResultPage * workspace.pageSize < resultTotalCount
+      : resultLoadedCount >= workspace.pageSize);
+  const resultMinimumPageSize = QUERY_PAGE_SIZE_OPTIONS[0];
+  const shouldShowResultPageSize =
+    workspace.logs !== null &&
+    resultLoadedCount > 0 &&
+    (resultTotalCount > resultMinimumPageSize ||
+      resultLoadedCount >= resultMinimumPageSize ||
+      currentResultPage > 1);
+  const shouldShowResultPager =
+    workspace.logs !== null &&
+    resultLoadedCount > 0 &&
+    (resultHasPreviousPage || resultHasNextPage || (resultTotalPages ?? 1) > 1);
+  const shouldShowResultRangeSummary =
+    resultLoadedCount > 0 &&
+    (shouldShowResultPager || currentResultPage > 1);
+  const resultBarSummaryText =
+    resultLoadedCount > 0
+      ? shouldShowResultRangeSummary
+        ? `${formatCount(resultRangeStart)} - ${formatCount(resultRangeEnd)}`
+        : formatRowsLabel(resultLoadedCount)
+      : "No data";
+  const isUnsupportedLogContentQuery = isUnsupportedLogContentQueryError(workspace.errorMessage);
+  const resultBlockingErrorMessage = isUnsupportedLogContentQuery ? "" : workspace.errorMessage;
+  const modalFieldStatsView = fieldStatsState ? buildFieldStatsView(fieldStatsState) : null;
+  const hasResultRows = Boolean(workspace.logs && workspace.logs.logs.length > 0);
+  const currentResultBatchCount = resultLoadedCount;
+  const currentResultBatchIndexes = Array.from(
+    { length: currentResultBatchCount },
+    (_, index) => index
+  );
+  const allCurrentBatchLogsExpanded =
+    currentResultBatchIndexes.length > 0 &&
+    currentResultBatchIndexes.every((index) =>
+      expandedLogIndexes.has(index)
+    );
+  const resultBulkExpandControl = currentResultBatchCount > 1 ? (
+    <ResultToolbarIconAction
+      label={allCurrentBatchLogsExpanded ? "Collapse all" : "Expand all"}
+      icon={allCurrentBatchLogsExpanded ? "fold" : "unfold"}
+      onClick={toggleAllLoadedLogDetails}
+      disabled={resultBulkExpandLoading}
+      loading={resultBulkExpandLoading}
+      ariaPressed={allCurrentBatchLogsExpanded}
+      showIcon={false}
+      showLabel
+      title={`${allCurrentBatchLogsExpanded ? "Collapse" : "Expand"} current page (${formatCount(currentResultBatchCount)} rows)`}
+    />
+  ) : null;
+  const resultLoadingControl = workspace.loading ? (
+    <span className="cv-query-result-bar__loading">
+      <span className="cv-query-result-bar__loading-status" role="status" aria-live="polite">
+        <span className="cv-query-result-action__spinner cv-query-result-action__spinner--active" aria-hidden="true" />
+        <span>Loading</span>
+      </span>
+      <button
+        type="button"
+        className="cv-query-result-bar__cancel"
+        aria-label="Cancel query"
+        onClick={workspace.cancelQuery}
+      >
+        Cancel
+      </button>
+    </span>
+  ) : null;
+  const resultBodyLoadingOverlay = workspace.loading && hasResultRows ? (
+    <div className="cv-query-result-body-refresh" aria-live="polite">
+      <span className="cv-query-result-body-refresh__pill" role="status" aria-label="Refreshing query results">
+        <span className="cv-query-result-action__spinner cv-query-result-action__spinner--active" aria-hidden="true" />
+        <span>Refreshing</span>
+        <button
+          type="button"
+          className="cv-query-result-body-refresh__cancel"
+          aria-label="Cancel result refresh"
+          onClick={workspace.cancelQuery}
+        >
+          Cancel
+        </button>
+      </span>
+    </div>
+  ) : null;
+  function renderResultPageSizeControl(placement: "toolbar" | "footer") {
+    if (!shouldShowResultPageSize) {
+      return null;
+    }
+    const radioGroupName = `query-result-page-size-${placement}`;
+    return (
+      <div
+        className={`cv-query-page-size cv-query-page-size--${placement}`}
+        role="radiogroup"
+        aria-label={placement === "toolbar" ? "Rows per page" : "Rows per page footer"}
+      >
+        <span className="cv-query-page-size__label">Rows</span>
+        {QUERY_PAGE_SIZE_OPTIONS.map((size) => (
+          <label
+            key={size}
+            className={
+              size === workspace.pageSize
+                ? "cv-query-page-size__option cv-query-page-size__option--active"
+                : "cv-query-page-size__option"
+            }
+          >
+            <input
+              type="radio"
+              name={radioGroupName}
+              value={size}
+              checked={size === workspace.pageSize}
+              disabled={workspace.loading}
+              onChange={() => changeResultPageSize(size)}
+            />
+            <span>{size}</span>
+          </label>
+        ))}
+      </div>
+    );
+  }
+
+  function renderResultPagerControls(placement: "toolbar" | "footer") {
+    if (!shouldShowResultPager) {
+      return null;
+    }
+    return (
+      <div
+        className={`cv-query-pagination__pager cv-query-pagination__pager--${placement}`}
+        aria-label={placement === "toolbar" ? "Result page controls" : "Result page controls footer"}
+      >
+        <button
+          type="button"
+          className="cv-query-pagination__button"
+          aria-label="Previous page"
+          disabled={workspace.loading || !resultHasPreviousPage}
+          onClick={() => goToResultPage(currentResultPage - 1)}
+        >
+          <EuiIcon type="arrowLeft" size="s" aria-hidden="true" />
+          <span>Previous</span>
+        </button>
+        <span className="cv-query-pagination__page">
+          {resultTotalPages
+            ? `${formatCount(currentResultPage)} / ${formatCount(resultTotalPages)}`
+            : formatCount(currentResultPage)}
+        </span>
+        <button
+          type="button"
+          className="cv-query-pagination__button"
+          aria-label="Next page"
+          disabled={workspace.loading || !resultHasNextPage}
+          onClick={() => goToResultPage(currentResultPage + 1)}
+        >
+          <span>Next</span>
+          <EuiIcon type="arrowRight" size="s" aria-hidden="true" />
+        </button>
+      </div>
+    );
+  }
+  const resultToolbarPageSizeControl = renderResultPageSizeControl("toolbar");
+  const resultToolbarPagerControls = renderResultPagerControls("toolbar");
+  const resultFooterPageSizeControl = renderResultPageSizeControl("footer");
+  const resultFooterPagerControls = renderResultPagerControls("footer");
+  const histogramIntervalSelectOptions = availableHistogramIntervalOptions.map((option) => {
+    const label = option.value === "auto" && autoHistogramBucketSizeLabel ? `Auto (${autoHistogramBucketSizeLabel})` : option.label;
+    return {
+      value: option.value,
+      inputDisplay: <span className="cv-query-histogram-interval__value">{label}</span>,
+      dropdownDisplay: <span className="cv-query-histogram-interval__option">{label}</span>
+    };
+  });
+  const hasHistogramChartData = histogramChartData.length > 0;
+  const canShowHistogramChart = hasHistogramChartData && !histogramCollapsed;
+  const hasHistogramSummary = Boolean(histogramSelectionRange);
+  const canToggleHistogram = histogramCollapsed || hasHistogramChartData || Boolean(histogramSelectionRange);
+  const hasHistogramControls = canToggleHistogram || timeRangeHistory.length > 0;
+  const hasHistogramToolbar = hasHistogramSummary || hasHistogramControls;
+  const isHistogramEmptyPanel = !histogramCollapsed && !hasHistogramToolbar && !canShowHistogramChart;
+  const isResultEmptyPanel = !hasResultRows && !resultBlockingErrorMessage;
+
+  function clearResultBulkExpandTimers() {
+    if (resultBulkExpandTimerRef.current !== null) {
+      window.clearTimeout(resultBulkExpandTimerRef.current);
+      resultBulkExpandTimerRef.current = null;
+    }
+    if (resultBulkExpandFinishTimerRef.current !== null) {
+      window.clearTimeout(resultBulkExpandFinishTimerRef.current);
+      resultBulkExpandFinishTimerRef.current = null;
+    }
+  }
+
+  function toggleAllLoadedLogDetails() {
+    if (currentResultBatchIndexes.length === 0 || resultBulkExpandLoading) {
+      return;
+    }
+    clearResultBulkExpandTimers();
+    const nextExpanded = !allCurrentBatchLogsExpanded;
+    const targetIndexes = [...currentResultBatchIndexes];
+    setResultBulkExpandLoading(true);
+    resultBulkExpandTimerRef.current = window.setTimeout(() => {
+      setExpandedLogIndexes((current) => {
+        const next = new Set(current);
+        targetIndexes.forEach((index) => {
+          if (nextExpanded) {
+            next.add(index);
+          } else {
+            next.delete(index);
+          }
+        });
+        return next;
+      });
+      resultBulkExpandTimerRef.current = null;
+      resultBulkExpandFinishTimerRef.current = window.setTimeout(() => {
+        resultBulkExpandFinishTimerRef.current = null;
+        setResultBulkExpandLoading(false);
+      }, 0);
+    }, 0);
   }
 
   function clearQueryHistory() {
     workspace.clearQueryHistory();
     setQueryHistoryMenuOpen(false);
-    setFeedbackMessage("已清空当前日志表的最近查询");
+    setFeedbackMessage("");
   }
+
+  function renderSourcePickerContent() {
+    const sourceSearchKeyword = sourceSearch.trim().toLowerCase();
+    const hasSourceSearch = sourceSearchKeyword.length > 0;
+    const matchesSourceSearch = (...values: Array<string | undefined>) =>
+      hasSourceSearch &&
+      values.some((value) => String(value ?? "").toLowerCase().includes(sourceSearchKeyword));
+    const sourceGroups = workspace.instances
+      .map((item) => {
+        const isActiveInstance = workspace.selectedInstanceId === item.id;
+        const instanceMatches = matchesSourceSearch(item.name, item.desc);
+        const databaseGroups = (item.databases ?? [])
+          .map((database) => {
+            const isActiveDatabase = isActiveInstance && workspace.selectedDatabase === database.name;
+            const databaseMatches = matchesSourceSearch(database.name, database.desc, database.cluster);
+            const allDatabaseTables = database.tables ?? [];
+            const databaseTables =
+              !hasSourceSearch || instanceMatches || databaseMatches
+                ? allDatabaseTables
+                : allDatabaseTables.filter((table) => matchesSourceSearch(table.name, table.desc));
+            if (hasSourceSearch && !instanceMatches && !databaseMatches && databaseTables.length === 0) {
+              return null;
+            }
+            return {
+              database,
+              databaseTables,
+              isActiveDatabase,
+              isExpandedDatabase: hasSourceSearch || isActiveDatabase
+            };
+          })
+          .filter(Boolean) as Array<{
+          database: QuerySourceDatabase;
+          databaseTables: QuerySourceTable[];
+          isActiveDatabase: boolean;
+          isExpandedDatabase: boolean;
+        }>;
+        if (hasSourceSearch && !instanceMatches && databaseGroups.length === 0) {
+          return null;
+        }
+        return {
+          item,
+          isActiveInstance,
+          isExpandedInstance: hasSourceSearch || isActiveInstance,
+          databaseGroups
+        };
+      })
+      .filter(Boolean) as Array<{
+      item: QuerySourceInstance;
+      isActiveInstance: boolean;
+      isExpandedInstance: boolean;
+      databaseGroups: Array<{
+        database: QuerySourceDatabase;
+        databaseTables: QuerySourceTable[];
+        isActiveDatabase: boolean;
+        isExpandedDatabase: boolean;
+      }>;
+    }>;
+
+    return (
+      <div className="cv-query-source-popover" role="dialog" aria-label="Select data source">
+        <div className="cv-query-source-popover__header">
+          <div>
+            <strong>Sources</strong>
+            {workspace.contextLoading ? <span>Loading</span> : null}
+          </div>
+          {privateLite ? null : (
+            <a className="cv-secondary-button" href={buildV2RouteHref("query/ingestion")}>
+              Create log library
+            </a>
+          )}
+        </div>
+        <div className="cv-query-source-popover__search">
+          <EuiFieldSearch
+            compressed
+            fullWidth
+            inputRef={(node) => {
+              sourceSearchInputRef.current = node;
+            }}
+            aria-label="Search sources"
+            placeholder="Search sources"
+            value={sourceSearch}
+            onChange={(event) => setSourceSearch(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Escape" && sourceSearch) {
+                event.preventDefault();
+                event.stopPropagation();
+                setSourceSearch("");
+              }
+            }}
+          />
+        </div>
+        <div className="cv-query-source-popover__body">
+          <section role="tree" aria-label="Instances, databases, and log tables" className="cv-query-tree">
+            {sourceGroups.map(({ item, isActiveInstance, isExpandedInstance, databaseGroups }) => {
+              return (
+                <div
+                  key={item.id}
+                  role="treeitem"
+                  aria-label={item.name}
+                  aria-expanded={isExpandedInstance}
+                  className="cv-query-tree__group"
+                >
+                  <div className={`cv-query-tree__instance-row${isActiveInstance ? " cv-query-tree__instance-row--active" : ""}`}>
+                    <button
+                      type="button"
+                      className={`cv-query-tree__instance${isActiveInstance ? " cv-query-tree__instance--active" : ""}`}
+                      onClick={() => workspace.setSelectedInstanceId(item.id)}
+                      onContextMenu={(event) => {
+                        event.preventDefault();
+                        workspace.setSelectedInstanceId(item.id);
+                        openContextMenu(event.clientX, event.clientY, "Instance actions", [
+                          {
+                            key: "create-database",
+                            label: "New database",
+                            onSelect: () => openCreateDatabase(item)
+                          }
+                        ]);
+                      }}
+                      aria-haspopup="menu"
+                      aria-expanded={treeContextMenu.items.length > 0}
+                    >
+                      <span className="cv-query-tree__instance-mark" aria-hidden="true" />
+                      <span className="cv-query-tree__instance-name">{item.name}</span>
+                    </button>
+                  </div>
+                  {isExpandedInstance ? (
+                    <div role="group" aria-label={`${item.name} databases`} className="cv-query-tree__children">
+                      {databaseGroups.map(({ database, databaseTables, isActiveDatabase, isExpandedDatabase }) => {
+                        return (
+                          <div key={database.name} className="cv-query-tree__database-group">
+                            <button
+                              type="button"
+                              aria-pressed={isActiveDatabase}
+                              aria-label={`Database ${database.name}`}
+                              className={`cv-query-tree__database${isActiveDatabase ? " cv-query-tree__database--active" : ""}`}
+                              onClick={() => {
+                                workspace.setSelectedInstanceId(item.id);
+                                workspace.setSelectedDatabase(database.name);
+                              }}
+                              onContextMenu={(event) => {
+                                event.preventDefault();
+                                workspace.setSelectedInstanceId(item.id);
+                                workspace.setSelectedDatabase(database.name);
+                                openContextMenu(event.clientX, event.clientY, "Database actions", [
+                                  {
+                                    key: "edit-database",
+                                    label: "Edit database",
+                                    onSelect: () => openEditDatabase(item, database)
+                                  },
+                                  {
+                                    key: "access-log-library",
+                                    label: "Add existing table",
+                                    onSelect: () => openAccessLogLibrary(item, database.name)
+                                  },
+                                  {
+                                    key: "delete-database",
+                                    label: "Delete database",
+                                    onSelect: () => requestDeleteDatabase(item, database)
+                                  }
+                                ]);
+                              }}
+                            >
+                              <span className="cv-query-tree__database-rail" aria-hidden="true" />
+                              <span className="cv-query-tree__database-dot" aria-hidden="true" />
+                              {database.name}
+                            </button>
+                            {isExpandedDatabase ? (
+                              <div role="group" aria-label={`${database.name} log tables`} className="cv-query-tree__tables">
+                                {databaseTables.map((table) => {
+                                  const isActiveTable = workspace.selectedTable === table.name;
+                                  return (
+                                    <button
+                                      key={table.name}
+                                      type="button"
+                                      aria-pressed={isActiveTable}
+                                      aria-label={`Table ${table.name}`}
+                                      className={`cv-query-tree__table${isActiveTable ? " cv-query-tree__table--active" : ""}`}
+                                      onClick={() => selectTableAndQueryRecentLogs(item, database, table)}
+                                      onContextMenu={(event) => {
+                                        event.preventDefault();
+                                        workspace.setSelectedInstanceId(item.id);
+                                        workspace.setSelectedDatabase(database.name);
+                                        workspace.setSelectedTable(table.name);
+                                        openContextMenu(event.clientX, event.clientY, "Table actions", [
+                                          {
+                                            key: "delete-table",
+                                            label: "Delete table",
+                                            onSelect: () => requestDeleteTable(item, database, table)
+                                          }
+                                        ]);
+                                      }}
+                                    >
+                                      <span className="cv-query-tree__table-rail" aria-hidden="true" />
+                                      <span className="cv-query-tree__table-dot" aria-hidden="true" />
+                                      {table.name}
+                                    </button>
+                                  );
+                                })}
+                                {databaseTables.length === 0 ? (
+                                  <span className="cv-query-tree__empty">No tables</span>
+                                ) : null}
+                              </div>
+                            ) : null}
+                          </div>
+                        );
+                      })}
+                      {databaseGroups.length === 0 ? (
+                        <span className="cv-query-tree__empty">No databases</span>
+                      ) : null}
+                    </div>
+                  ) : null}
+                </div>
+              );
+            })}
+            {sourceGroups.length === 0 ? (
+              <span className="cv-query-tree__empty">{hasSourceSearch ? "No data" : "No data sources"}</span>
+            ) : null}
+          </section>
+        </div>
+      </div>
+    );
+  }
+
+  const queryHistorySearchKeyword = queryHistorySearch.trim().toLowerCase();
+  const visibleQueryHistory = queryHistorySearchKeyword
+    ? workspace.queryHistory.filter((query) => query.toLowerCase().includes(queryHistorySearchKeyword))
+    : workspace.queryHistory;
+  const savedQuerySearchKeyword = savedQuerySearch.trim().toLowerCase();
+  const visibleSavedFilterProfiles = savedQuerySearchKeyword
+    ? workspace.savedFilterProfiles.filter((profile) => {
+        const searchableText = [
+          profile.name,
+          profile.creator,
+          profile.updater,
+          profile.database,
+          profile.table,
+          ...profile.conditions.flatMap((condition) => [
+            condition.field,
+            condition.operator,
+            String(condition.value ?? "")
+          ])
+        ]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+        return searchableText.includes(savedQuerySearchKeyword);
+      })
+    : workspace.savedFilterProfiles;
+
+  const queryUtilityActions = (
+    <div className="cv-query-command-tools" ref={queryUtilityActionsRef}>
+      <div className="cv-query-action-row cv-query-action-row--utility">
+        <EuiPopover
+          anchorPosition="downRight"
+          button={
+            <button
+              type="button"
+              className="cv-query-text-action"
+              onClick={() => {
+                setSavedQueryMenuOpen(false);
+                setQueryHistoryMenuOpen((current) => !current);
+              }}
+              aria-expanded={queryHistoryMenuOpen}
+              aria-haspopup="dialog"
+              title="Recent queries"
+            >
+              Recent
+            </button>
+          }
+          closePopover={() => setQueryHistoryMenuOpen(false)}
+          display="inlineBlock"
+          isOpen={queryHistoryMenuOpen}
+          ownFocus={false}
+          panelClassName="cv-query-saved__popover-panel"
+          panelPaddingSize="none"
+          repositionOnScroll
+        >
+          <div
+            className="cv-query-saved__menu cv-query-saved__menu--popover cv-query-saved__menu--history"
+            role="dialog"
+            aria-label="Recent queries"
+          >
+            {workspace.queryHistory.length > 0 ? (
+              <>
+                <div className="cv-query-saved__search">
+                  <EuiFieldSearch
+                    compressed
+                    fullWidth
+                    inputRef={(node) => {
+                      queryHistorySearchInputRef.current = node;
+                    }}
+                    aria-label="Search recent queries"
+                    placeholder="Search recent queries"
+                    value={queryHistorySearch}
+                    onChange={(event) => setQueryHistorySearch(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Escape" && queryHistorySearch) {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        setQueryHistorySearch("");
+                      }
+                    }}
+                  />
+                </div>
+                <div className="cv-query-saved__list">
+                  {visibleQueryHistory.map((query, index) => (
+                    <article key={`${query}-${index}`} className="cv-query-saved__item cv-query-saved__item--single">
+                      <button type="button" onClick={() => applyQueryHistoryItem(query)}>
+                        <strong title={query}>{query}</strong>
+                      </button>
+                    </article>
+                  ))}
+                  {visibleQueryHistory.length === 0 ? (
+                    <div className="cv-query-saved__empty cv-query-saved__empty--inline">No data</div>
+                  ) : null}
+                </div>
+                <div className="cv-query-saved__footer">
+                  <button type="button" className="cv-query-saved__footer-action" onClick={clearQueryHistory}>
+                    Clear history
+                  </button>
+                </div>
+              </>
+            ) : (
+              <div className="cv-query-saved__empty">No data</div>
+            )}
+          </div>
+        </EuiPopover>
+        <EuiPopover
+          anchorPosition="downRight"
+          button={
+            <button
+              type="button"
+              className="cv-query-text-action"
+              onClick={() => {
+                setQueryHistoryMenuOpen(false);
+                setSavedQueryMenuOpen((current) => !current);
+              }}
+              aria-expanded={savedQueryMenuOpen}
+              aria-haspopup="dialog"
+              title="Saved queries"
+            >
+              Saved
+            </button>
+          }
+          closePopover={() => setSavedQueryMenuOpen(false)}
+          display="inlineBlock"
+          isOpen={savedQueryMenuOpen}
+          ownFocus={false}
+          panelClassName="cv-query-saved__popover-panel"
+          panelPaddingSize="none"
+          repositionOnScroll
+        >
+          <div className="cv-query-saved__menu cv-query-saved__menu--popover" role="dialog" aria-label="Saved queries">
+            {workspace.savedFilterLoading ? <div className="cv-query-saved__status">Loading</div> : null}
+            {workspace.savedFilterProfiles.length > 0 ? (
+              <>
+                <div className="cv-query-saved__search">
+                  <EuiFieldSearch
+                    compressed
+                    fullWidth
+                    inputRef={(node) => {
+                      savedQuerySearchInputRef.current = node;
+                    }}
+                    aria-label="Search saved queries"
+                    placeholder="Search saved queries"
+                    value={savedQuerySearch}
+                    onChange={(event) => setSavedQuerySearch(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Escape" && savedQuerySearch) {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        setSavedQuerySearch("");
+                      }
+                    }}
+                  />
+                </div>
+                <div className="cv-query-saved__list">
+                  {visibleSavedFilterProfiles.map((profile) => (
+                    <article key={profile.id} className="cv-query-saved__item">
+                      <button type="button" onClick={() => applySavedFilterProfile(profile)}>
+                        <strong>{profile.name}</strong>
+                        <span>{formatConditionCountLabel(profile.conditions.length)} · {profile.creator || "system"}</span>
+                      </button>
+                      <button
+                        type="button"
+                        className="cv-query-saved__delete"
+                        aria-label={`Delete saved query ${profile.name}`}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          void deleteSavedFilterProfile(profile.id, profile.name);
+                        }}
+                      >
+                        <EuiIcon type="trash" size="s" aria-hidden="true" />
+                      </button>
+                    </article>
+                  ))}
+                  {visibleSavedFilterProfiles.length === 0 ? (
+                    <div className="cv-query-saved__empty cv-query-saved__empty--inline">No data</div>
+                  ) : null}
+                </div>
+              </>
+            ) : (
+              <div className="cv-query-saved__empty">No data</div>
+            )}
+            <div className="cv-query-saved__footer">
+              <button
+                type="button"
+                className="cv-query-saved__footer-action cv-query-saved__footer-action--primary"
+                onClick={() => {
+                  setSavedQueryMenuOpen(false);
+                  openSaveQueryModal();
+                }}
+              >
+                Save current query
+              </button>
+            </div>
+          </div>
+        </EuiPopover>
+        <button
+          type="button"
+          className="cv-query-text-action cv-query-text-action--share"
+          onClick={() => void handleShareQuery()}
+          aria-busy={shareLoading}
+          disabled={shareLoading}
+          title={shareLoading ? "Creating share link" : "Share query"}
+        >
+          Share
+        </button>
+      </div>
+    </div>
+  );
 
   return (
     <section className={shareMode ? "cv-section-stack cv-query-page cv-query-page--share" : "cv-section-stack cv-query-page"}>
-      <header className="cv-page-toolbar">
-        <div className="cv-page-toolbar__main">
-          <div className="cv-breadcrumb" aria-label="页面路径">
-            <span>查询</span>
-            <span aria-hidden="true">/</span>
-            <span className="cv-breadcrumb__current">{shareMode ? "分享结果" : "日志查询"}</span>
-          </div>
-          <h1 className="cv-page-title cv-sr-only">{shareMode ? "分享结果" : "日志查询"}</h1>
-        </div>
-        <div className="cv-query-toolbar-chips">
-          <TimeRangeDropdown value={timeRange} onChange={setTimeRange} />
-        </div>
-      </header>
+      <h1 className="cv-page-title cv-sr-only">{shareMode ? "Shared results" : "Log query"}</h1>
 
       <div className="cv-query-shell">
-        {shareMode ? null : (
-        <aside aria-label="查询上下文" className="cv-panel cv-query-panel cv-query-sidebar">
-          <div className="cv-panel-header">
-            <div>
-              <h2 className="cv-panel-title">数据源</h2>
-            </div>
-            <div className="cv-inline-actions">
-              {workspace.contextLoading ? <span className="cv-query-panel__status">加载中...</span> : null}
-              {privateLite ? null : (
-                <a className="cv-secondary-button" href={buildV2RouteHref("query/ingestion")}>
-                  创建日志库
-                </a>
-              )}
-            </div>
-          </div>
-          <div className="cv-query-sidebar__body">
-            <section role="tree" aria-label="实例、数据库与日志表" className="cv-query-tree">
-              <div className="cv-query-tree__heading">
-                <strong>实例 / 数据库 / 日志表</strong>
+        <div className="cv-query-main">
+          {!shareMode ? (
+            <div className="cv-query-log-tabs" aria-label="Log table workspace">
+              <div className="cv-query-source-anchor" ref={sourcePickerRef}>
+                <EuiPopover
+                  anchorPosition="downLeft"
+                  button={
+                    <button
+                      type="button"
+                      className={sourcePickerOpen ? "cv-query-source-trigger cv-query-source-trigger--open" : "cv-query-source-trigger"}
+                      onClick={() =>
+                        setSourcePickerOpen((current) => {
+                          if (current) {
+                            closeInstanceContextMenu();
+                          }
+                          return !current;
+                        })
+                      }
+                      aria-expanded={sourcePickerOpen}
+                      aria-haspopup="dialog"
+                      aria-label="Sources"
+                      title="Select data source"
+                    >
+                      <EuiIcon type="table" size="s" aria-hidden="true" />
+                      <span>Sources</span>
+                      <EuiIcon
+                        type={sourcePickerOpen ? "arrowUp" : "arrowDown"}
+                        size="s"
+                        aria-hidden="true"
+                        className="cv-query-source-trigger__chevron"
+                      />
+                    </button>
+                  }
+                  closePopover={() => {
+                    setSourcePickerOpen(false);
+                    closeInstanceContextMenu();
+                  }}
+                  display="inlineBlock"
+                  isOpen={sourcePickerOpen}
+                  ownFocus={false}
+                  panelClassName="cv-query-source-popover-panel"
+                  panelPaddingSize="none"
+                  repositionToCrossAxis={false}
+                  repositionOnScroll
+                >
+                  {renderSourcePickerContent()}
+                </EuiPopover>
               </div>
-              {workspace.instances.map((item) => {
-                const isActiveInstance = workspace.selectedInstanceId === item.id;
-                return (
-                  <div
-                    key={item.id}
-                    role="treeitem"
-                    aria-label={item.name}
-                    aria-expanded={isActiveInstance}
-                    className="cv-query-tree__group"
-                  >
-                    <div className={`cv-query-tree__instance-row${isActiveInstance ? " cv-query-tree__instance-row--active" : ""}`}>
+              <div className="cv-query-log-tab-list" role="tablist" aria-label="Log table tabs">
+                {validOpenLogTabs.map((tab) => {
+                  const active = tab.id === workspace.selectedTableId;
+                  return (
+                    <span
+                      key={tab.id}
+                      className={active ? "cv-query-log-tab cv-query-log-tab--active" : "cv-query-log-tab"}
+                    >
                       <button
                         type="button"
-                        className={`cv-query-tree__instance${isActiveInstance ? " cv-query-tree__instance--active" : ""}`}
-                        onClick={() => workspace.setSelectedInstanceId(item.id)}
-                        onContextMenu={(event) => {
-                          event.preventDefault();
-                          workspace.setSelectedInstanceId(item.id);
-                          openContextMenu(event.clientX, event.clientY, "实例操作", [
-                            {
-                              key: "create-database",
-                              label: "新增数据库",
-                              onSelect: () => openCreateDatabase(item)
-                            }
-                          ]);
-                        }}
-                        aria-haspopup="menu"
-                        aria-expanded={treeContextMenu.items.length > 0}
+                        role="tab"
+                        aria-selected={active}
+                        aria-label={`${tab.databaseName}.${tab.tableName}`}
+                        title={`${tab.databaseName}.${tab.tableName}`}
+                        className="cv-query-log-tab__main"
+                        onClick={() => switchLogTab(tab)}
                       >
-                        <span className="cv-query-tree__instance-mark" aria-hidden="true" />
-                        <span className="cv-query-tree__instance-name">{item.name}</span>
+                        <EuiIcon type="table" size="s" aria-hidden="true" className="cv-query-log-tab__icon" />
+                        <strong>{tab.tableName}</strong>
                       </button>
-                    </div>
-                    {isActiveInstance ? (
-                      <div role="group" aria-label={`${item.name} 数据库`} className="cv-query-tree__children">
-                        {workspace.databases.map((database) => {
-                          const isActiveDatabase = workspace.selectedDatabase === database.name;
-                          const databaseTables = workspace.tablesByDatabase[database.name] ?? [];
-                          return (
-                            <div key={database.name} className="cv-query-tree__database-group">
-                              <button
-                                type="button"
-                                aria-pressed={isActiveDatabase}
-                                aria-label={`数据库 ${database.name}`}
-                                className={`cv-query-tree__database${isActiveDatabase ? " cv-query-tree__database--active" : ""}`}
-                                onClick={() => workspace.setSelectedDatabase(database.name)}
-                                onContextMenu={(event) => {
-                                  event.preventDefault();
-                                  workspace.setSelectedInstanceId(item.id);
-                                  workspace.setSelectedDatabase(database.name);
-                                  openContextMenu(event.clientX, event.clientY, "数据库操作", [
-                                    {
-                                      key: "edit-database",
-                                      label: "编辑数据库",
-                                      onSelect: () => openEditDatabase(item, database)
-                                    },
-                                    {
-                                      key: "access-log-library",
-                                      label: "接入已有日志表",
-                                      onSelect: () => openAccessLogLibrary(item, database.name)
-                                    },
-                                    {
-                                      key: "delete-database",
-                                      label: "删除数据库",
-                                      onSelect: () => requestDeleteDatabase(item, database)
-                                    }
-                                  ]);
-                                }}
-                              >
-                                <span className="cv-query-tree__database-rail" aria-hidden="true" />
-                                <span className="cv-query-tree__database-dot" aria-hidden="true" />
-                                {database.name}
-                              </button>
-                              {isActiveDatabase ? (
-                                <div role="group" aria-label={`${database.name} 日志表`} className="cv-query-tree__tables">
-                                  {databaseTables.map((table) => {
-                                    const isActiveTable = workspace.selectedTable === table.name;
-                                    return (
-                                      <button
-                                        key={table.name}
-                                        type="button"
-                                        aria-pressed={isActiveTable}
-                                        aria-label={`日志表 ${table.name}`}
-                                        className={`cv-query-tree__table${isActiveTable ? " cv-query-tree__table--active" : ""}`}
-                                        onClick={() => selectTableAndQueryRecentLogs(item, database, table)}
-                                        onContextMenu={(event) => {
-                                          event.preventDefault();
-                                          workspace.setSelectedInstanceId(item.id);
-                                          workspace.setSelectedDatabase(database.name);
-                                          workspace.setSelectedTable(table.name);
-                                          openContextMenu(event.clientX, event.clientY, "日志表操作", [
-                                            {
-                                              key: "delete-table",
-                                              label: "删除表",
-                                              onSelect: () => requestDeleteTable(item, database, table)
-                                            }
-                                          ]);
-                                        }}
-                                      >
-                                        <span className="cv-query-tree__table-rail" aria-hidden="true" />
-                                        <span className="cv-query-tree__table-dot" aria-hidden="true" />
-                                        {table.name}
-                                      </button>
-                                    );
-                                  })}
-                                  {databaseTables.length === 0 ? (
-                                    <span className="cv-query-tree__empty">无日志表</span>
-                                  ) : null}
-                                </div>
-                              ) : null}
-                            </div>
-                          );
-                        })}
-                        {workspace.databases.length === 0 ? (
-                          <span className="cv-query-tree__empty">无库</span>
-                        ) : null}
-                      </div>
-                    ) : null}
-                  </div>
-                );
-              })}
-            </section>
-          </div>
-        </aside>
-        )}
-
-        <div className="cv-query-main">
-          {!shareMode && validOpenLogTabs.length > 0 ? (
-            <div className="cv-query-log-tabs" role="tablist" aria-label="日志表工作区标签">
-              {validOpenLogTabs.map((tab) => {
-                const active = tab.id === workspace.selectedTableId;
-                return (
-                  <span
-                    key={tab.id}
-                    className={active ? "cv-query-log-tab cv-query-log-tab--active" : "cv-query-log-tab"}
-                  >
-                    <button
-                      type="button"
-                      role="tab"
-                      aria-selected={active}
-                      className="cv-query-log-tab__main"
-                      onClick={() => switchLogTab(tab)}
-                    >
-                      <strong>{tab.tableName}</strong>
-                      <span>{tab.databaseName}</span>
-                    </button>
-                    <button
-                      type="button"
-                      className="cv-query-log-tab__close"
-                      aria-label={`关闭日志表 ${tab.tableName}`}
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        closeLogTab(tab);
-                      }}
-                    >
-                      ×
-                    </button>
-                  </span>
-                );
-              })}
+                      <button
+                        type="button"
+                        className="cv-query-log-tab__close"
+                        aria-label={`Close table ${tab.tableName}`}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          closeLogTab(tab);
+                        }}
+                      >
+                        ×
+                      </button>
+                    </span>
+                  );
+                })}
+              </div>
             </div>
           ) : null}
-          <section aria-label="查询输入" className="cv-panel cv-query-panel">
-            <div className="cv-panel-header">
-              <div>
-                <h2 className="cv-panel-title">筛选</h2>
-              </div>
-              <div className="cv-query-action-row">
-                <button type="button" className="cv-secondary-button" onClick={openNewConditionModal}>
-                  新增条件
-                </button>
-                <div className="cv-query-saved">
+          <section
+            aria-label="Query input"
+            className={[
+              "cv-panel cv-query-panel cv-query-panel--command",
+              inlineFieldPickerOpen || fieldPickerOpen || queryHistoryMenuOpen || savedQueryMenuOpen
+                ? "cv-query-panel--dropdown-open"
+                : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+          >
+            <div className="cv-query-command-row">
+              <div className="cv-query-sql" onBlur={() => window.setTimeout(() => setQueryInputFocused(false), 120)}>
+                <span className="cv-query-sql__badge">
+                  SQL
+                  <EuiToolTip content="ClickHouse SQL syntax" position="top">
+                    <button type="button" className="cv-query-sql__tip" aria-label="SQL syntax tip">
+                      <EuiIcon type="info" size="s" aria-hidden="true" />
+                    </button>
+                  </EuiToolTip>
+                </span>
+                <input
+                  value={workspace.queryText}
+                  onFocus={() => setQueryInputFocused(true)}
+                  onChange={(event) => workspace.setQueryText(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" && !event.shiftKey) {
+                      event.preventDefault();
+                      void workspace.runQuery(1);
+                    }
+                  }}
+                  placeholder="Search"
+                  spellCheck={false}
+                  aria-label="SQL query"
+                />
+                {workspace.queryText.trim() ? (
                   <button
                     type="button"
-                    className="cv-secondary-button"
-                    onClick={() => {
-                      setSavedQueryMenuOpen(false);
-                      setQueryHistoryMenuOpen((current) => !current);
-                    }}
-                    aria-expanded={queryHistoryMenuOpen}
-                    aria-haspopup="menu"
+                    className="cv-query-sql__clear"
+                    aria-label="Clear SQL query"
+                    onClick={() => workspace.setQueryText("")}
                   >
-                    最近查询
-                    {workspace.queryHistory.length > 0 ? ` ${workspace.queryHistory.length}` : ""}
+                    ×
                   </button>
-                  {queryHistoryMenuOpen ? (
-                    <div className="cv-query-saved__menu" role="menu" aria-label="最近查询">
-                      <div className="cv-query-saved__menu-header">
-                        <strong>最近查询</strong>
-                        <span>{workspace.queryHistory.length} 条</span>
-                      </div>
-                      {workspace.queryHistory.length > 0 ? (
-                        <>
-                          <div className="cv-query-saved__list">
-                            {workspace.queryHistory.map((query, index) => (
-                              <article key={`${query}-${index}`} className="cv-query-saved__item cv-query-saved__item--single">
-                                <button type="button" role="menuitem" onClick={() => applyQueryHistoryItem(query)}>
-                                  <strong title={query}>{query}</strong>
-                                  <span>点击填入查询语句</span>
-                                </button>
-                              </article>
-                            ))}
-                          </div>
-                          <button type="button" className="cv-query-saved__create" onClick={clearQueryHistory}>
-                            清空最近查询
-                          </button>
-                        </>
-                      ) : (
-                        <div className="cv-query-saved__empty">执行查询后会自动记录最近 10 条</div>
-                      )}
-                    </div>
-                  ) : null}
-                </div>
-                <div className="cv-query-saved">
-                  <button
-                    type="button"
-                    className="cv-secondary-button"
-                    onClick={() => {
-                      setQueryHistoryMenuOpen(false);
-                      setSavedQueryMenuOpen((current) => !current);
-                    }}
-                    aria-expanded={savedQueryMenuOpen}
-                    aria-haspopup="menu"
-                  >
-                    收藏查询
-                    {workspace.savedFilterProfiles.length > 0 ? ` ${workspace.savedFilterProfiles.length}` : ""}
-                  </button>
-                  {savedQueryMenuOpen ? (
-                    <div className="cv-query-saved__menu" role="menu" aria-label="收藏查询">
-                      <div className="cv-query-saved__menu-header">
-                        <strong>收藏查询</strong>
-                        <span>{workspace.savedFilterLoading ? "加载中..." : `${workspace.savedFilterProfiles.length} 条`}</span>
-                      </div>
+                ) : null}
+                {queryInputFocused && workspace.autocompleteItems.length > 0 ? (
+                  <div className="cv-query-sql__suggestions" role="listbox" aria-label="Query suggestions">
+                    {workspace.autocompleteItems.map((item) => (
                       <button
+                        key={item}
                         type="button"
-                        className="cv-query-saved__create"
-                        onClick={() => {
-                          setSavedQueryMenuOpen(false);
-                          openSaveQueryModal();
-                        }}
+                        role="option"
+                        onMouseDown={(event) => event.preventDefault()}
+                        onClick={() => applyAutocompleteItem(item)}
                       >
-                        保存当前查询
+                        {item}
                       </button>
-                      {workspace.savedFilterProfiles.length > 0 ? (
-                        <div className="cv-query-saved__list">
-                          {workspace.savedFilterProfiles.map((profile) => (
-                            <article key={profile.id} className="cv-query-saved__item">
-                              <button type="button" role="menuitem" onClick={() => applySavedFilterProfile(profile)}>
-                                <strong>{profile.name}</strong>
-                                <span>{profile.conditions.length} 条条件 · {profile.creator || "system"}</span>
-                              </button>
-                              <button
-                                type="button"
-                                className="cv-query-saved__delete"
-                                aria-label={`删除收藏 ${profile.name}`}
-                                onClick={(event) => {
-                                  event.stopPropagation();
-                                  void deleteSavedFilterProfile(profile.id, profile.name);
-                                }}
-                              >
-                                删除
-                              </button>
-                            </article>
-                          ))}
-                        </div>
-                      ) : (
-                        <div className="cv-query-saved__empty">暂无收藏查询</div>
-                      )}
-                    </div>
-                  ) : null}
-                </div>
-                <button
-                  type="button"
-                  className="cv-secondary-button"
-                  onClick={() => void handleShareQuery()}
-                  disabled={shareLoading}
-                >
-                  {shareLoading ? "生成中..." : "分享"}
-                </button>
-                <button
-                  type="button"
-                  className="cv-action-button"
-                  onClick={() => void workspace.runQuery(1)}
-                  disabled={workspace.loading}
-                >
-                  {workspace.loading ? "查询中..." : "执行查询"}
-                </button>
-              </div>
-            </div>
-
-            <div className="cv-query-builder">
-              <section
-                aria-label="条件清单"
-                className="cv-query-builder__list"
-                onClick={(event) => {
-                  if (event.target === event.currentTarget) {
-                    openNewConditionModal();
-                  }
-                }}
-              >
-                <div className="cv-query-builder__list-header">
-                  <h3 className="cv-query-builder__title">条件</h3>
-                  <span>{workspace.conditions.length} 项</span>
-                </div>
-                {workspace.conditions.length > 0 ? (
-                  <div className="cv-query-condition-list">
-                    {workspace.conditions.map((condition) => (
-                      <span
-                        key={condition.id}
-                        className={
-                          [
-                            "cv-query-condition",
-                            condition.id === activeCondition?.id ? "cv-query-condition--active" : "",
-                            condition.disabled ? "cv-query-condition--disabled" : ""
-                          ]
-                            .filter(Boolean)
-                            .join(" ")
-                        }
-                      >
-                        <button
-                          type="button"
-                          className="cv-query-condition__main"
-                          onClick={() => openEditConditionModal(condition.id)}
-                        >
-                          {`${condition.field || "未选字段"} / ${condition.operator} / ${formatConditionSummaryValue(condition.value)}`}
-                        </button>
-                        <button
-                          type="button"
-                          className="cv-query-condition__toggle"
-                          aria-label={`${condition.disabled ? "启用" : "禁用"}条件 ${condition.field || "未选字段"}`}
-                          title={condition.disabled ? "启用条件" : "禁用条件"}
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            toggleConditionDisabled(condition);
-                          }}
-                        >
-                          {condition.disabled ? "启用" : "禁用"}
-                        </button>
-                      </span>
                     ))}
                   </div>
-                ) : (
-                  <button type="button" className="cv-query-empty-action" onClick={openNewConditionModal}>
-                    暂无条件，点击添加
-                  </button>
-                )}
-              </section>
+                ) : null}
+              </div>
+              <TimeRangeAbsolutePicker
+                value={absolutePickerRange}
+                onChange={applyAbsolutePickerRange}
+                isLoading={workspace.loading || workspace.chartLoading}
+              />
+              <div className="cv-query-command-row__actions">
+                <button
+                  type="button"
+                  className="cv-action-button cv-query-run-button"
+                  onClick={() => void workspace.runQuery(1)}
+                  disabled={workspace.loading}
+                  aria-busy={workspace.loading}
+                >
+                  <EuiIcon type="search" size="s" aria-hidden="true" />
+                  <span>Run</span>
+                </button>
+              </div>
+              {queryUtilityActions}
             </div>
 
-            <div className="cv-query-builder__preview">
-              <strong>查询预览</strong>
-              <code>{queryPreview}</code>
+            <div className="cv-query-kibana">
+              <div className="cv-query-filter-bar" aria-label="Filter conditions">
+                <div className="cv-query-add-filter-anchor" ref={filterComposerRef}>
+                  <EuiPopover
+                    anchorPosition="downLeft"
+                    button={
+                      <button
+                        type="button"
+                        className={filterComposerOpen ? "cv-query-add-filter cv-query-add-filter--active" : "cv-query-add-filter"}
+                        onClick={() => {
+                          if (filterComposerOpen) {
+                            cancelInlineCondition();
+                            return;
+                          }
+                          openInlineConditionComposer();
+                        }}
+                        aria-expanded={filterComposerOpen}
+                        aria-haspopup="dialog"
+                      >
+                        <EuiIcon type="plus" size="s" aria-hidden="true" />
+                        Add condition
+                      </button>
+                    }
+                    closePopover={cancelInlineCondition}
+                    display="inlineBlock"
+                    isOpen={filterComposerOpen}
+                    ownFocus={false}
+                    panelClassName="cv-query-filter-composer-popover-panel"
+                    panelPaddingSize="none"
+                    repositionOnScroll
+                  >
+                    <div
+                      className="cv-query-filter-composer"
+                      aria-label="Filter condition editor"
+                      onKeyDown={handleInlineConditionComposerKeyDown}
+                      role="group"
+                    >
+                      <div className="cv-query-filter-composer__inputs">
+                        <label
+                          ref={inlineFieldPickerRef}
+                          className="cv-query-filter-composer__field cv-query-filter-composer__field--picker"
+                          onBlur={(event) => {
+                            if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+                              setInlineFieldPickerOpen(false);
+                            }
+                          }}
+                        >
+                          <EuiFieldText
+                            compressed
+                            fullWidth
+                            value={formatConditionFieldInputValue(inlineConditionDraft.field)}
+                            onChange={(event) => handleInlineConditionFieldChange(event.target.value)}
+                            onKeyDown={handleInlineFieldPickerKeyDown}
+                            onFocus={(event) => {
+                              event.currentTarget.select();
+                              setFieldPickerOpen(false);
+                              setInlineFieldPickerActiveIndex(0);
+                              setInlineFieldPickerOpen(true);
+                            }}
+                            onClick={() => {
+                              setFieldPickerOpen(false);
+                              setInlineFieldPickerActiveIndex(0);
+                              setInlineFieldPickerOpen(true);
+                            }}
+                            placeholder="Field"
+                            aria-label="Field"
+                            aria-expanded={inlineFieldPickerOpen}
+                            aria-haspopup="listbox"
+                            role="combobox"
+                          />
+                          {inlineFieldPickerOpen && (inlineFieldPickerOptions.length > 0 || inlineConditionDraft.field.trim()) ? (
+                            <FieldPickerDropdown
+                              value={inlineConditionDraft.field.trim()}
+                              options={inlineFieldPickerOptions}
+                              onSelect={(field) => {
+                                handleInlineConditionFieldChange(field);
+                                setInlineFieldPickerOpen(false);
+                                window.setTimeout(() => {
+                                  inlineConditionValueInputRef.current?.focus();
+                                }, 0);
+                              }}
+                              onClose={() => setInlineFieldPickerOpen(false)}
+                              activeIndex={inlineFieldPickerActiveIndex}
+                            />
+                          ) : null}
+                        </label>
+                        <div className="cv-query-filter-composer__clause">
+                          <label className="cv-query-filter-composer__operator">
+                            <QueryCompactSelect
+                              value={inlineConditionDraft.operator}
+                              onChange={(operator) =>
+                                setInlineConditionDraft((current) => ({
+                                  ...current,
+                                  operator
+                                }))
+                              }
+                              ariaLabel="Operator"
+                              options={inlineOperatorOptions}
+                            />
+                          </label>
+                          <label className="cv-query-filter-composer__value">
+                            <EuiFieldText
+                              compressed
+                              fullWidth
+                              inputRef={inlineConditionValueInputRef}
+                              value={String(inlineConditionDraft.value ?? "")}
+                              onChange={(event) =>
+                                setInlineConditionDraft((current) => ({
+                                  ...current,
+                                  value: event.target.value
+                                }))
+                              }
+                              onKeyDown={(event) => {
+                                if (event.key === "Enter") {
+                                  event.preventDefault();
+                                  addInlineCondition();
+                                }
+                              }}
+                              placeholder={inlineConditionDraft.valueType === "number" ? "number" : "Value"}
+                              aria-label="Value"
+                            />
+                          </label>
+                        </div>
+                      </div>
+                      <div className="cv-query-filter-composer__actions">
+                        <button
+                          type="button"
+                          className="cv-query-filter-composer__text-action cv-query-filter-composer__text-action--primary"
+                          onClick={addInlineCondition}
+                        >
+                          Add
+                        </button>
+                        <button
+                          type="button"
+                          className="cv-query-filter-composer__text-action"
+                          onClick={cancelInlineCondition}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  </EuiPopover>
+                </div>
+                {workspace.conditions.length > 0 ? (
+                  <div className="cv-query-filter-pills" role="list" aria-label="Applied conditions">
+                    {workspace.conditions.map((condition) => {
+                      const conditionFieldLabel = formatConditionFieldLabel(condition.field);
+                      return (
+                        <span
+                          key={condition.id}
+                          role="listitem"
+                          className={
+                            [
+                              "cv-query-filter-pill",
+                              condition.id === activeCondition?.id ? "cv-query-filter-pill--active" : "",
+                              condition.disabled ? "cv-query-filter-pill--disabled" : ""
+                            ]
+                              .filter(Boolean)
+                              .join(" ")
+                          }
+                        >
+                          <button
+                            type="button"
+                            className="cv-query-filter-pill__main"
+                            onClick={() => openEditConditionModal(condition.id)}
+                            title={`${conditionFieldLabel} ${condition.operator} ${formatConditionSummaryValue(condition.value)}`}
+                          >
+                            <strong>{conditionFieldLabel}</strong>
+                            <em>{condition.operator}</em>
+                            <span>{formatConditionSummaryValue(condition.value)}</span>
+                          </button>
+                          <EuiToolTip content={condition.disabled ? "Enable condition" : "Disable condition"}>
+                            <button
+                              type="button"
+                              className="cv-query-filter-pill__toggle"
+                              aria-label={`${condition.disabled ? "Enable" : "Disable"} condition ${conditionFieldLabel}`}
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                toggleConditionDisabled(condition);
+                              }}
+                            >
+                              <EuiIcon type={condition.disabled ? "eye" : "eyeClosed"} size="s" aria-hidden="true" />
+                            </button>
+                          </EuiToolTip>
+                          <button
+                            type="button"
+                            className="cv-query-filter-pill__remove"
+                            aria-label={`Remove condition ${conditionFieldLabel}`}
+                            title="Remove condition"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              removeConditionAndRun(condition.id);
+                            }}
+                          >
+                            <EuiIcon type="cross" size="s" aria-hidden="true" />
+                          </button>
+                        </span>
+                      );
+                    })}
+                  </div>
+                ) : null}
+                {canShowQueryPreview ? (
+                  <div className="cv-query-builder__preview-wrap">
+                    <EuiPopover
+                      anchorPosition="downLeft"
+                      button={
+                        <button
+                          type="button"
+                          className="cv-query-builder__preview-trigger"
+                          onClick={() => setQueryPreviewOpen((current) => !current)}
+                          aria-expanded={queryPreviewOpen}
+                          aria-haspopup="dialog"
+                        >
+                          <EuiIcon type="inspect" size="s" aria-hidden="true" />
+                          <span>Inspect SQL</span>
+                        </button>
+                      }
+                      closePopover={() => setQueryPreviewOpen(false)}
+                      isOpen={queryPreviewOpen}
+                      ownFocus={false}
+                      panelClassName="cv-query-preview-popover-panel"
+                      panelPaddingSize="none"
+                      repositionOnScroll
+                    >
+                      <div className="cv-query-builder__preview" role="dialog" aria-label="SQL preview">
+                        <code>{queryPreview}</code>
+                        {canUseQueryPreview ? (
+                          <div className="cv-query-builder__preview-actions">
+                            <button
+                              type="button"
+                              className="cv-query-builder__preview-action"
+                              onClick={() => void copyQueryPreview()}
+                            >
+                              Copy
+                            </button>
+                            {workspace.conditions.length > 0 ? (
+                              <button
+                                type="button"
+                                className="cv-query-builder__preview-action cv-query-builder__preview-action--primary"
+                                onClick={convertConditionsToManualSql}
+                              >
+                                Use as SQL
+                              </button>
+                            ) : null}
+                          </div>
+                        ) : null}
+                      </div>
+                    </EuiPopover>
+                  </div>
+                ) : null}
+              </div>
+
             </div>
 
             {feedbackMessage ? (
@@ -2652,367 +7477,575 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
           </section>
 
           <div className="cv-query-workspace">
-            <section aria-label="直方图" className="cv-panel cv-query-panel">
-        <div className="cv-panel-header">
-          <div>
-            <h2 className="cv-panel-title">时间分布</h2>
-          </div>
-          {workspace.chartLoading ? <span className="cv-query-panel__status">加载中...</span> : null}
-        </div>
-        {workspace.charts.length > 0 ? (
-          <div className="cv-query-histogram">
-            <div className="cv-query-histogram__y-axis" aria-hidden="true">
-              <span>{formatCount(chartAxisMax)}</span>
-              <span>0</span>
-            </div>
-            <div className="cv-query-histogram__plot">
-              {workspace.charts.map((item) => {
-                const hasCount = item.count > 0;
-                return (
-                  <div key={`${item.from}-${item.to}`} className="cv-query-histogram__item">
-                    <span className="cv-query-histogram__value">{hasCount ? formatCount(item.count) : ""}</span>
-                    <button
-                      type="button"
-                      title={
-                        hasCount
-                          ? `${formatTimeAxisLabel(item.from)} - ${formatTimeAxisLabel(item.to)}：${formatCount(item.count)} 条`
-                          : undefined
-                      }
-                      onClick={() => {
-                        if (hasCount) {
-                          const nextRange = [new Date(item.from * 1000), new Date(item.to * 1000)] as [Date, Date];
-                          setTimeRange(nextRange);
-                          void workspace.runQuery(1, { st: item.from, et: item.to });
-                        }
-                      }}
-                      className={hasCount ? "cv-query-histogram__bar" : "cv-query-histogram__bar cv-query-histogram__bar--empty"}
-                      aria-disabled={!hasCount}
-                      tabIndex={hasCount ? 0 : -1}
-                      style={{
-                        height: hasCount ? `${Math.max(12, Math.round((item.count / chartAxisMax) * 72))}px` : "0px"
-                      }}
-                    />
-                    <span className="cv-query-histogram__axis">{formatTimeAxisLabel(item.from)}</span>
-                  </div>
-                );
-              })}
-              <div className="cv-query-histogram__baseline" aria-hidden="true" />
-            </div>
-          </div>
-        ) : (
-          <div className="cv-query-empty-text cv-query-empty-text--spaced">暂无分布</div>
-        )}
-            </section>
-
-            <section aria-label="查询结果" className="cv-panel cv-query-panel">
-        <div className="cv-panel-header">
-          <div>
-            <h2 className="cv-panel-title">查询结果</h2>
-          </div>
-          {workspace.logs ? (
-            <div className="cv-query-result-meta">
-              <span>共 {formatCount(workspace.logs.count)} 条结果</span>
-              <span>耗时 {workspace.logs.cost} ms</span>
-            </div>
-          ) : null}
-        </div>
-        <div className="cv-query-result-tools">
-          <div className="cv-query-column-config">
-            <button
-              type="button"
-              className="cv-secondary-button"
-              onClick={() => setResultColumnSelectorOpen((current) => !current)}
+            <section
+              aria-label="Histogram"
+              className={
+                [
+                  "cv-panel cv-query-panel cv-query-panel--histogram",
+                  histogramCollapsed ? "cv-query-panel--histogram-collapsed" : "",
+                  isHistogramEmptyPanel ? "cv-query-panel--workspace-empty" : ""
+                ]
+                  .filter(Boolean)
+                  .join(" ")
+              }
             >
-              列配置
-            </button>
-            {resultColumnSelectorOpen ? (
-              <div className="cv-query-column-config__panel" role="dialog" aria-label="结果列配置">
-                <div className="cv-query-column-config__header">
-                  <strong>显示字段</strong>
-                  <button type="button" className="cv-link-button" onClick={resetResultColumns}>
-                    恢复默认
-                  </button>
-                </div>
-                <div className="cv-query-column-config__list">
-                  {resultColumnOptions.map((item) => (
-                    <label key={item.key} className="cv-query-column-config__item">
-                      <input
-                        type="checkbox"
-                        checked={resultColumnKeys.includes(item.key)}
-                        onChange={() => toggleResultColumn(item.key)}
-                      />
-                      <span>{item.label}</span>
-                      <em>{item.kind === "builtin" ? "摘要" : "字段"}</em>
-                    </label>
-                  ))}
-                </div>
-              </div>
-            ) : null}
-          </div>
-        </div>
-        {workspace.errorMessage ? (
-          <div role="alert" className="cv-query-alert">
-            {workspace.errorMessage}
-          </div>
-        ) : null}
-
-        {!workspace.errorMessage && workspace.logs && workspace.logs.logs.length > 0 ? (
-          <div className="cv-query-result-stack">
-            <TraceTimeline groups={traceGroups} />
-            <table className="cv-query-result-table">
-                <thead>
-                  <tr>
-                    {visibleResultColumns.map((column) => (
-                      <th key={column.key}>{column.label}</th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {normalizedLogRows.map((row, index) => (
-                    <Fragment key={`${index}-${row.timeText}`}>
-                      <tr
-                        className={
-                          expandedLogIndex === index
-                            ? "cv-query-result-table__row cv-query-result-table__row--active"
-                            : "cv-query-result-table__row"
-                        }
-                        tabIndex={0}
-                        aria-expanded={expandedLogIndex === index}
-                        onClick={() => toggleExpandedLog(index)}
+              {hasHistogramToolbar ? (
+                <div
+                  className={
+                    histogramSelectionRange
+                      ? "cv-query-histogram-toolbar cv-query-histogram-toolbar--selection"
+                      : "cv-query-histogram-toolbar"
+                  }
+                >
+                  <div className="cv-query-histogram-toolbar__primary">
+                    <div className="cv-query-histogram-summary" aria-live="polite">
+                      {histogramSelectionRange ? (
+                        <span className="cv-query-histogram-selection-summary">
+                          <strong>
+                            {formatCount(histogramSelectionRange.count)} {formatHitsLabel(histogramSelectionRange.count)}
+                          </strong>
+                          <span>{formatHistogramTooltipRange(histogramSelectionRange.from, histogramSelectionRange.to)}</span>
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+                  <div className="cv-query-histogram-actions" aria-label="Chart controls">
+                    {histogramSelectionRange ? (
+                      <div
+                        className="cv-query-histogram-selection-actions"
+                        aria-label="Selected range controls"
                         onKeyDown={(event) => {
-                          if (event.key === "Enter" || event.key === " ") {
+                          if (event.key === "Escape") {
                             event.preventDefault();
-                            toggleExpandedLog(index);
+                            event.stopPropagation();
+                            clearHistogramSelection();
                           }
                         }}
                       >
-                        {visibleResultColumns.map((column) => {
-                          const value = formatResultColumnValue(row, column);
-                          const cellClassName = [
-                            column.key === "__level" || column.key === "lv" ? "cv-query-result-table__level" : "",
-                            value.empty ? "cv-query-result-table__empty" : ""
-                          ]
-                            .filter(Boolean)
-                            .join(" ");
-                          return (
-                            <td
-                              key={column.key}
-                              className={cellClassName || undefined}
+                        <button
+                          type="button"
+                          className="cv-query-histogram-action cv-query-histogram-action--primary"
+                          onClick={applyHistogramSelectionRange}
+                          disabled={workspace.loading || workspace.chartLoading}
+                        >
+                          <EuiIcon type="magnifyWithPlus" size="s" aria-hidden="true" />
+                          Zoom in
+                        </button>
+                        <button
+                          type="button"
+                          className="cv-query-histogram-action cv-query-histogram-action--muted"
+                          onClick={clearHistogramSelection}
+                          disabled={workspace.loading || workspace.chartLoading}
+                        >
+                          <EuiIcon type="cross" size="s" aria-hidden="true" />
+                          Cancel
+                        </button>
+                      </div>
+                    ) : null}
+                    {!histogramSelectionRange && hasHistogramChartData ? (
+                      <label className="cv-query-histogram-interval">
+                        <span className="cv-sr-only">Interval</span>
+                        <EuiSuperSelect<HistogramIntervalValue>
+                          compressed
+                          aria-label="Histogram interval"
+                          className="cv-query-histogram-interval__select"
+                          valueOfSelected={histogramInterval}
+                          options={histogramIntervalSelectOptions}
+                          onChange={changeHistogramInterval}
+                          disabled={workspace.chartLoading}
+                          itemClassName="cv-query-histogram-interval__item"
+                          popoverProps={{
+                            panelClassName: "cv-query-histogram-interval__panel",
+                            repositionOnScroll: true
+                          }}
+                        />
+                      </label>
+                    ) : null}
+                    {timeRangeHistory.length > 0 ? (
+                      <HistogramIconAction
+                        label="Back"
+                        icon="editorUndo"
+                        onClick={restorePreviousHistogramTimeRange}
+                        disabled={workspace.loading || workspace.chartLoading}
+                        showLabel
+                      />
+                    ) : null}
+                    {!histogramSelectionRange && timeRange && hasHistogramChartData ? (
+                      <HistogramIconAction
+                        label="Zoom out"
+                        icon="magnifyWithMinus"
+                        onClick={zoomOutHistogramTimeRange}
+                        disabled={workspace.loading || workspace.chartLoading}
+                        showLabel
+                      />
+                    ) : null}
+                    {canToggleHistogram && !histogramSelectionRange ? (
+                      <HistogramIconAction
+                        label={histogramCollapsed ? "Show chart" : "Hide chart"}
+                        icon={histogramCollapsed ? "visBarVerticalStacked" : "eyeClosed"}
+                        onClick={() => {
+                          setHistogramCollapsed((current) => !current);
+                          clearHistogramSelection();
+                        }}
+                        muted
+                        ariaExpanded={!histogramCollapsed}
+                      />
+                    ) : null}
+                  </div>
+                </div>
+              ) : null}
+              {canShowHistogramChart ? (
+                <div className="cv-query-histogram">
+                  <Chart
+                    key={histogramChartKey}
+                    renderer="svg"
+                    size={{ height: HISTOGRAM_HEIGHT, width: "100%" }}
+                    className="cv-query-histogram__chart"
+                  >
+                    <Settings
+                      ariaLabel="Log time distribution"
+                      brushAxis={BrushAxis.X}
+                      minBrushDelta={2}
+                      roundHistogramBrushValues
+                      allowBrushingLastHistogramBin
+                      showLegend={false}
+                      theme={HISTOGRAM_CHART_THEME}
+                      xDomain={histogramXDomain}
+                      onBrushEnd={handleHistogramBrushEnd}
+                      onElementClick={handleHistogramElementClick}
+                    />
+                    <Tooltip
+                      type={TooltipType.VerticalCursor}
+                      customTooltip={HistogramTooltip}
+                      headerFormatter={({ value }) => {
+                        const valueMs = Number(value);
+                        const datum = histogramChartData.find(
+                          (item) => valueMs >= item.from * 1000 && valueMs < item.to * 1000
+                        );
+                        return datum
+                          ? formatHistogramTooltipRange(datum.from, datum.to)
+                          : formatHistogramTooltipDate(Math.floor(valueMs / 1000));
+                      }}
+                    />
+                    <Axis
+                      id="bottom"
+                      position={Position.Bottom}
+                      tickFormat={(value) => formatHistogramTickLabel(Math.floor(Number(value) / 1000), chartSpanSeconds)}
+                      ticks={8}
+                      timeAxisLayerCount={0}
+                      style={HISTOGRAM_BOTTOM_AXIS_STYLE}
+                    />
+                    <Axis
+                      id="left"
+                      position={Position.Left}
+                      tickFormat={formatHistogramCountTickLabel}
+                      ticks={3}
+                      maximumFractionDigits={0}
+                      style={HISTOGRAM_LEFT_AXIS_STYLE}
+                    />
+                    {histogramSelectionRange ? (
+                      <RectAnnotation
+                        id="selected-time-range"
+                        dataValues={[
+                          {
+                            coordinates: {
+                              x0: histogramSelectionRange.from * 1000,
+                              x1: histogramSelectionRange.to * 1000
+                            },
+                            details: formatHistogramTooltipRange(histogramSelectionRange.from, histogramSelectionRange.to)
+                          }
+                        ]}
+                        hideTooltips
+                      />
+                    ) : null}
+                    <HistogramBarSeries
+                      id="records"
+                      name="records"
+                      data={histogramChartData}
+                      xAccessor="x"
+                      yAccessors={["count"]}
+                      xScaleType={ScaleType.Time}
+                      yScaleType={ScaleType.Linear}
+                      color={HISTOGRAM_BAR_COLOR}
+                      minBarHeight={2}
+                    />
+                  </Chart>
+                  {histogramSelectionRange && histogramSelectionOverlayStyle ? (
+                    <HistogramSelectionOverlay
+                      ref={histogramSelectionOverlayRef}
+                      range={histogramSelectionRange}
+                      style={histogramSelectionOverlayStyle}
+                      disabled={workspace.loading || workspace.chartLoading}
+                      onZoom={applyHistogramSelectionRange}
+                      onCancel={clearHistogramSelection}
+                    />
+                  ) : null}
+                </div>
+              ) : histogramCollapsed ? null : renderHistogramEmptyState()}
+            </section>
+
+            <section
+              aria-label="Query results"
+              className={
+                [
+                  "cv-panel cv-query-panel cv-query-panel--results",
+                  isResultEmptyPanel ? "cv-query-panel--workspace-empty" : ""
+                ]
+                  .filter(Boolean)
+                  .join(" ")
+              }
+            >
+              {resultBlockingErrorMessage ? (
+                <div role="alert" className="cv-query-alert">
+                  {resultBlockingErrorMessage}
+                </div>
+              ) : null}
+
+              {!resultBlockingErrorMessage && hasResultRows ? (
+                <div
+                  ref={resultStackRef}
+                  className="cv-query-result-stack"
+                  aria-busy={workspace.loading}
+                >
+                  <TraceTimeline groups={traceGroups} />
+                  <div
+                    className={
+                      workspace.loading
+                        ? "cv-query-result-table-shell cv-query-result-table-shell--refreshing"
+                        : "cv-query-result-table-shell"
+                    }
+                  >
+                    <div className="cv-query-result-bar">
+                      <div className="cv-query-result-bar__page">
+                        <span className="cv-query-result-bar__summary">
+                          {resultBarSummaryText}
+                          {shouldShowResultRangeSummary && hasResultKnownTotal ? <> <em>of {formatCount(resultTotalCount)}</em></> : null}
+                        </span>
+                        {resultLoadingControl}
+                        {resultToolbarPageSizeControl ? (
+                          <span className="cv-query-result-bar__page-size">
+                            {resultToolbarPageSizeControl}
+                          </span>
+                        ) : null}
+                        {resultBulkExpandControl ? (
+                          <span className="cv-query-result-bar__inline-action">
+                            {resultBulkExpandControl}
+                          </span>
+                        ) : null}
+                      </div>
+                      <div className="cv-query-result-actions" aria-label="Result actions">
+                        {resultToolbarPagerControls ? (
+                          <div className="cv-query-result-actions__group cv-query-result-actions__group--pagination">
+                            {resultToolbarPagerControls}
+                          </div>
+                        ) : null}
+                        <div className="cv-query-result-actions__group cv-query-result-actions__group--view">
+                          <div
+                            className={
+                              fieldCatalogOpen
+                                ? "cv-query-fields-panel-anchor cv-query-fields-panel-anchor--open"
+                                : "cv-query-fields-panel-anchor"
+                            }
+                            ref={fieldCatalogRef}
+                          >
+                            <EuiPopover
+                              anchorPosition="downRight"
+                              button={
+                                <EuiToolTip content="Fields" delay="long">
+                                  <button
+                                    type="button"
+                                    className="cv-query-result-action cv-query-result-action--text"
+                                    onClick={() => {
+                                      if (fieldCatalogOpen) {
+                                        closeFieldCatalogPanel();
+                                      } else {
+                                        setFieldCatalogOpen(true);
+                                      }
+                                    }}
+                                    aria-label="Fields"
+                                    aria-expanded={fieldCatalogOpen}
+                                    aria-haspopup="dialog"
+                                    title="Fields"
+                                  >
+                                    <span className="cv-query-result-action__label">Fields</span>
+                                  </button>
+                                </EuiToolTip>
+                              }
+                              closePopover={closeFieldCatalogPanel}
+                              display="inlineBlock"
+                              isOpen={fieldCatalogOpen}
+                              ownFocus={false}
+                              panelClassName="cv-query-fields-panel__popover-panel"
+                              panelPaddingSize="none"
+                              repositionOnScroll
                             >
-                              <span className="cv-query-truncate-text" title={value.text}>
-                                {truncate(value.text)}
-                              </span>
-                            </td>
-                          );
-                        })}
-                      </tr>
-                      {expandedLogIndex === index ? (
-                        <tr className="cv-query-result-table__detail-row">
-                          <td colSpan={visibleResultColumns.length}>
-                            <section
-                              aria-label="日志详情"
-                              className="cv-query-detail cv-query-detail--inline"
-                            >
-                              <div className="cv-query-detail__header">
-                                <div>
-                                  <strong>日志详情</strong>
-                                  <span>{Object.keys(row.parsed).length} 个字段</span>
-                                </div>
+                              {renderFieldCatalogPanel()}
+                            </EuiPopover>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+              <div
+                className="cv-query-result-table-header"
+                ref={resultTableHeaderScrollRef}
+                onWheel={handleResultTableHeaderWheel}
+              >
+                <table className="cv-query-result-table cv-query-result-table--header" style={{ minWidth: resultTableMinWidth }}>
+                  {renderResultTableColGroup()}
+                  {renderResultTableHeader()}
+                </table>
+              </div>
+              <div
+                className="cv-query-result-table-scroll"
+                ref={resultTableScrollRef}
+                onScroll={handleResultTableBodyScroll}
+              >
+                <table className="cv-query-result-table cv-query-result-table--body" style={{ minWidth: resultTableMinWidth }}>
+                  {renderResultTableColGroup()}
+                  <tbody>
+                    {normalizedLogRows.map((row, index) => {
+                    const isLogExpanded = expandedLogIndexes.has(index);
+                    const detailMessageEntry = getLogDetailMessageEntry(row);
+                    const detailMessageText = getLogDetailMessageText(row);
+                    const visibleLogDetailEntries = getVisibleLogDetailEntries(row);
+                    const primaryLogDetailEntries = visibleLogDetailEntries.filter(
+                      ([key, value]) => !isLowPriorityResultField(key) && !isPromotedLogDetailMessageField(key, value, detailMessageText)
+                    );
+                    const metadataLogDetailEntries = visibleLogDetailEntries.filter(
+                      ([key, value]) => isLowPriorityResultField(key) && !isPromotedLogDetailMessageField(key, value, detailMessageText)
+                    );
+                    const metadataExpanded = expandedLogMetadataIndexes.has(index);
+                    const renderLogDetailEntryRows = ([key, value]: [string, unknown]) => {
+                      const nestedEntries = scalarJsonEntries(key, value);
+                      const nestedToggleKey = `${index}:${key}`;
+                      const nestedExpanded = expandedLogNestedKeys.has(nestedToggleKey);
+                      return (
+                        <Fragment key={key}>
+                          <div className="cv-query-detail__row">
+                            {renderLogDetailFieldCell(row, key, value, {
+                              statsPreferRawLog: !isPresentLogValue(row.original[key])
+                            })}
+                            <span className="cv-query-detail__value-cell">
+                              {renderLogDetailValueCell(value)}
+                              {nestedEntries.length > 0 ? (
                                 <button
                                   type="button"
-                                  className="cv-secondary-button"
+                                  className="cv-query-detail__nested-toggle"
+                                  aria-expanded={nestedExpanded}
                                   onClick={(event) => {
                                     event.stopPropagation();
-                                    setExpandedLogDisplayMode((current) => (current === "json" ? "fields" : "json"));
+                                    toggleExpandedLogNestedField(index, key);
                                   }}
                                 >
-                                  {expandedLogDisplayMode === "json" ? "字段" : "JSON"}
+                                  {nestedExpanded ? "Hide fields" : formatFieldsCount(nestedEntries.length)}
                                 </button>
+                              ) : null}
+                            </span>
+                          </div>
+                          {nestedExpanded ? nestedEntries.map((nestedEntry) => {
+                            const nestedKey = nestedEntry.key;
+                            const nestedValue = nestedEntry.value;
+                            const nestedConditionField = nestedEntry.fieldRef?.fieldKey ?? nestedKey;
+                            return (
+                              <div key={`${key}.${nestedKey}`} className="cv-query-detail__row cv-query-detail__row--nested">
+                                {renderLogDetailFieldCell(row, nestedKey, nestedValue, {
+                                  title: `${key}.${nestedKey}`,
+                                  conditionField: nestedConditionField,
+                                  statsPreferRawLog: true,
+                                  statsFieldRef: nestedEntry.fieldRef
+                                })}
+                                {renderLogDetailValueCell(nestedValue)}
                               </div>
-                              {expandedLogDisplayMode === "json" ? (
-                                <pre className="cv-query-pre cv-query-detail__json">
-                                  {formatLogJsonPreview(row)}
-                                </pre>
-                              ) : (
-                                <div className="cv-query-detail__body">
-                                  {Object.entries(row.parsed).map(([key, value]) => {
-                                    const nestedEntries = scalarJsonEntries(key, value);
-                                    return (
-                                      <Fragment key={key}>
-                                        <div className="cv-query-detail__row">
-                                          <strong title={key}>
-                                            {canOpenFieldStats(key, value) ? (
-                                              <button
-                                                type="button"
-                                                className="cv-query-detail__key-button"
-                                                title={`查看 ${key} 的值分布`}
-                                                onClick={(event) => {
-                                                  event.stopPropagation();
-                                                  void openFieldStatsModal(key, value, !isPresentLogValue(row.original[key]));
-                                                }}
-                                              >
-                                                {key}
-                                              </button>
-                                            ) : (
-                                              key
-                                            )}
-                                          </strong>
-                                          {canCreateConditionFromDetailValue(key, value) ? (
-                                            <span className="cv-query-detail__value-actions">
-                                              <button
-                                                type="button"
-                                                className="cv-query-detail__value-button"
-                                                title={`查看 ${key} = ${formatLogDetailValue(value)} 的分布`}
-                                                onClick={(event) => {
-                                                  event.stopPropagation();
-                                                  if (isLogTimeField(key)) {
-                                                    addConditionFromLogDetail(key, value);
-                                                    return;
-                                                  }
-                                                  void openFieldStatsModal(key, value, !isPresentLogValue(row.original[key]));
-                                                }}
-                                              >
-                                                {formatLogDetailValue(value)}
-                                              </button>
-                                              <button
-                                                type="button"
-                                                className="cv-query-detail__link-button"
-                                                title={`添加条件：${key} = ${formatLogDetailValue(value)}`}
-                                                onClick={(event) => {
-                                                  event.stopPropagation();
-                                                  addConditionFromLogDetail(key, value);
-                                                }}
-                                              >
-                                                添加
-                                              </button>
-                                              {canStartAIAnalysisFromField(key, value) ? (
-                                                <button
-                                                  type="button"
-                                                  className="cv-query-detail__link-button"
-                                                  title={`用 ${key} 进行 AI 分析`}
-                                                  onClick={(event) => {
-                                                    event.stopPropagation();
-                                                    openLinkQueryModal(row, key, value);
-                                                  }}
-                                                >
-                                                  AI 分析
-                                                </button>
-                                              ) : null}
-                                            </span>
-                                          ) : (
-                                            <span className="cv-query-detail__value-text" title={formatLogDetailValue(value)}>
-                                              {formatLogDetailValue(value)}
-                                            </span>
-                                          )}
-                                        </div>
-                                        {nestedEntries.map((nestedEntry) => {
-                                          const nestedKey = nestedEntry.key;
-                                          const nestedValue = nestedEntry.value;
-                                          return (
-                                            <div key={`${key}.${nestedKey}`} className="cv-query-detail__row cv-query-detail__row--nested">
-                                              <strong title={`${key}.${nestedKey}`}>
-                                                <button
-                                                  type="button"
-                                                  className="cv-query-detail__key-button"
-                                                  title={`查看 ${nestedKey} 的值分布`}
-                                                  onClick={(event) => {
-                                                    event.stopPropagation();
-                                                    void openFieldStatsModal(nestedKey, nestedValue, true, nestedEntry.fieldRef);
-                                                  }}
-                                                >
-                                                  {nestedKey}
-                                                </button>
-                                              </strong>
-                                              <span className="cv-query-detail__value-actions">
-                                                <button
-                                                  type="button"
-                                                  className="cv-query-detail__value-button"
-                                                  title={`查看 ${nestedKey} = ${nestedValue} 的分布`}
-                                                  aria-label={`查看 JSON 字段 ${nestedKey} 的值分布`}
-                                                  onClick={(event) => {
-                                                    event.stopPropagation();
-                                                    void openFieldStatsModal(nestedKey, nestedValue, true, nestedEntry.fieldRef);
-                                                  }}
-                                                >
-                                                  {nestedValue}
-                                                </button>
-                                                <button
-                                                  type="button"
-                                                  className="cv-query-detail__link-button"
-                                                  aria-label={`从 JSON 添加条件 ${nestedKey} = ${nestedValue}`}
-                                                  title={`添加条件：${nestedKey} = ${nestedValue}`}
-                                                  onClick={(event) => {
-                                                    event.stopPropagation();
-                                                    addConditionFromLogDetail(nestedKey, nestedValue);
-                                                  }}
-                                                >
-                                                  添加
-                                                </button>
-                                                {canStartAIAnalysisFromField(nestedKey, nestedValue) ? (
-                                                  <button
-                                                    type="button"
-                                                    className="cv-query-detail__link-button"
-                                                    title={`用 ${nestedKey} 进行 AI 分析`}
-                                                    onClick={(event) => {
-                                                      event.stopPropagation();
-                                                      openLinkQueryModal(row, nestedKey, nestedValue);
-                                                    }}
-                                                  >
-                                                    AI 分析
-                                                  </button>
-                                                ) : null}
-                                              </span>
-                                            </div>
-                                          );
-                                        })}
-                                      </Fragment>
-                                    );
-                                  })}
-                                </div>
-                              )}
-                            </section>
+                            );
+                          }) : null}
+                        </Fragment>
+                      );
+                    };
+                    return (
+                      <Fragment key={`${index}-${row.timeText}`}>
+                        <tr
+                          className={
+                            isLogExpanded
+                              ? "cv-query-result-table__row cv-query-result-table__row--active"
+                              : "cv-query-result-table__row"
+                          }
+                          tabIndex={0}
+                          aria-expanded={isLogExpanded}
+                          onClick={() => toggleExpandedLog(index)}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter" || event.key === " ") {
+                              event.preventDefault();
+                              toggleExpandedLog(index);
+                            }
+                          }}
+                        >
+                          <td className="cv-query-result-table__toggle-cell">
+                            <button
+                              type="button"
+                              className="cv-query-result-table__toggle-button"
+                              aria-label={isLogExpanded ? "Collapse log details" : "Expand log details"}
+                              aria-expanded={isLogExpanded}
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                toggleExpandedLog(index);
+                              }}
+                              onKeyDown={(event) => {
+                                event.stopPropagation();
+                              }}
+                            >
+                              <EuiIcon type={isLogExpanded ? "arrowDown" : "arrowRight"} size="s" aria-hidden="true" />
+                            </button>
                           </td>
+                          {visibleResultColumns.map((column) => {
+                            const value = formatResultColumnValue(row, column);
+                            const isLevelColumn =
+                              column.key === "__level" || ["level", "lv", "severity", "log_level"].includes(column.key);
+                            const levelTone = isLevelColumn && !value.empty ? getLogLevelTone(value.text) : "";
+                            const cellClassName = [
+                              "cv-query-result-table__cell",
+                              getResultColumnLayoutClass(column.key),
+                              isLevelColumn ? "cv-query-result-table__level" : "",
+                              levelTone ? `cv-query-result-table__level--${levelTone}` : "",
+                              value.empty ? "cv-query-result-table__empty" : ""
+                            ]
+                              .filter(Boolean)
+                              .join(" ");
+                            return (
+                              <td
+                                key={column.key}
+                                className={cellClassName || undefined}
+                              >
+                                <span className="cv-query-truncate-text" title={value.text}>
+                                  {truncate(value.text, getResultColumnTextMaxLength(column.key))}
+                                </span>
+                              </td>
+                            );
+                          })}
                         </tr>
-                      ) : null}
-                    </Fragment>
-                  ))}
-                </tbody>
-            </table>
-            <div className="cv-query-pagination">
-              <span className="cv-query-empty-text">
-                第 {workspace.page} 页，每页 {workspace.pageSize} 条
-              </span>
-              <div className="cv-query-action-row">
-                <button
-                  type="button"
-                  className="cv-secondary-button"
-                  disabled={workspace.page <= 1 || workspace.loading}
-                  onClick={() => void workspace.runQuery(workspace.page - 1)}
-                >
-                  上一页
-                </button>
-                <button
-                  type="button"
-                  className="cv-secondary-button"
-                  disabled={workspace.loading || workspace.logs.logs.length < workspace.pageSize}
-                  onClick={() => void workspace.runQuery(workspace.page + 1)}
-                >
-                  下一页
-                </button>
+                        {isLogExpanded ? (
+                          <tr className="cv-query-result-table__detail-row">
+                            <td colSpan={visibleResultColumns.length + 1}>
+                              <section
+                                aria-label="Log details"
+                                className={`cv-query-detail cv-query-detail--inline cv-query-detail--${expandedLogDisplayMode}`}
+                              >
+                                <div className="cv-query-detail__header">
+                                  <div className="cv-query-detail__view-switch" role="tablist" aria-label="Log detail view">
+                                    <button
+                                      type="button"
+                                      role="tab"
+                                      aria-selected={expandedLogDisplayMode === "fields"}
+                                      className={
+                                        expandedLogDisplayMode === "fields"
+                                          ? "cv-query-detail__view cv-query-detail__view--active"
+                                          : "cv-query-detail__view"
+                                      }
+                                      onClick={(event) => {
+                                        event.stopPropagation();
+                                        setExpandedLogDisplayMode("fields");
+                                      }}
+                                    >
+                                      Fields
+                                    </button>
+                                    <button
+                                      type="button"
+                                      role="tab"
+                                      aria-selected={expandedLogDisplayMode === "json"}
+                                      className={
+                                        expandedLogDisplayMode === "json"
+                                          ? "cv-query-detail__view cv-query-detail__view--active"
+                                          : "cv-query-detail__view"
+                                      }
+                                      onClick={(event) => {
+                                        event.stopPropagation();
+                                        setExpandedLogDisplayMode("json");
+                                      }}
+                                    >
+                                      JSON
+                                    </button>
+                                  </div>
+                                  <div className="cv-query-detail__actions">
+                                    <button
+                                      type="button"
+                                      className="cv-query-detail__action"
+                                      onClick={(event) => {
+                                        event.stopPropagation();
+                                        void copyExpandedLog(row);
+                                      }}
+                                    >
+                                      <EuiIcon type="copyClipboard" size="s" aria-hidden="true" />
+                                      <span>Copy log</span>
+                                    </button>
+                                  </div>
+                                </div>
+                                {expandedLogDisplayMode === "json" ? (
+                                  <pre className="cv-query-pre cv-query-detail__json">
+                                    {formatLogJsonPreview(row)}
+                                  </pre>
+                                ) : (
+                                  <div className="cv-query-detail__body">
+                                    <div className="cv-query-detail__focus">
+                                      <div className="cv-query-detail__message">
+                                        {renderLogDetailFieldCell(row, detailMessageEntry.key, detailMessageEntry.value)}
+                                        <code title={detailMessageText}>{detailMessageText}</code>
+                                      </div>
+                                    </div>
+                                    <div className="cv-query-detail__fields">
+                                      {primaryLogDetailEntries.map(renderLogDetailEntryRows)}
+                                      {metadataLogDetailEntries.length > 0 ? (
+                                        <>
+                                          <div className="cv-query-detail__row cv-query-detail__row--metadata-toggle">
+                                            <strong className="cv-query-detail__field-cell">
+                                              <span className="cv-query-detail__key-text">Metadata</span>
+                                            </strong>
+                                            <button
+                                              type="button"
+                                              className="cv-query-detail__metadata-toggle"
+                                              aria-expanded={metadataExpanded}
+                                              onClick={(event) => {
+                                                event.stopPropagation();
+                                                toggleExpandedLogMetadata(index);
+                                              }}
+                                            >
+                                              {metadataExpanded ? "Hide fields" : `Show ${formatFieldsCount(metadataLogDetailEntries.length)}`}
+                                            </button>
+                                          </div>
+                                          {metadataExpanded ? metadataLogDetailEntries.map(renderLogDetailEntryRows) : null}
+                                        </>
+                                      ) : null}
+                                    </div>
+                                  </div>
+                                )}
+                              </section>
+                            </td>
+                          </tr>
+                        ) : null}
+                      </Fragment>
+                    );
+                    })}
+                  </tbody>
+                </table>
               </div>
+              {resultBodyLoadingOverlay}
+              {resultFooterPageSizeControl || resultFooterPagerControls ? (
+                <div className="cv-query-result-footer">
+                  <div className="cv-query-result-footer__meta">
+                    <span className="cv-query-result-footer__summary">
+                      {resultBarSummaryText}
+                      {shouldShowResultRangeSummary && hasResultKnownTotal ? (
+                        <em>of {formatCount(resultTotalCount)}</em>
+                      ) : null}
+                    </span>
+                    {resultFooterPageSizeControl}
+                  </div>
+                  {resultFooterPagerControls}
+                </div>
+              ) : null}
             </div>
           </div>
         ) : null}
 
-        {!workspace.errorMessage && workspace.logs && workspace.logs.logs.length === 0 ? (
-          <div className="cv-query-empty-text cv-query-empty-text--spaced">无结果</div>
-        ) : null}
-
-        {!workspace.errorMessage && !workspace.logs ? (
-          <div className="cv-query-empty-text cv-query-empty-text--spaced">
-            执行后显示结果
-          </div>
-        ) : null}
+        {!resultBlockingErrorMessage && (!workspace.logs || workspace.logs.logs.length === 0) ? renderResultEmptyState() : null}
             </section>
           </div>
         </div>
@@ -3028,132 +8061,83 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
       />
 
       {fieldStatsState ? (
-        <div className="cv-report-modal-backdrop" role="presentation" onClick={closeFieldStatsModal}>
-          <section
-            className="cv-report-modal cv-query-modal cv-query-field-stats-modal"
-            role="dialog"
-            aria-modal="true"
-            aria-label={`${fieldStatsState.field} 字段值分布`}
-            onClick={(event) => event.stopPropagation()}
-          >
-            <div className="cv-panel-header">
-              <div>
-                <h2 className="cv-panel-title">{fieldStatsState.field}</h2>
-                <p className="cv-panel-description">
-                  当前时间范围和筛选条件下的字段值占比
-                  {fieldStatsState.data ? ` · 非空 ${formatCount(fieldStatsState.data.total)} 条` : ""}
-                  {fieldStatsState.fieldRef.source !== "column" || !fieldStatsState.fieldRef.isAccelerated
-                    ? " · 来源日志内容字段"
-                    : " · 来源外层字段"}
-                  {" · 点击值加入搜索条件"}
-                </p>
-              </div>
-              <button type="button" className="cv-secondary-button" onClick={closeFieldStatsModal}>
-                关闭
-              </button>
-            </div>
-            <div className="cv-query-field-stats">
-              {fieldStatsState.loading ? <div className="cv-query-empty-text">统计中...</div> : null}
-              {fieldStatsState.error ? (
-                <div className="cv-query-alert" role="alert">{fieldStatsState.error}</div>
-              ) : null}
-              {!fieldStatsState.loading && !fieldStatsState.error && fieldStatsState.data?.items.length === 0 ? (
-                <div className="cv-query-empty-text">当前条件下没有非空字段值</div>
-              ) : null}
-              {fieldStatsState.data?.items.map((item) => (
-                <button
-                  key={`${item.value}-${item.count}`}
-                  type="button"
-                  className="cv-query-field-stats__item"
-                  title={
-                    fieldStatsState.fieldRef.source === "column" && fieldStatsState.fieldRef.isAccelerated
-                      ? `添加条件：${fieldStatsState.field} = ${item.value}`
-                      : `添加全局匹配：${item.value}`
-                  }
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    requestAddConditionFromFieldStatsValue(fieldStatsState.fieldRef, item.value);
-                  }}
-                >
-                  <span className="cv-query-field-stats__value">{item.value}</span>
-                  <span className="cv-query-field-stats__bar" aria-hidden="true">
-                    <span style={{ width: `${Math.max(item.percentage, 1)}%` }} />
-                  </span>
-                  <span className="cv-query-field-stats__meta">
-                    <strong>{formatPercentage(item.percentage)}</strong>
-                    <span>{formatCount(item.count)}</span>
-                  </span>
-                </button>
-              ))}
-            </div>
-          </section>
-        </div>
-      ) : null}
-
-      {fieldStatsConfirmState ? (
         <div
-          className="cv-report-modal-backdrop cv-query-confirm-backdrop"
+          className="cv-report-modal-backdrop cv-query-field-stats-backdrop"
           role="presentation"
-          onClick={() => setFieldStatsConfirmState(null)}
+          onClick={closeFieldStatsModal}
         >
           <section
-            className="cv-report-modal cv-query-field-stats-confirm"
+            ref={fieldStatsPanelRef}
+            className="cv-report-modal cv-query-modal cv-query-field-stats-modal"
             role="dialog"
-            aria-modal="true"
-            aria-label="确认加入搜索条件"
+            aria-modal="false"
+            aria-label={`${fieldStatsState.field} top values`}
             onClick={(event) => event.stopPropagation()}
           >
-            <div className="cv-query-field-stats-confirm__header">
+            <div className="cv-panel-header cv-query-field-stats__header">
               <div>
-                <h2 className="cv-panel-title">加入搜索条件</h2>
-                <p className="cv-panel-description">确认后会追加到当前查询条件中。</p>
+                <h2 className="cv-panel-title">{fieldStatsState.field}</h2>
+                <div className="cv-query-field-stats__meta-line" aria-label="Top values summary">
+                  <span>Top values</span>
+                  {modalFieldStatsView?.source ? <span>{modalFieldStatsView.source}</span> : null}
+                  {modalFieldStatsView && modalFieldStatsView.total > 0 ? (
+                    <span>{formatCount(modalFieldStatsView.total)}</span>
+                  ) : null}
+                </div>
               </div>
-              <button type="button" className="cv-secondary-button" onClick={() => setFieldStatsConfirmState(null)}>
-                关闭
-              </button>
-            </div>
-            <div className="cv-query-field-stats-confirm__body">
-              <div className="cv-query-field-stats-confirm__body-header">
-                <span>将加入</span>
+              <div className="cv-query-field-stats__header-actions">
+                {fieldStatsState.loading ? (
+                  <button
+                    type="button"
+                    className="cv-query-field-stats__cancel"
+                    onClick={closeFieldStatsModal}
+                    aria-label="Cancel top values query"
+                  >
+                    Cancel
+                  </button>
+                ) : null}
                 <button
                   type="button"
-                  className="cv-query-field-stats-confirm__copy"
-                  onClick={() => void copyFieldStatsConfirmText()}
+                  className="cv-query-field-stats__close"
+                  onClick={closeFieldStatsModal}
+                  aria-label="Close top values"
                 >
-                  复制全部
+                  <EuiIcon type="cross" size="s" aria-hidden="true" />
                 </button>
               </div>
-              <code title={fieldStatsConfirmState.actionText}>{fieldStatsConfirmState.actionText}</code>
             </div>
-            <div className="cv-query-modal__footer">
-              <button type="button" className="cv-secondary-button" onClick={() => setFieldStatsConfirmState(null)}>
-                取消
-              </button>
-              <button type="button" className="cv-action-button" onClick={confirmAddConditionFromFieldStatsValue}>
-                加入查询
-              </button>
-            </div>
+            {renderFieldStatsContent(fieldStatsState, modalFieldStatsView ?? undefined)}
           </section>
         </div>
       ) : null}
 
       {conditionModalOpen && conditionDraft ? (
-        <div className="cv-report-modal-backdrop" role="presentation" onClick={closeConditionModal}>
+        <div
+          className="cv-report-modal-backdrop cv-query-condition-modal-backdrop"
+          role="presentation"
+          onMouseDown={handleConditionModalBackdropMouseDown}
+          onClick={handleConditionModalBackdropClick}
+        >
           <section
             className="cv-report-modal cv-query-modal cv-query-condition-modal"
             role="dialog"
             aria-modal="true"
-            aria-label={conditionModalMode === "create" ? "新增条件" : "编辑条件"}
+            aria-label={conditionModalMode === "create" ? "Add condition" : "Edit condition"}
             onClick={(event) => event.stopPropagation()}
           >
-            <div className="cv-panel-header">
+            <div className="cv-panel-header cv-query-condition-modal__header">
               <div>
                 <h2 className="cv-panel-title">
-                  {conditionModalMode === "create" ? "新增条件" : "编辑条件"}
+                  {conditionModalMode === "create" ? "Add condition" : "Edit condition"}
                 </h2>
               </div>
-              <button type="button" className="cv-secondary-button" onClick={closeConditionModal}>
-                关闭
+              <button
+                type="button"
+                className="cv-query-condition-modal__close"
+                onClick={closeConditionModal}
+                aria-label="Close filter editor"
+              >
+                <EuiIcon type="cross" size="s" aria-hidden="true" />
               </button>
             </div>
             <div className="cv-query-condition-modal__body">
@@ -3167,135 +8151,60 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
                     }
                   }}
                 >
-                  字段
+                  Field
                   <button
                     id="query-condition-field-trigger"
                     type="button"
-                    aria-label="字段"
+                    aria-label="Field"
                     aria-expanded={fieldPickerOpen}
                     aria-haspopup="listbox"
                     className="cv-query-field-select__trigger"
                     role="combobox"
-                    onClick={() => setFieldPickerOpen((current) => !current)}
+                    onClick={() => {
+                      setInlineFieldPickerOpen(false);
+                      setFieldPickerOpen((current) => !current);
+                    }}
                   >
-                    <span>{conditionDraft.field || "未选字段"}</span>
+                    <span>{formatConditionFieldLabel(conditionDraft.field)}</span>
                     <span aria-hidden="true" className="cv-query-field-select__chevron">⌄</span>
                   </button>
                   {fieldPickerOpen ? (
-                    <div className="cv-query-field-picker" role="listbox" aria-label="字段候选">
-                      {conditionDraft.field &&
-                      !conditionFieldOptions.some((item) => item.field === conditionDraft.field) ? (
-                        <button
-                          type="button"
-                          role="option"
-                          aria-selected="true"
-                          className="cv-query-field-picker__option cv-query-field-picker__option--active"
-                          onMouseDown={(event) => event.preventDefault()}
-                          onClick={() => setFieldPickerOpen(false)}
-                        >
-                          <span className="cv-query-field-picker__name">{conditionDraft.field}</span>
-                          <span className="cv-query-field-picker__meta">
-                            <span>自定义字段</span>
-                            <span>JSON 路径查询</span>
-                          </span>
-                        </button>
-                      ) : null}
-                      {conditionFieldOptions.map((item) => (
-                        <button
-                          key={`field-${item.source}-${item.field}`}
-                          type="button"
-                          role="option"
-                          aria-selected={item.field === conditionDraft.field}
-                          className={
-                            item.field === conditionDraft.field
-                              ? "cv-query-field-picker__option cv-query-field-picker__option--active"
-                              : "cv-query-field-picker__option"
-                          }
-                          onMouseDown={(event) => event.preventDefault()}
-                          onClick={() => {
-                            handleConditionDraftFieldChange(item.field);
-                            setFieldPickerOpen(false);
-                          }}
-                        >
-                          <span className="cv-query-field-picker__name">{item.field}</span>
-                          <span className="cv-query-field-picker__meta">
-                            <span>{item.sourceLabel}</span>
-                            <span>{item.queryLabel}</span>
-                          </span>
-                        </button>
-                      ))}
-                    </div>
+                    <FieldPickerDropdown
+                      value={conditionDraft.field}
+                      options={conditionFieldOptions}
+                      onSelect={(field) => {
+                        handleConditionDraftFieldChange(field);
+                        setFieldPickerOpen(false);
+                      }}
+                      onClose={() => setFieldPickerOpen(false)}
+                    />
                   ) : null}
-                  <div className="cv-query-field-meta">
-                    {activeFieldOption ? (
-                      <>
-                        <span className="cv-query-field-meta__badge">{activeFieldOption.sourceLabel}</span>
-                        <span>{activeFieldOption.queryLabel}</span>
-                      </>
-                    ) : isGlobalMatchUnsupported ? (
-                      <span>当前日志表未配置日志内容字段，不能使用全局匹配</span>
-                    ) : (
-                      <span>未匹配字段目录，默认按 JSON 路径查询</span>
-                    )}
-                  </div>
                 </label>
 
-                <label className="cv-query-builder-form__field" htmlFor="query-condition-operator">
-                  运算符
-                  <select
-                    id="query-condition-operator"
+                <label className="cv-query-builder-form__field">
+                  Operator
+                  <QueryCompactSelect
                     value={conditionDraft.operator}
-                    onChange={(event) =>
+                    onChange={(operator) =>
                       setConditionDraft((current) =>
                         current
                           ? {
                               ...current,
-                              operator: event.target.value as (typeof queryOperatorOptions)[number]["value"]
+                              operator
                             }
                           : current
                       )
                     }
-                  >
-                    {queryOperatorOptions.map((item) => (
-                      <option key={`operator-${item.value}`} value={item.value}>
-                        {item.label}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-
-                <label className="cv-query-builder-form__field" htmlFor="query-condition-value-type">
-                  值类型
-                  <select
-                    id="query-condition-value-type"
-                    value={conditionDraft.valueType}
-                    onChange={(event) =>
-                      setConditionDraft((current) =>
-                        current
-                          ? {
-                              ...current,
-                              valueType: event.target.value as (typeof queryValueTypeOptions)[number]["value"],
-                              operator:
-                                event.target.value !== "string" &&
-                                (current.operator === "like" || current.operator === "not like")
-                                  ? "="
-                                  : current.operator
-                            }
-                          : current
-                      )
-                    }
-                  >
-                    {queryValueTypeOptions.map((item) => (
-                      <option key={`value-type-${item.value}`} value={item.value}>
-                        {item.label}
-                      </option>
-                    ))}
-                  </select>
+                    options={conditionOperatorOptions}
+                    ariaLabel="Operator"
+                  />
                 </label>
 
                 <label className="cv-query-builder-form__field" htmlFor="query-condition-value">
-                  条件值
-                  <input
+                  Value
+                  <EuiFieldText
+                    compressed
+                    fullWidth
                     id="query-condition-value"
                     value={String(conditionDraft.value ?? "")}
                     onChange={(event) =>
@@ -3308,29 +8217,38 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
                           : current
                       )
                     }
-                    placeholder={conditionDraft.valueType === "number" ? "请输入数字" : "请输入筛选值"}
+                    placeholder={conditionDraft.valueType === "number" ? "number" : "value"}
+                    aria-label="Value"
                   />
                 </label>
               </div>
               <div className="cv-query-condition-modal__footer">
                 {conditionModalMode === "edit" ? (
-                  <button type="button" className="cv-secondary-button" onClick={deleteConditionFromModal}>
-                    删除条件
+                  <button
+                    type="button"
+                    className="cv-query-condition-modal__text-action cv-query-condition-modal__text-action--danger"
+                    onClick={deleteConditionFromModal}
+                  >
+                    Delete
                   </button>
                 ) : (
                   <span />
                 )}
                 <div className="cv-query-condition-modal__actions">
-                  <button type="button" className="cv-secondary-button" onClick={closeConditionModal}>
-                    取消
+                  <button
+                    type="button"
+                    className="cv-query-condition-modal__text-action"
+                    onClick={closeConditionModal}
+                  >
+                    Cancel
                   </button>
                   <button
                     type="button"
-                    className="cv-action-button"
+                    className="cv-query-condition-modal__text-action cv-query-condition-modal__text-action--primary"
                     onClick={saveConditionModal}
                     disabled={isGlobalMatchUnsupported}
                   >
-                    确认
+                    {conditionModalMode === "create" ? "Add" : "Save"}
                   </button>
                 </div>
               </div>
@@ -3340,51 +8258,61 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
       ) : null}
 
       {linkQueryAnchor ? (
-        <div className="cv-report-modal-backdrop" role="presentation" onClick={closeLinkQueryModal}>
+        <div
+          className="cv-report-modal-backdrop cv-query-link-modal-backdrop"
+          role="presentation"
+          onClick={closeLinkQueryModal}
+        >
           <section
+            ref={linkQueryPanelRef}
             className="cv-report-modal cv-query-modal cv-query-link-modal"
             role="dialog"
-            aria-modal="true"
-            aria-label="链路查询"
+            aria-modal="false"
+            aria-label="Correlate logs"
             onClick={(event) => event.stopPropagation()}
           >
-            <div className="cv-panel-header">
+            <div className="cv-panel-header cv-query-link-modal__header">
               <div>
-                <h2 className="cv-panel-title">链路查询</h2>
+                <h2 className="cv-panel-title">Correlate logs</h2>
               </div>
-              <button type="button" className="cv-secondary-button" onClick={closeLinkQueryModal}>
-                关闭
+              <button
+                type="button"
+                className="cv-query-link-modal__close"
+                onClick={closeLinkQueryModal}
+                aria-label="Close correlation"
+              >
+                <EuiIcon type="cross" size="s" aria-hidden="true" />
               </button>
             </div>
             <div className="cv-query-link-modal__body">
               <div className="cv-query-link-anchor">
-                <span>锚点字段</span>
-                <strong>{linkQueryAnchor.field}</strong>
-                <span>锚点值</span>
-                <code>{linkQueryAnchor.value}</code>
+                <div>
+                  <span>Field</span>
+                  <strong>{linkQueryAnchor.field}</strong>
+                </div>
+                <div>
+                  <span>Value</span>
+                  <code>{linkQueryAnchor.value}</code>
+                </div>
               </div>
-              <label className="cv-query-builder-form__field" htmlFor="query-link-window">
-                时间窗口
-                <select
-                  id="query-link-window"
-                  value={linkQueryWindowMinutes}
-                  onChange={(event) => setLinkQueryWindowMinutes(Number(event.target.value))}
-                >
-                  <option value={1}>前后 1 分钟</option>
-                  <option value={5}>前后 5 分钟</option>
-                  <option value={15}>前后 15 分钟</option>
-                  <option value={30}>前后 30 分钟</option>
-                </select>
+              <label className="cv-query-builder-form__field cv-query-link-window">
+                Time window
+                <QueryCompactSelect
+                  value={String(linkQueryWindowMinutes)}
+                  onChange={(value) => setLinkQueryWindowMinutes(Number(value))}
+                  options={linkQueryWindowOptions}
+                  ariaLabel="Time window"
+                />
               </label>
-              <div className="cv-query-link-table-picker" role="group" aria-label="选择日志表">
+              <div className="cv-query-link-table-picker" role="group" aria-label="Select log tables">
                 <div className="cv-query-link-table-picker__header">
-                  <strong>查询日志表</strong>
+                  <strong>Tables</strong>
                   <button
                     type="button"
-                    className="cv-link-button"
+                    className="cv-query-link-modal__text-action"
                     onClick={() => setLinkQuerySelectedTableIds(linkQueryTableOptions.map((item) => item.id))}
                   >
-                    全选
+                    Select all
                   </button>
                 </div>
                 <div className="cv-query-link-table-picker__list">
@@ -3401,11 +8329,19 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
                 </div>
               </div>
               <div className="cv-query-modal__footer">
-                <button type="button" className="cv-secondary-button" onClick={closeLinkQueryModal}>
-                  取消
+                <button
+                  type="button"
+                  className="cv-query-link-modal__text-action"
+                  onClick={closeLinkQueryModal}
+                >
+                  Cancel
                 </button>
-                <button type="button" className="cv-action-button" onClick={openLinkQueryPage}>
-                  打开链路查询
+                <button
+                  type="button"
+                  className="cv-query-link-modal__text-action cv-query-link-modal__text-action--primary"
+                  onClick={openLinkQueryPage}
+                >
+                  Open correlation
                 </button>
               </div>
             </div>
@@ -3435,46 +8371,60 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
       />
       {saveQueryModalOpen ? (
         <div
-          className="cv-report-modal-backdrop"
+          className="cv-report-modal-backdrop cv-query-save-modal-backdrop"
           role="presentation"
           onClick={() => setSaveQueryModalOpen(false)}
         >
           <section
-            className="cv-report-modal cv-query-modal"
+            className="cv-report-modal cv-query-modal cv-query-save-modal"
             role="dialog"
             aria-modal="true"
-            aria-label="保存查询"
+            aria-label="Save query"
             onClick={(event) => event.stopPropagation()}
           >
-            <div className="cv-panel-header">
+            <div className="cv-panel-header cv-query-save-modal__header">
               <div>
-                <h2 className="cv-panel-title">保存查询</h2>
+                <h2 className="cv-panel-title">Save query</h2>
               </div>
-              <button type="button" className="cv-secondary-button" onClick={() => setSaveQueryModalOpen(false)}>
-                关闭
+              <button
+                type="button"
+                className="cv-query-save-modal__close"
+                onClick={() => setSaveQueryModalOpen(false)}
+                aria-label="Close save query"
+              >
+                <EuiIcon type="cross" size="s" aria-hidden="true" />
               </button>
             </div>
-            <div className="cv-form-grid cv-query-modal__form">
-              <label className="cv-query-field">
-                <span className="cv-query-label">收藏名称</span>
-                <input
-                  className="cv-input"
+            <div className="cv-query-save-modal__body">
+              <label className="cv-query-save-modal__field">
+                <span>Name</span>
+                <EuiFieldText
+                  compressed
+                  fullWidth
                   value={saveQueryName}
                   onChange={(event) => setSaveQueryName(event.target.value)}
-                  placeholder="例如：错误日志排查"
-                  aria-label="收藏名称"
+                  placeholder="Error investigation"
+                  aria-label="Query name"
                 />
               </label>
-              <div className="cv-query-builder__preview">
-                <strong>保存内容</strong>
+              <div className="cv-query-save-modal__preview">
+                <strong>SQL</strong>
                 <code>{queryPreview}</code>
               </div>
               <div className="cv-query-modal__footer">
-                <button type="button" className="cv-secondary-button" onClick={() => setSaveQueryModalOpen(false)}>
-                  取消
+                <button
+                  type="button"
+                  className="cv-query-save-modal__text-action"
+                  onClick={() => setSaveQueryModalOpen(false)}
+                >
+                  Cancel
                 </button>
-                <button type="button" className="cv-action-button" onClick={() => void handleSaveQuery()}>
-                  保存
+                <button
+                  type="button"
+                  className="cv-query-save-modal__text-action cv-query-save-modal__text-action--primary"
+                  onClick={() => void handleSaveQuery()}
+                >
+                  Save
                 </button>
               </div>
             </div>
@@ -3483,34 +8433,43 @@ export default function QueryPage({ shareMode = false }: { shareMode?: boolean }
       ) : null}
       {confirmState ? (
         <div
-          className="cv-report-modal-backdrop"
+          className="cv-report-modal-backdrop cv-query-confirm-modal-backdrop"
           role="presentation"
           onClick={() => setConfirmState(null)}
         >
           <section
-            className="cv-report-modal cv-query-modal"
+            className="cv-report-modal cv-query-modal cv-query-confirm-modal"
             role="dialog"
             aria-modal="true"
             aria-label={confirmState.title}
             onClick={(event) => event.stopPropagation()}
           >
-            <div className="cv-panel-header">
+            <div className="cv-panel-header cv-query-confirm-modal__header">
               <div>
                 <h2 className="cv-panel-title">{confirmState.title}</h2>
               </div>
-              <button type="button" className="cv-secondary-button" onClick={() => setConfirmState(null)}>
-                关闭
+              <button
+                type="button"
+                className="cv-query-confirm-modal__close"
+                onClick={() => setConfirmState(null)}
+                aria-label="Close confirmation"
+              >
+                <EuiIcon type="cross" size="s" aria-hidden="true" />
               </button>
             </div>
-            <div className="cv-form-grid cv-query-modal__form">
+            <div className="cv-query-confirm-modal__body">
               <div className="cv-query-confirm__content">{confirmState.content}</div>
               <div className="cv-query-modal__footer">
-                <button type="button" className="cv-secondary-button" onClick={() => setConfirmState(null)}>
-                  取消
+                <button
+                  type="button"
+                  className="cv-query-confirm-modal__text-action"
+                  onClick={() => setConfirmState(null)}
+                >
+                  Cancel
                 </button>
                 <button
                   type="button"
-                  className="cv-action-button cv-action-button--danger"
+                  className="cv-query-confirm-modal__text-action cv-query-confirm-modal__text-action--danger"
                   onClick={() => {
                     void confirmState.onConfirm().finally(() => setConfirmState(null));
                   }}

--- a/ui-v2/src/main.tsx
+++ b/ui-v2/src/main.tsx
@@ -1,20 +1,126 @@
 import ReactDOM from "react-dom/client";
+import type { ReactNode } from "react";
+import { EuiContext, EuiProvider } from "@elastic/eui";
 import { RouterProvider } from "react-router-dom";
 import { CustomProvider } from "rsuite";
 import zhCN from "rsuite/locales/zh_CN";
+import moment from "moment";
+import "moment/locale/zh-cn";
 import { router } from "./app/router";
 import { getPublicPathLoginRedirectHref } from "./shared/layout/VersionSwitcher";
 import "rsuite/dist/rsuite-no-reset.min.css";
+import "@elastic/charts/dist/theme_only_light.css";
 import "./styles.css";
 
+moment.locale("zh-cn");
+
 const publicPathRedirectHref = getPublicPathLoginRedirectHref();
+const euiI18n = {
+  locale: "en",
+  mapping: {
+    "euiTimeWindowButtons.previousDescription": ({ displayInterval }: Record<string, unknown>) =>
+      `Shift backward ${displayInterval ?? ""}`,
+    "euiTimeWindowButtons.nextDescription": ({ displayInterval }: Record<string, unknown>) =>
+      `Shift forward ${displayInterval ?? ""}`,
+    "euiTimeWindowButtons.invalidShiftLabel": "Cannot shift an invalid time window",
+    "euiTimeWindowButtons.invalidZoomInLabel": "Cannot zoom in on an invalid time window",
+    "euiTimeWindowButtons.cannotZoomInLabel": "Cannot zoom in any further",
+    "euiTimeWindowButtons.invalidZoomOutLabel": "Cannot zoom out on an invalid time window",
+    "euiTimeWindowButtons.previousLabel": "Previous",
+    "euiTimeWindowButtons.zoomInLabel": "Zoom in",
+    "euiTimeWindowButtons.zoomOutLabel": "Zoom out",
+    "euiTimeWindowButtons.nextLabel": "Next",
+    "euiQuickSelectPopover.buttonLabel": "Select time range",
+    "euiQuickSelect.quickSelectTitle": "Quick select",
+    "euiQuickSelect.previousLabel": "Previous time window",
+    "euiQuickSelect.nextLabel": "Next time window",
+    "euiQuickSelect.tenseLabel": "Time direction",
+    "euiQuickSelect.valueLabel": "Time value",
+    "euiQuickSelect.unitLabel": "Time unit",
+    "euiQuickSelect.applyButton": "Apply",
+    "euiQuickSelect.fullDescription": ({ timeTense, timeValue, timeUnit }: Record<string, unknown>) =>
+      `Current setting is ${timeTense ?? ""} ${timeValue ?? ""} ${timeUnit ?? ""}`,
+    "euiCommonlyUsedTimeRanges.legend": "Commonly used",
+    "euiTimeOptions.last": "Last",
+    "euiTimeOptions.next": "Next",
+    "euiTimeOptions.seconds": "seconds",
+    "euiTimeOptions.minutes": "minutes",
+    "euiTimeOptions.hours": "hours",
+    "euiTimeOptions.days": "days",
+    "euiTimeOptions.weeks": "weeks",
+    "euiTimeOptions.months": "months",
+    "euiTimeOptions.years": "years",
+    "euiTimeOptions.secondsAgo": "seconds ago",
+    "euiTimeOptions.minutesAgo": "minutes ago",
+    "euiTimeOptions.hoursAgo": "hours ago",
+    "euiTimeOptions.daysAgo": "days ago",
+    "euiTimeOptions.weeksAgo": "weeks ago",
+    "euiTimeOptions.monthsAgo": "months ago",
+    "euiTimeOptions.yearsAgo": "years ago",
+    "euiTimeOptions.secondsFromNow": "seconds from now",
+    "euiTimeOptions.minutesFromNow": "minutes from now",
+    "euiTimeOptions.hoursFromNow": "hours from now",
+    "euiTimeOptions.daysFromNow": "days from now",
+    "euiTimeOptions.weeksFromNow": "weeks from now",
+    "euiTimeOptions.monthsFromNow": "months from now",
+    "euiTimeOptions.yearsFromNow": "years from now",
+    "euiTimeOptions.roundToSecond": "Round to the second",
+    "euiTimeOptions.roundToMinute": "Round to the minute",
+    "euiTimeOptions.roundToHour": "Round to the hour",
+    "euiTimeOptions.roundToDay": "Round to the day",
+    "euiTimeOptions.roundToWeek": "Round to the week",
+    "euiTimeOptions.roundToMonth": "Round to the month",
+    "euiTimeOptions.roundToYear": "Round to the year",
+    "euiPrettyDuration.lastDurationSeconds": ({ duration }: Record<string, unknown>) => `Last ${duration ?? ""} seconds`,
+    "euiPrettyDuration.nextDurationSeconds": ({ duration }: Record<string, unknown>) => `Next ${duration ?? ""} seconds`,
+    "euiPrettyDuration.lastDurationMinutes": ({ duration }: Record<string, unknown>) => `Last ${duration ?? ""} minutes`,
+    "euiPrettyDuration.nextDurationMinutes": ({ duration }: Record<string, unknown>) => `Next ${duration ?? ""} minutes`,
+    "euiPrettyDuration.lastDurationHours": ({ duration }: Record<string, unknown>) => `Last ${duration ?? ""} hours`,
+    "euiPrettyDuration.nextDurationHours": ({ duration }: Record<string, unknown>) => `Next ${duration ?? ""} hours`,
+    "euiPrettyDuration.lastDurationDays": ({ duration }: Record<string, unknown>) => `Last ${duration ?? ""} days`,
+    "euiPrettyDuration.nexttDurationDays": ({ duration }: Record<string, unknown>) => `Next ${duration ?? ""} days`,
+    "euiPrettyDuration.lastDurationWeeks": ({ duration }: Record<string, unknown>) => `Last ${duration ?? ""} weeks`,
+    "euiPrettyDuration.nextDurationWeeks": ({ duration }: Record<string, unknown>) => `Next ${duration ?? ""} weeks`,
+    "euiPrettyDuration.lastDurationMonths": ({ duration }: Record<string, unknown>) => `Last ${duration ?? ""} months`,
+    "euiPrettyDuration.nextDurationMonths": ({ duration }: Record<string, unknown>) => `Next ${duration ?? ""} months`,
+    "euiPrettyDuration.lastDurationYears": ({ duration }: Record<string, unknown>) => `Last ${duration ?? ""} years`,
+    "euiPrettyDuration.nextDurationYears": ({ duration }: Record<string, unknown>) => `Next ${duration ?? ""} years`,
+    "euiDatePopoverContent.startDateLabel": "Start date",
+    "euiDatePopoverContent.endDateLabel": "End date",
+    "euiDatePopoverContent.absoluteTabLabel": "Absolute",
+    "euiDatePopoverContent.relativeTabLabel": "Relative",
+    "euiDatePopoverContent.nowTabLabel": "Now",
+    "euiDatePopoverContent.nowTabContent":
+      "Setting the time to now means this value is recalculated on every refresh.",
+    "euiDatePopoverContent.nowTabButtonStart": "Set start date and time to now",
+    "euiDatePopoverContent.nowTabButtonEnd": "Set end date and time to now",
+    "euiRelativeTab.numberInputLabel": "Time span value",
+    "euiRelativeTab.numberInputError": "Must be greater than or equal to 0",
+    "euiRelativeTab.dateInputError": "Enter a valid time range",
+    "euiRelativeTab.unitInputLabel": "Relative time unit",
+    "euiRelativeTab.fullDescription": ({ unit }: Record<string, unknown>) => `Current unit is ${unit ?? ""}`,
+    "euiAbsoluteTab.dateFormatButtonLabel": "Parse date",
+    "euiAbsoluteTab.dateFormatError": ({ dateFormat }: { dateFormat?: ReactNode }) => (
+      <>Supported formats: {dateFormat}, ISO 8601, RFC 2822, or Unix timestamp.</>
+    ),
+    "euiSuperUpdateButton.updatingButtonLabel": "Updating",
+    "euiSuperUpdateButton.updateButtonLabel": "Update",
+    "euiSuperUpdateButton.refreshButtonLabel": "Refresh",
+    "euiSuperUpdateButton.cannotUpdateTooltip": "Cannot update",
+    "euiSuperUpdateButton.clickToApplyTooltip": "Click to apply"
+  }
+};
 
 if (publicPathRedirectHref) {
   window.location.replace(publicPathRedirectHref);
 } else {
   ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <CustomProvider locale={zhCN}>
-      <RouterProvider router={router} />
+      <EuiProvider colorMode="light" globalStyles={false} utilityClasses={false}>
+        <EuiContext i18n={euiI18n}>
+          <RouterProvider router={router} />
+        </EuiContext>
+      </EuiProvider>
     </CustomProvider>
   );
 }

--- a/ui-v2/src/shared/http/client.ts
+++ b/ui-v2/src/shared/http/client.ts
@@ -6,6 +6,10 @@ interface ApiEnvelope<T> {
   data: T;
 }
 
+export interface RequestOptions {
+  signal?: AbortSignal;
+}
+
 function buildApiUrl(path: string) {
   const basePath = getV2BasePath();
   return `${basePath}${path}`;
@@ -83,33 +87,38 @@ async function requestJson<T>(path: string, init: RequestInit): Promise<T> {
 }
 
 export const client = {
-  get<T>(path: string) {
+  get<T>(path: string, options?: RequestOptions) {
     return requestJson<T>(path, {
-      method: "GET"
+      method: "GET",
+      signal: options?.signal
     });
   },
-  post<T>(path: string, payload: unknown) {
+  post<T>(path: string, payload: unknown, options?: RequestOptions) {
     return requestJson<T>(path, {
       method: "POST",
-      body: JSON.stringify(payload)
+      body: JSON.stringify(payload),
+      signal: options?.signal
     });
   },
-  patch<T>(path: string, payload: unknown) {
+  patch<T>(path: string, payload: unknown, options?: RequestOptions) {
     return requestJson<T>(path, {
       method: "PATCH",
-      body: JSON.stringify(payload)
+      body: JSON.stringify(payload),
+      signal: options?.signal
     });
   },
-  put<T>(path: string, payload: unknown) {
+  put<T>(path: string, payload: unknown, options?: RequestOptions) {
     return requestJson<T>(path, {
       method: "PUT",
-      body: JSON.stringify(payload)
+      body: JSON.stringify(payload),
+      signal: options?.signal
     });
   },
-  delete<T>(path: string, payload?: unknown) {
+  delete<T>(path: string, payload?: unknown, options?: RequestOptions) {
     return requestJson<T>(path, {
       method: "DELETE",
-      body: payload === undefined ? undefined : JSON.stringify(payload)
+      body: payload === undefined ? undefined : JSON.stringify(payload),
+      signal: options?.signal
     });
   }
 };

--- a/ui-v2/src/shared/styles.css
+++ b/ui-v2/src/shared/styles.css
@@ -1,9 +1,7 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap");
-
 :root {
   color-scheme: light;
-  --cv-font-headline: "Space Grotesk", "Inter", -apple-system, BlinkMacSystemFont, "PingFang SC", sans-serif;
-  --cv-font-body: "Inter", -apple-system, BlinkMacSystemFont, "PingFang SC", sans-serif;
+  --cv-font-headline: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", "Helvetica Neue", Arial, sans-serif;
+  --cv-font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", "Helvetica Neue", Arial, sans-serif;
   --cv-surface: #faf8ff;
   --cv-surface-low: #f2f3ff;
   --cv-surface-high: #e2e7ff;

--- a/ui-v2/src/styles.css
+++ b/ui-v2/src/styles.css
@@ -1,10 +1,7 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;700&display=swap");
-
 :root {
   color-scheme: light;
-  font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans",
-    sans-serif;
+  --cv-font-ui: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+  font-family: var(--cv-font-ui);
   color: #1f2328;
   background: #f6f7f9;
   --cv-bg: #f6f7f9;
@@ -18,7 +15,11 @@
   --cv-text-soft: #6b7280;
   --cv-primary: #f97316;
   --cv-primary-strong: #ea580c;
+  --cv-primary-text: #c2410c;
+  --cv-primary-text-strong: #9a3412;
   --cv-primary-soft: #fff3e8;
+  --cv-primary-tint: color-mix(in srgb, var(--cv-primary) 8%, #ffffff);
+  --cv-primary-focus: color-mix(in srgb, var(--cv-primary) 22%, transparent);
   --cv-orange: var(--cv-primary);
   --cv-orange-strong: var(--cv-primary-strong);
   --cv-success: #16a34a;
@@ -237,7 +238,7 @@ textarea {
 
 .cv-shell__headline {
   margin: 0;
-  font-family: "Space Grotesk", sans-serif;
+  font-family: var(--cv-font-ui);
   font-size: clamp(32px, 5vw, 46px);
   line-height: 1;
   letter-spacing: -0.05em;
@@ -316,7 +317,7 @@ textarea {
 .cv-panel-title,
 .cv-stat-value,
 .cv-hero-number {
-  font-family: "Space Grotesk", sans-serif;
+  font-family: var(--cv-font-ui);
 }
 
 .cv-action-button,
@@ -456,8 +457,8 @@ textarea {
   justify-content: space-between;
   align-items: center;
   gap: 10px;
-  min-height: 30px;
-  margin-bottom: 6px;
+  min-height: 22px;
+  margin-bottom: 4px;
   padding: 0 2px;
 }
 
@@ -555,8 +556,8 @@ textarea {
 
 .cv-query-shell {
   display: grid;
-  grid-template-columns: 248px minmax(0, 1fr);
-  gap: 12px;
+  grid-template-columns: 240px minmax(0, 1fr);
+  gap: 10px;
   align-items: start;
 }
 
@@ -567,7 +568,7 @@ textarea {
 .cv-query-main,
 .cv-query-workspace {
   display: grid;
-  gap: 12px;
+  gap: 8px;
 }
 
 .cv-query-workspace {
@@ -832,35 +833,36 @@ textarea {
 
 .cv-context-menu {
   position: fixed;
-  z-index: 80;
-  min-width: 132px;
-  padding: 6px;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.98);
-  box-shadow:
-    0 18px 36px rgba(15, 23, 42, 0.14),
-    inset 0 0 0 1px var(--cv-border);
+  z-index: 2200;
   display: grid;
-  gap: 4px;
+  gap: 2px;
+  min-width: 148px;
+  padding: 4px;
+  border: 1px solid #d3dae6;
+  border-radius: 4px;
+  background: #ffffff;
+  box-shadow: 0 10px 24px rgba(52, 55, 65, 0.14);
 }
 
 .cv-context-menu__item {
   width: 100%;
-  min-height: 30px;
+  min-height: 28px;
   border: 0;
-  border-radius: 8px;
+  border-radius: 3px;
   background: transparent;
-  color: var(--cv-text);
+  color: #343741;
   text-align: left;
-  font-size: 12px;
+  font-size: 11.5px;
   font-weight: 600;
-  padding: 0 10px;
+  padding: 0 8px;
   cursor: pointer;
 }
 
-.cv-context-menu__item:hover {
-  background: var(--cv-primary-soft);
+.cv-context-menu__item:hover,
+.cv-context-menu__item:focus-visible {
+  background: var(--cv-primary-tint);
   color: var(--cv-primary-strong);
+  outline: none;
 }
 
 .cv-query-modal {
@@ -877,42 +879,130 @@ textarea {
   gap: 8px;
 }
 
-.cv-query-link-modal {
-  width: min(640px, calc(100vw - 32px));
+.cv-report-modal-backdrop.cv-query-link-modal-backdrop {
+  align-items: flex-start;
+  justify-content: flex-end;
+  padding: 92px 14px 16px;
+  background: transparent;
+  pointer-events: none;
+}
+
+.cv-report-modal.cv-query-link-modal {
+  width: min(380px, calc(100vw - 24px));
+  max-height: min(68vh, 520px);
+  overflow: hidden;
+  border: 1px solid #d8dee8;
+  border-radius: 4px;
+  background: #ffffff;
+  box-shadow: 0 8px 20px rgba(52, 55, 65, 0.12);
+  padding: 0;
+  pointer-events: auto;
+}
+
+.cv-query-link-modal__header {
+  align-items: center;
+  margin: 0;
+  border-bottom: 1px solid #e5e8ef;
+  background: #fbfcfd;
+  padding: 8px 10px 8px 12px;
+}
+
+.cv-query-link-modal__header .cv-panel-title {
+  color: #343741;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.cv-query-link-modal__close {
+  display: grid;
+  flex: 0 0 auto;
+  width: 26px;
+  height: 26px;
+  place-items: center;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #69707d;
+  cursor: pointer;
+  padding: 0;
+}
+
+.cv-query-link-modal__close:hover,
+.cv-query-link-modal__close:focus-visible {
+  background: #eef1f6;
+  color: #343741;
+  outline: none;
 }
 
 .cv-query-link-modal__body {
   display: grid;
-  gap: 12px;
-  margin-top: 12px;
+  gap: 10px;
+  max-height: calc(min(68vh, 520px) - 44px);
+  overflow: auto;
+  padding: 10px 12px 12px;
 }
 
 .cv-query-link-anchor {
   display: grid;
-  grid-template-columns: 72px minmax(0, 1fr);
-  gap: 6px 10px;
-  border: 1px solid rgba(148, 163, 184, 0.16);
-  border-radius: 8px;
-  background: #fffaf5;
-  padding: 8px;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 8px;
+  border-bottom: 1px solid #edf0f5;
+  padding: 0 0 9px;
   font-size: 12px;
 }
 
+.cv-query-link-anchor > div {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
 .cv-query-link-anchor span {
-  color: #64748b;
+  color: #69707d;
+  font-size: 11px;
+  font-weight: 700;
 }
 
 .cv-query-link-anchor strong,
 .cv-query-link-anchor code {
   overflow: hidden;
-  color: #0f172a;
+  color: #343741;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.cv-query-link-anchor code {
+  border-radius: 3px;
+  background: #f5f7fa;
+  padding: 1px 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.cv-query-link-window {
+  width: min(176px, 100%);
+  gap: 4px;
+  color: #69707d;
+  font-size: 11px;
+}
+
+.cv-query-link-window .euiSuperSelect .euiFormControlLayout {
+  min-height: 30px;
+  border: 1px solid #d6dde8;
+  border-radius: 4px;
+  background: #fcfdff;
+  box-shadow: none;
+}
+
+.cv-query-link-window .euiSuperSelect .euiFormControlLayout:focus-within {
+  border-color: #98a2b3;
+  box-shadow: none;
 }
 
 .cv-query-link-table-picker {
   display: grid;
-  gap: 6px;
+  gap: 5px;
 }
 
 .cv-query-link-table-picker__header {
@@ -923,17 +1013,17 @@ textarea {
 }
 
 .cv-query-link-table-picker__header strong {
-  color: #0f172a;
+  color: #343741;
   font-size: 12px;
 }
 
 .cv-query-link-table-picker__list {
   display: grid;
   gap: 2px;
-  max-height: 240px;
+  max-height: 184px;
   overflow: auto;
-  border: 1px solid rgba(148, 163, 184, 0.16);
-  border-radius: 8px;
+  border: 1px solid #d3dae6;
+  border-radius: 4px;
   background: #ffffff;
   padding: 4px;
 }
@@ -943,26 +1033,57 @@ textarea {
   align-items: center;
   gap: 8px;
   min-height: 28px;
-  border-radius: 6px;
+  border-radius: 3px;
   padding: 4px 6px;
-  color: #334155;
+  color: #343741;
   font-size: 12px;
+  font-weight: 600;
   cursor: pointer;
 }
 
 .cv-query-link-table-picker__item:hover {
-  background: #fff7ed;
+  background: #f5f7fa;
+}
+
+.cv-query-link-modal .cv-query-modal__footer {
+  margin-top: 2px;
+}
+
+.cv-query-link-modal__text-action {
+  min-height: 26px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #69707d;
+  cursor: pointer;
+  padding: 0 1px;
+  font-family: var(--cv-font-ui);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.cv-query-link-modal__text-action:hover,
+.cv-query-link-modal__text-action:focus-visible {
+  color: var(--cv-primary-strong);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  outline: none;
+}
+
+.cv-query-link-modal__text-action--primary {
+  color: var(--cv-primary-strong);
 }
 
 .cv-query-confirm__content {
-  font-size: 13px;
-  color: var(--cv-text);
-  line-height: 1.6;
+  color: #343741;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.5;
 }
 
 .cv-query-panel {
-  padding: 12px;
-  border-radius: 12px;
+  padding: 10px;
+  border-radius: 8px;
 }
 
 .cv-query-toolbar-chips,
@@ -975,6 +1096,27 @@ textarea {
   gap: 8px;
 }
 
+.cv-query-toolbar-chips {
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 0;
+}
+
+.cv-query-action-row {
+  align-items: center;
+}
+
+.cv-query-action-row--utility {
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.cv-query-action-row--utility .cv-secondary-button {
+  min-height: 28px;
+  padding: 0 9px;
+  font-size: 12px;
+}
+
 .cv-query-result-tools {
   display: flex;
   align-items: center;
@@ -984,12 +1126,13 @@ textarea {
 .cv-query-log-tabs {
   display: flex;
   flex-wrap: nowrap;
-  gap: 4px;
+  gap: 2px;
   overflow-x: auto;
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  border-radius: 10px;
-  background: #ffffff;
-  padding: 6px;
+  overscroll-behavior-x: contain;
+  min-height: 32px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  background: transparent;
+  padding: 0 2px;
 }
 
 .cv-query-log-tab {
@@ -997,27 +1140,29 @@ textarea {
   align-items: stretch;
   min-width: 0;
   overflow: hidden;
-  border: 1px solid rgba(148, 163, 184, 0.22);
-  border-radius: 8px;
-  background: #ffffff;
+  border: 1px solid transparent;
+  border-bottom: 0;
+  border-radius: 7px 7px 0 0;
+  background: transparent;
   color: #475569;
 }
 
 .cv-query-log-tab--active {
-  border-color: rgba(234, 88, 12, 0.42);
-  background: #fff7ed;
+  border-color: rgba(148, 163, 184, 0.24);
+  background: #ffffff;
   color: #c2410c;
+  box-shadow: inset 0 2px 0 var(--cv-primary);
 }
 
 .cv-query-log-tab__main {
   display: grid;
   gap: 1px;
-  min-width: 104px;
-  max-width: 220px;
+  min-width: 96px;
+  max-width: 200px;
   border: 0;
   background: transparent;
   color: inherit;
-  padding: 6px 9px;
+  padding: 4px 8px;
   text-align: left;
   cursor: pointer;
 }
@@ -1072,78 +1217,166 @@ textarea {
   position: relative;
 }
 
+.cv-query-saved--open {
+  z-index: 220;
+}
+
 .cv-query-saved__menu {
   position: absolute;
   top: calc(100% + 6px);
   right: 0;
-  z-index: 30;
-  width: 340px;
+  z-index: 240;
+  width: min(276px, calc(100vw - 32px));
+  min-width: 228px;
+  max-width: calc(100vw - 32px);
+  max-height: min(300px, calc(100vh - 248px));
   overflow: hidden;
-  border: 1px solid rgba(148, 163, 184, 0.22);
-  border-radius: 10px;
+  border: 1px solid #d8dee8;
+  border-radius: 4px;
   background: #ffffff;
-  box-shadow: 0 16px 34px rgba(15, 23, 42, 0.14);
+  box-shadow: 0 8px 20px rgba(52, 55, 65, 0.11);
 }
 
-.cv-query-saved__menu-header {
+.cv-query-saved__popover-panel {
+  width: min(276px, calc(100vw - 32px)) !important;
+  min-width: 228px !important;
+  max-width: calc(100vw - 32px) !important;
+  overflow: hidden !important;
+  border: 1px solid #d8dee8 !important;
+  border-radius: 4px !important;
+  background: #ffffff !important;
+  box-shadow:
+    0 8px 18px rgba(52, 55, 65, 0.1),
+    0 1px 2px rgba(52, 55, 65, 0.04) !important;
+}
+
+.cv-query-saved__menu--popover {
+  position: static;
+  top: auto;
+  right: auto;
+  z-index: auto;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.14);
-  padding: 9px 10px;
+  flex-direction: column;
+  width: 100%;
+  min-width: 0;
+  max-width: none;
+  max-height: min(276px, calc(100vh - 140px));
+  min-height: 0;
+  overflow: hidden;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
 }
 
-.cv-query-saved__menu-header strong {
-  color: #0f172a;
-  font-size: 13px;
+.cv-query-saved__menu--history {
+  right: 0;
+  left: auto;
 }
 
-.cv-query-saved__menu-header span,
-.cv-query-saved__empty {
-  color: #64748b;
-  font-size: 12px;
+.cv-query-saved__search {
+  padding: 6px 6px 5px;
+  border-bottom: 1px solid #eef2f7;
+  background: #ffffff;
 }
 
-.cv-query-saved__create {
-  display: flex;
-  width: calc(100% - 12px);
-  align-items: center;
-  justify-content: center;
-  margin: 6px;
-  border: 1px dashed rgba(234, 88, 12, 0.36);
-  border-radius: 8px;
-  background: #fff7ed;
-  color: #c2410c;
-  padding: 7px 10px;
-  cursor: pointer;
-  font-size: 12px;
-  font-weight: 700;
+.cv-query-saved__search .euiFormControlLayout {
+  min-height: 28px !important;
+  border: 1px solid #d3dae6 !important;
+  border-radius: 4px !important;
+  background: #fbfcfd !important;
+  box-shadow: none !important;
 }
 
-.cv-query-saved__create:hover {
-  border-color: rgba(234, 88, 12, 0.62);
-  background: #ffedd5;
+.cv-query-saved__search .euiFormControlLayout__childrenWrapper {
+  min-height: 28px !important;
+  border: 0 !important;
+  border-radius: 3px !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+.cv-query-saved__search .euiFormControlLayout.euiFormControlLayout-isFocused,
+.cv-query-saved__search .euiFormControlLayout--focused,
+.cv-query-saved__search .euiFormControlLayout:focus-within {
+  border-color: #b9c4d2 !important;
+  background: #ffffff !important;
+  box-shadow: none !important;
+}
+
+.cv-query-saved__search .euiFormControlLayout::before,
+.cv-query-saved__search .euiFormControlLayout::after,
+.cv-query-saved__search .euiFormControlLayout__childrenWrapper::before,
+.cv-query-saved__search .euiFormControlLayout__childrenWrapper::after {
+  box-shadow: none !important;
+}
+
+.cv-query-saved__search .euiFieldSearch {
+  height: 28px !important;
+  min-height: 28px !important;
+  color: #343741 !important;
+  font-size: 12px !important;
+  font-weight: 500 !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.cv-query-saved__search .euiFieldSearch:focus,
+.cv-query-saved__search .euiFieldSearch:focus-visible {
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.cv-query-saved__search .euiFieldSearch::placeholder {
+  color: #98a2b3 !important;
+}
+
+.cv-query-saved__search .euiFormControlLayoutClearButton {
+  width: 18px !important;
+  min-width: 18px !important;
+  inline-size: 18px !important;
+  height: 18px !important;
+  padding: 0 !important;
+  border-radius: 999px !important;
+  background: #edf1f6 !important;
+  color: #69707d !important;
+  box-shadow: none !important;
+}
+
+.cv-query-saved__search .euiFormControlLayoutClearButton:hover,
+.cv-query-saved__search .euiFormControlLayoutClearButton:focus-visible {
+  background: #e2e8f0 !important;
+  color: #343741 !important;
+  outline: none !important;
+}
+
+.cv-query-saved__search .euiFormControlLayoutClearButton svg,
+.cv-query-saved__search .euiFormControlLayoutClearButton .euiIcon {
+  color: currentColor !important;
+  opacity: 0.82 !important;
 }
 
 .cv-query-saved__list {
   display: grid;
-  max-height: 320px;
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: none;
   overflow: auto;
-  padding: 6px;
+  padding: 4px;
+  scrollbar-gutter: stable;
 }
 
 .cv-query-saved__item {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  gap: 6px;
-  border-radius: 8px;
-  padding: 4px;
+  gap: 4px;
+  border-radius: 3px;
+  padding: 0;
 }
 
-.cv-query-saved__item:hover {
-  background: #fff7ed;
+.cv-query-saved__item:hover,
+.cv-query-saved__item:focus-within {
+  background: #f5f7fa;
 }
 
 .cv-query-saved__item--single {
@@ -1152,49 +1385,134 @@ textarea {
 
 .cv-query-saved__item > button:first-child {
   display: grid;
-  gap: 3px;
+  gap: 2px;
   min-width: 0;
+  min-height: 28px;
+  width: 100%;
   border: 0;
+  border-radius: 3px;
   background: transparent;
   color: inherit;
-  padding: 5px 6px;
+  padding: 5px 7px;
   text-align: left;
   cursor: pointer;
 }
 
+.cv-query-saved__item > button:first-child:focus-visible {
+  background: var(--cv-primary-tint);
+  outline: none;
+}
+
 .cv-query-saved__item strong {
   overflow: hidden;
-  color: #334155;
+  color: #343741;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 12px;
+  font-weight: 650;
+}
+
+.cv-query-saved__menu--history .cv-query-saved__item strong {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11.5px;
+  font-weight: 600;
 }
 
 .cv-query-saved__item span {
   overflow: hidden;
-  color: #64748b;
+  color: #69707d;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 11px;
 }
 
 .cv-query-saved__delete {
+  display: grid;
+  width: 24px;
+  height: 24px;
+  place-items: center;
   border: 0;
-  border-radius: 6px;
+  border-radius: 4px;
   background: transparent;
-  color: #b91c1c;
-  padding: 5px 7px;
+  color: #98a2b3;
+  padding: 0;
   cursor: pointer;
-  font-size: 12px;
 }
 
-.cv-query-saved__delete:hover {
-  background: #fee2e2;
+.cv-query-saved__delete:hover,
+.cv-query-saved__delete:focus-visible {
+  background: #f5f7fa;
+  color: #bd271e;
+  outline: none;
 }
 
 .cv-query-saved__empty {
-  padding: 14px 10px;
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 56px;
+  align-items: center;
+  justify-content: center;
+  color: #69707d;
+  padding: 14px 8px 12px;
   text-align: center;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.cv-query-saved__menu--popover > .cv-query-saved__empty {
+  min-height: 96px;
+  color: #98a2b3;
+  padding: 22px 10px;
+}
+
+.cv-query-saved__empty--inline {
+  min-height: 56px;
+  padding: 20px 8px;
+}
+
+.cv-query-saved__status {
+  padding: 6px 8px 0;
+  color: #69707d;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.cv-query-saved__footer {
+  display: flex;
+  flex: 0 0 auto;
+  justify-content: flex-end;
+  padding: 3px 6px 5px;
+  border-top: 1px solid #eef2f7;
+  background: #ffffff;
+}
+
+.cv-query-saved__empty + .cv-query-saved__footer {
+  justify-content: center;
+  padding-top: 4px;
+}
+
+.cv-query-saved__footer-action {
+  min-height: 22px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #69707d;
+  cursor: pointer;
+  padding: 0 4px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.cv-query-saved__footer-action:hover,
+.cv-query-saved__footer-action:focus-visible {
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-strong);
+  text-decoration: none;
+  outline: none;
+}
+
+.cv-query-saved__footer-action--primary {
+  color: var(--cv-primary-strong);
 }
 
 .cv-action-button--danger {
@@ -1226,213 +1544,6 @@ textarea {
 .cv-query-toolbar-select--datetime .cv-input {
   min-width: 196px;
   padding-right: 12px;
-}
-
-.cv-query-time-range {
-  position: relative;
-  min-width: 210px;
-}
-
-.cv-query-time-range__trigger {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  width: 100%;
-  min-height: 32px;
-  border: 1px solid rgba(148, 163, 184, 0.26);
-  border-radius: 8px;
-  background: #f8fafc;
-  color: #334155;
-  padding: 0 10px;
-  font-size: 12px;
-  font-weight: 700;
-  cursor: pointer;
-}
-
-.cv-query-time-range__trigger:hover,
-.cv-query-time-range__trigger--open {
-  border-color: rgba(234, 88, 12, 0.38);
-  background: #fff7ed;
-  color: #9a3412;
-}
-
-.cv-query-time-range__icon {
-  color: #64748b;
-  font-size: 15px;
-}
-
-.cv-query-time-range__chevron {
-  margin-left: auto;
-  color: #64748b;
-  font-size: 13px;
-}
-
-.cv-query-time-popover {
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
-  z-index: 40;
-  display: grid;
-  grid-template-columns: 324px 220px;
-  min-height: 420px;
-  overflow: hidden;
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  border-radius: 8px;
-  background: #ffffff;
-  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.16);
-}
-
-.cv-query-time-popover__absolute,
-.cv-query-time-popover__quick {
-  display: flex;
-  flex-direction: column;
-}
-
-.cv-query-time-popover__absolute {
-  gap: 12px;
-  padding: 12px;
-}
-
-.cv-query-time-popover__absolute h2 {
-  margin: 0 0 2px;
-  color: #1f2937;
-  font-size: 13px;
-  line-height: 1.2;
-}
-
-.cv-query-time-field {
-  display: grid;
-  gap: 6px;
-  color: #1f2937;
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.cv-query-time-field input {
-  height: 32px;
-  border: 1px solid rgba(148, 163, 184, 0.38);
-  border-radius: 4px;
-  background: #ffffff;
-  color: #111827;
-  padding: 0 8px;
-  font-size: 13px;
-}
-
-.cv-query-time-field input:focus,
-.cv-query-time-search input:focus {
-  border-color: rgba(234, 88, 12, 0.65);
-  box-shadow: 0 0 0 2px rgba(234, 88, 12, 0.12);
-  outline: none;
-}
-
-.cv-query-time-popover__apply {
-  align-self: flex-start;
-  height: 32px;
-  border: 1px solid var(--cv-primary);
-  border-radius: 4px;
-  background: var(--cv-primary);
-  color: #ffffff;
-  padding: 0 14px;
-  font-size: 12px;
-  font-weight: 800;
-  cursor: pointer;
-}
-
-.cv-query-time-popover__recent {
-  display: grid;
-  gap: 10px;
-  margin-top: auto;
-  color: #334155;
-  font-size: 12px;
-}
-
-.cv-query-time-popover__recent strong {
-  color: #1f2937;
-}
-
-.cv-query-time-popover__footer {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  border-top: 1px solid rgba(148, 163, 184, 0.2);
-  padding-top: 10px;
-  color: #475569;
-  font-size: 12px;
-}
-
-.cv-query-time-popover__quick {
-  border-left: 1px solid rgba(148, 163, 184, 0.24);
-  background: #fbfbfc;
-}
-
-.cv-query-time-search {
-  position: relative;
-  display: block;
-  padding: 8px 8px 10px;
-}
-
-.cv-query-time-search span {
-  position: absolute;
-  top: 15px;
-  left: 18px;
-  color: #64748b;
-  font-size: 13px;
-}
-
-.cv-query-time-search input {
-  width: 100%;
-  height: 32px;
-  border: 1px solid rgba(148, 163, 184, 0.36);
-  border-radius: 3px;
-  background: #ffffff;
-  color: #111827;
-  padding: 0 8px 0 28px;
-  font-size: 12px;
-}
-
-.cv-query-time-popover__quick-list {
-  overflow: auto;
-  padding: 6px 0;
-}
-
-.cv-query-time-popover__quick-item {
-  display: block;
-  width: 100%;
-  min-height: 34px;
-  border: 0;
-  background: transparent;
-  color: #1f2937;
-  padding: 0 12px;
-  text-align: left;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-}
-
-.cv-query-time-popover__quick-item:hover {
-  background: #fff7ed;
-}
-
-.cv-query-time-popover__quick-item--active {
-  background: #f1f5f9;
-  color: #9a3412;
-  font-weight: 800;
-}
-
-@media (max-width: 760px) {
-  .cv-query-time-popover {
-    right: auto;
-    left: 0;
-    grid-template-columns: minmax(280px, 1fr);
-    width: min(92vw, 360px);
-    min-height: 0;
-  }
-
-  .cv-query-time-popover__quick {
-    border-left: 0;
-    border-top: 1px solid rgba(148, 163, 184, 0.24);
-  }
 }
 
 .cv-query-panel__status {
@@ -1484,6 +1595,525 @@ textarea {
     opacity: 1;
     transform: translateY(0);
   }
+}
+
+.cv-query-time-error {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 35;
+  border: 1px solid rgba(185, 28, 28, 0.24);
+  border-radius: 7px;
+  background: #fff1f2;
+  color: #b91c1c;
+  padding: 5px 8px;
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.cv-query-panel--command {
+  padding: 8px 10px 10px;
+}
+
+.cv-query-command-header {
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.cv-query-command-header--utility-only,
+.cv-query-panel-header--utility-only {
+  justify-content: flex-end;
+  min-height: 0;
+  width: 100%;
+}
+
+.cv-query-command-row {
+  display: grid;
+  grid-template-columns: minmax(320px, 1fr) minmax(420px, 0.72fr) auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.cv-query-command-row__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: max-content;
+}
+
+.cv-query-run-button {
+  min-width: 72px;
+}
+
+.cv-query-kibana {
+  display: grid;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.cv-query-sql {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  min-height: var(--cv-control-height);
+  overflow: visible;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 1px 0 rgba(15, 23, 42, 0.02);
+}
+
+.cv-query-sql:focus-within {
+  border-color: color-mix(in srgb, var(--cv-primary) 52%, var(--cv-border));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--cv-primary) 12%, transparent);
+}
+
+.cv-query-sql__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  align-self: stretch;
+  min-width: 54px;
+  border-right: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 7px 0 0 7px;
+  background: #f8fafc;
+  color: #475569;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.cv-query-sql__tip {
+  appearance: none;
+  display: inline-grid;
+  place-items: center;
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: #94a3b8;
+  cursor: help;
+  line-height: 1;
+  opacity: 0.78;
+}
+
+.cv-query-sql__tip:hover,
+.cv-query-sql__tip:focus-visible {
+  background: transparent;
+  color: #64748b;
+  opacity: 1;
+  outline: 0;
+}
+
+.cv-query-sql input {
+  width: 100%;
+  min-width: 0;
+  height: 30px;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: #0f172a;
+  padding: 0 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+}
+
+.cv-query-sql input::placeholder {
+  color: #94a3b8;
+  font-family: var(--cv-font-ui);
+  font-weight: 500;
+}
+
+.cv-query-sql__clear {
+  width: 30px;
+  height: 30px;
+  margin-right: 2px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: #64748b;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+}
+
+.cv-query-sql__clear:hover {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.cv-query-sql__suggestions {
+  position: absolute;
+  top: calc(100% + 5px);
+  right: 0;
+  left: 60px;
+  z-index: 32;
+  display: grid;
+  max-height: 220px;
+  overflow: auto;
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.14);
+  padding: 4px;
+}
+
+.cv-query-sql__suggestions button {
+  min-width: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: #0f172a;
+  padding: 7px 8px;
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+}
+
+.cv-query-sql__suggestions button:hover {
+  background: #fff7ed;
+  color: #9a3412;
+}
+
+.cv-query-filter-composer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  width: fit-content;
+  max-width: 100%;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.cv-query-filter-composer__inputs {
+  display: grid;
+  grid-template-columns: 128px 72px minmax(146px, 206px);
+  align-items: stretch;
+  width: fit-content;
+  max-width: 100%;
+  overflow: visible;
+  border: 1px solid #e3e8f0;
+  border-radius: 4px;
+  background: #fcfdff;
+}
+
+.cv-query-filter-composer__inputs:focus-within {
+  border-color: #d3dae6;
+  background: #ffffff;
+  box-shadow: none;
+}
+
+.cv-query-filter-composer label {
+  position: relative;
+  display: block;
+  min-width: 0;
+}
+
+.cv-query-filter-composer__clause {
+  display: contents;
+  min-width: 0;
+}
+
+.cv-query-filter-composer .euiFormControlLayout {
+  max-width: none;
+  min-height: 28px;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+.cv-query-filter-composer input,
+.cv-query-filter-composer select {
+  width: 100%;
+  min-width: 0;
+  min-height: 28px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: #343741;
+  padding: 0 8px;
+  outline: none;
+  font-size: 12px;
+}
+
+.cv-query-filter-composer__field input {
+  padding-left: 9px;
+}
+
+.cv-query-filter-composer__field--picker {
+  z-index: 24;
+}
+
+.cv-query-filter-composer__operator,
+.cv-query-filter-composer__value {
+  border-left: 1px solid #edf1f6;
+}
+
+.cv-query-filter-composer__operator select {
+  border-radius: 0;
+  padding-right: 22px;
+}
+
+.cv-query-filter-composer__value input {
+  padding-left: 9px;
+}
+
+.cv-query-filter-composer input:focus,
+.cv-query-filter-composer select:focus {
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.cv-query-filter-composer__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+  padding: 0 2px;
+}
+
+.cv-query-filter-composer__text-action {
+  min-height: 24px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: #69707d;
+  padding: 0 2px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 24px;
+}
+
+.cv-query-filter-composer__text-action--primary {
+  color: var(--cv-primary-strong);
+}
+
+.cv-query-filter-composer__text-action:hover,
+.cv-query-filter-composer__text-action:focus-visible {
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-strong);
+  text-decoration: none;
+  outline: none;
+}
+
+.cv-query-filter-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  min-height: 24px;
+}
+
+.cv-query-filter-pills__count {
+  color: #64748b;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.cv-query-filter-pill {
+  display: inline-flex;
+  align-items: stretch;
+  max-width: 100%;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 7px;
+  background: #f8fafc;
+  color: #334155;
+}
+
+.cv-query-filter-pill--active {
+  border-color: rgba(148, 163, 184, 0.28);
+  background: #f8fafc;
+  color: #334155;
+  box-shadow: none;
+}
+
+.cv-query-filter-pill--disabled {
+  border-style: dashed;
+  background: #f8fafc;
+  color: #94a3b8;
+}
+
+.cv-query-filter-pill__main,
+.cv-query-filter-pill__toggle,
+.cv-query-filter-pill__remove {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+}
+
+.cv-query-filter-pill > .euiToolTipAnchor {
+  display: inline-flex;
+  align-items: stretch;
+}
+
+.cv-query-filter-pill__main {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  max-width: min(520px, 100%);
+  padding: 0 8px;
+  height: 28px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.cv-query-filter-pill__main strong,
+.cv-query-filter-pill__main span:last-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cv-query-filter-pill__main strong {
+  max-width: 180px;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.cv-query-filter-pill__main em {
+  color: #64748b;
+  font-style: normal;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.cv-query-filter-pill__toggle,
+.cv-query-filter-pill__remove {
+  display: inline-grid;
+  place-items: center;
+  border-left: 0;
+  padding: 0 7px;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.cv-query-filter-pill__toggle {
+  width: 28px;
+  min-width: 28px;
+  padding: 0;
+  color: #64748b;
+}
+
+.cv-query-filter-pill__remove {
+  min-width: 28px;
+  color: #64748b;
+  font-size: 16px;
+}
+
+.cv-query-filter-pill__toggle:hover,
+.cv-query-filter-pill__remove:hover {
+  background: rgba(15, 23, 42, 0.04);
+  color: var(--cv-primary-strong);
+}
+
+.cv-query-filter-pill--disabled .cv-query-filter-pill__main {
+  text-decoration: line-through;
+}
+
+@media (max-width: 1180px) {
+  .cv-query-command-row {
+    grid-template-columns: minmax(0, 1fr) minmax(360px, 0.85fr) auto;
+  }
+
+  .cv-query-filter-composer__inputs {
+    grid-template-columns: 128px 72px minmax(146px, 206px);
+  }
+}
+
+@media (max-width: 900px) {
+  .cv-query-command-row {
+    grid-template-columns: minmax(0, 1fr) 72px;
+  }
+
+  .cv-query-command-row__actions {
+    width: auto;
+  }
+
+  .cv-query-run-button {
+    width: 82px;
+    min-width: 82px;
+  }
+
+  .cv-query-filter-composer {
+    width: 100%;
+  }
+
+  .cv-query-filter-composer__inputs {
+    width: 100%;
+    grid-template-columns: minmax(0, 1fr) 104px minmax(0, 1fr);
+  }
+
+  .cv-query-filter-composer__actions {
+    flex: 1 1 100%;
+  }
+}
+
+@media (max-width: 640px) {
+  .cv-query-sql {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+  }
+
+  .cv-query-sql__badge {
+    grid-column: auto;
+    justify-content: center;
+    min-height: auto;
+    border-right: 1px solid rgba(148, 163, 184, 0.22);
+    border-bottom: 0;
+    border-radius: 4px 0 0 4px;
+    padding: 0 8px;
+  }
+
+  .cv-query-sql__suggestions {
+    left: 54px;
+  }
+
+  .cv-query-filter-composer {
+    width: 100%;
+  }
+
+  .cv-query-filter-composer__inputs {
+    width: 100%;
+    grid-template-columns: 90px minmax(0, 1fr);
+  }
+
+  .cv-query-filter-composer__field {
+    grid-column: 1 / -1;
+    border-bottom: 1px solid #e5e8ef;
+  }
+
+  .cv-query-filter-composer__operator {
+    border-left: 0;
+  }
+
+  .cv-query-filter-composer__actions {
+    flex-basis: 100%;
+    justify-content: flex-start;
+  }
+
+  .cv-query-filter-pill {
+    width: 100%;
+  }
+
+  .cv-query-filter-pill__main {
+    flex: 1 1 auto;
+  }
+
 }
 
 .cv-query-builder {
@@ -1698,47 +2328,52 @@ textarea {
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--cv-primary) 14%, transparent);
 }
 
-.cv-query-field-meta {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  min-height: 20px;
-  color: #64748b;
-  font-size: 11px;
-  font-weight: 600;
-}
-
-.cv-query-field-meta__badge {
-  display: inline-flex;
-  align-items: center;
-  height: 18px;
-  padding: 0 6px;
-  border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--cv-primary) 26%, var(--cv-border));
-  background: var(--cv-primary-soft);
-  color: var(--cv-primary-strong);
-}
-
 .cv-query-field-picker {
   position: absolute;
-  z-index: 30;
+  z-index: 100;
   top: 58px;
   left: 0;
-  width: min(520px, calc(100vw - 48px));
-  max-height: 360px;
+  width: 100%;
+  max-height: 240px;
   overflow: auto;
-  padding: 6px;
-  border: 1px solid var(--cv-border-strong);
-  border-radius: 10px;
+  padding: 3px;
+  border: 1px solid #d3dae6;
+  border-radius: 4px;
   background: #ffffff;
-  box-shadow: 0 14px 34px rgba(15, 23, 42, 0.14);
+  box-shadow:
+    0 10px 22px rgba(52, 55, 65, 0.1),
+    0 1px 2px rgba(52, 55, 65, 0.05);
+  overscroll-behavior: contain;
+  scrollbar-color: #c7d0dd transparent;
+  scrollbar-width: thin;
+}
+
+.cv-query-field-picker::-webkit-scrollbar {
+  width: 5px;
+}
+
+.cv-query-field-picker::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: #c7d0dd;
+}
+
+.cv-query-field-picker::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.cv-query-filter-composer__field .cv-query-field-picker {
+  top: calc(100% + 4px);
+  width: min(286px, calc(100vw - 40px));
+  max-height: 252px;
 }
 
 .cv-query-condition-modal .cv-query-field-picker {
   position: absolute;
   width: 100%;
   max-height: 188px;
-  box-shadow: 0 14px 34px rgba(15, 23, 42, 0.14);
+  box-shadow:
+    0 10px 22px rgba(52, 55, 65, 0.1),
+    0 1px 2px rgba(52, 55, 65, 0.05);
 }
 
 .cv-query-field-picker--empty {
@@ -1749,43 +2384,48 @@ textarea {
 }
 
 .cv-query-field-picker__option {
-  display: grid;
-  grid-template-columns: minmax(190px, 1fr) auto;
-  gap: 14px;
+  position: relative;
+  display: flex;
   align-items: center;
   width: 100%;
-  min-height: 42px;
-  padding: 7px 8px;
+  min-height: 24px;
+  padding: 0 8px;
   border: 0;
-  border-radius: 8px;
+  border-radius: 3px;
   background: transparent;
-  color: #0f172a;
+  color: #343741;
   text-align: left;
+  font-family: var(--cv-font-ui);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 24px;
   cursor: pointer;
 }
 
 .cv-query-field-picker__option:hover,
 .cv-query-field-picker__option--active {
-  background: #f4f6f8;
+  background: var(--cv-primary-tint);
+  color: #343741;
+}
+
+.cv-query-field-picker__option--active {
+  box-shadow: none;
+  font-weight: 650;
+}
+
+.cv-query-field-picker__option--active::before {
+  content: none;
 }
 
 .cv-query-field-picker__name {
+  display: block;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-family: var(--cv-font-ui);
   font-size: 12px;
-  font-weight: 700;
-}
-
-.cv-query-field-picker__meta {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  color: #64748b;
-  font-size: 11px;
   font-weight: 600;
-  white-space: nowrap;
 }
 
 .cv-query-builder-form__actions {
@@ -1795,12 +2435,53 @@ textarea {
   min-height: 58px;
 }
 
-.cv-query-condition-modal {
-  width: min(640px, calc(100vw - 32px));
-  height: min(430px, calc(100vh - 48px));
+.cv-report-modal.cv-query-condition-modal {
+  width: min(520px, calc(100vw - 32px));
+  max-height: min(320px, calc(100vh - 48px));
+  height: auto;
   display: flex;
   flex-direction: column;
   overflow: visible;
+  border: 1px solid #d3dae6;
+  border-radius: 6px;
+  background: #ffffff;
+  box-shadow: 0 14px 34px rgba(52, 55, 65, 0.16);
+  padding: 0;
+}
+
+.cv-query-condition-modal__header {
+  align-items: center;
+  margin: 0;
+  border-bottom: 1px solid #e5e8ef;
+  background: #fbfcfd;
+  padding: 8px 10px 8px 12px;
+}
+
+.cv-query-condition-modal__header .cv-panel-title {
+  color: #343741;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.cv-query-condition-modal__close {
+  display: grid;
+  flex: 0 0 auto;
+  width: 26px;
+  height: 26px;
+  place-items: center;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #69707d;
+  cursor: pointer;
+  padding: 0;
+}
+
+.cv-query-condition-modal__close:hover,
+.cv-query-condition-modal__close:focus-visible {
+  background: #eef1f6;
+  color: #343741;
+  outline: none;
 }
 
 .cv-query-condition-modal__body {
@@ -1808,22 +2489,102 @@ textarea {
   min-height: 0;
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 12px;
+  gap: 10px;
+  padding: 10px 12px 12px;
+}
+
+.cv-query-condition-modal .cv-query-builder-form--modal {
+  grid-template-columns: minmax(178px, 1.15fr) minmax(104px, 0.6fr) minmax(178px, 1fr);
+  align-items: end;
+  gap: 8px;
+}
+
+.cv-query-condition-modal .cv-query-builder-form__field {
+  gap: 4px;
+  color: #69707d;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.cv-query-condition-modal .cv-query-builder-form__field select,
+.cv-query-condition-modal .cv-query-builder-form__field input,
+.cv-query-condition-modal .cv-query-field-select__trigger {
+  min-height: 30px;
+  border: 1px solid #d6dde8;
+  border-radius: 4px;
+  background: #fcfdff;
+  color: #343741;
+  padding: 0 9px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.cv-query-condition-modal .cv-query-field-select__trigger:hover,
+.cv-query-condition-modal .cv-query-builder-form__field input:hover {
+  border-color: #c4ccd8;
+  background: #ffffff;
+}
+
+.cv-query-condition-modal .cv-query-field-select__trigger:focus,
+.cv-query-condition-modal .cv-query-builder-form__field input:focus,
+.cv-query-condition-modal .cv-query-builder-form__field input:focus-visible {
+  border-color: #98a2b3;
+  box-shadow: none;
+  outline: none;
 }
 
 .cv-query-condition-modal__footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
+  gap: 8px;
   margin-top: auto;
+  padding-top: 2px;
 }
 
 .cv-query-condition-modal__actions {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
+}
+
+.cv-query-condition-modal__text-action {
+  min-height: 26px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #69707d;
+  cursor: pointer;
+  padding: 0 1px;
+  font-family: var(--cv-font-ui);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.cv-query-condition-modal__text-action:hover,
+.cv-query-condition-modal__text-action:focus-visible {
+  color: var(--cv-primary-strong);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  outline: none;
+}
+
+.cv-query-condition-modal__text-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.cv-query-condition-modal__text-action--primary {
+  color: var(--cv-primary-strong);
+}
+
+.cv-query-condition-modal__text-action--danger {
+  color: #bd271e;
+}
+
+.cv-query-condition-modal__text-action--danger:hover,
+.cv-query-condition-modal__text-action--danger:focus-visible {
+  color: #8f1f18;
 }
 
 @media (max-width: 1180px) {
@@ -1834,6 +2595,10 @@ textarea {
   .cv-query-builder-form,
   .cv-query-builder-form--modal {
     grid-template-columns: minmax(220px, 1.5fr) minmax(92px, 0.7fr) minmax(92px, 0.7fr) minmax(180px, 1fr);
+  }
+
+  .cv-query-condition-modal .cv-query-builder-form--modal {
+    grid-template-columns: minmax(178px, 1.15fr) minmax(104px, 0.6fr) minmax(178px, 1fr);
   }
 
   .cv-query-builder-form__actions {
@@ -1853,31 +2618,54 @@ textarea {
 }
 
 .cv-query-builder__preview {
-  display: grid;
-  gap: 6px;
-  margin-top: 10px;
-  padding: 10px;
-  border-radius: 10px;
-  background: #f8fbff;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+  padding: 3px 8px;
+  border-radius: 7px;
+  background: #ffffff;
   box-shadow: inset 0 0 0 1px rgba(226, 232, 240, 0.9);
 }
 
 .cv-query-builder__preview strong {
-  font-size: 12px;
-  font-weight: 700;
-  color: #335c99;
+  flex: 0 0 auto;
+  font-size: 11px;
+  font-weight: 800;
+  color: #64748b;
 }
 
 .cv-query-builder__preview code {
   display: block;
-  border-radius: 8px;
-  padding: 8px 10px;
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 0;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 12px;
   color: #0f172a;
-  background: #eff6ff;
-  white-space: pre-wrap;
-  word-break: break-word;
+  background: transparent;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cv-query-builder__preview-action {
+  flex: 0 0 auto;
+  min-height: 22px;
+  padding: 0 4px;
+  border: 0;
+  background: transparent;
+  color: var(--cv-primary-strong);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+}
+
+.cv-query-builder__preview-action:hover,
+.cv-query-builder__preview-action:focus-visible {
+  color: var(--cv-primary-strong);
+  text-decoration: underline;
+  outline: none;
 }
 
 .cv-query-histogram {
@@ -1958,15 +2746,33 @@ textarea {
 }
 
 .cv-query-histogram__axis {
-  width: 100%;
-  overflow: hidden;
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  width: max-content;
+  max-width: none;
+  overflow: visible;
+  transform: translateX(-50%);
   color: #475569;
   font-size: 11px;
   font-weight: 650;
   line-height: 1.2;
   text-align: center;
-  text-overflow: ellipsis;
   white-space: nowrap;
+  pointer-events: none;
+}
+
+.cv-query-histogram__axis--start {
+  left: 0;
+  transform: none;
+  text-align: left;
+}
+
+.cv-query-histogram__axis--end {
+  right: 0;
+  left: auto;
+  transform: none;
+  text-align: right;
 }
 
 .cv-query-histogram__baseline {
@@ -1978,12 +2784,359 @@ textarea {
   background: rgba(148, 163, 184, 0.3);
 }
 
-.cv-query-result-meta {
+.cv-query-histogram-summary {
   display: flex;
-  gap: 14px;
-  color: #1e3a8a;
-  font-weight: 700;
-  font-size: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  color: #64748b;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.cv-query-histogram-status {
+  display: inline-flex;
+  align-items: center;
+  min-height: 20px;
+}
+
+.cv-query-histogram {
+  align-items: stretch;
+  gap: 10px;
+  margin-top: 6px;
+}
+
+.cv-query-histogram__y-axis {
+  height: 148px;
+  padding: 10px 0 22px;
+}
+
+.cv-query-histogram__plot {
+  align-items: stretch;
+  gap: 3px;
+  min-height: 148px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  overscroll-behavior-x: contain;
+  padding: 0 2px;
+  user-select: none;
+}
+
+.cv-query-histogram__plot--selecting,
+.cv-query-histogram__plot--selecting .cv-query-histogram__item,
+.cv-query-histogram__plot--selecting .cv-query-histogram__bar {
+  cursor: col-resize;
+}
+
+.cv-query-histogram__grid {
+  position: absolute;
+  top: 10px;
+  right: 2px;
+  bottom: 22px;
+  left: 2px;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(to bottom, rgba(148, 163, 184, 0.16) 1px, transparent 1px) 0 0 / 100% 50%,
+    linear-gradient(to bottom, rgba(148, 163, 184, 0.1) 1px, transparent 1px) 0 100% / 100% 100%;
+}
+
+.cv-query-histogram__item {
+  position: relative;
+  z-index: 1;
+  grid-template-rows: 18px 108px 22px;
+  gap: 0;
+  min-width: 18px;
+  cursor: crosshair;
+}
+
+.cv-query-histogram__item--selected::before {
+  content: "";
+  position: absolute;
+  top: 18px;
+  right: -1px;
+  bottom: 22px;
+  left: -1px;
+  background: var(--cv-primary-tint);
+  pointer-events: none;
+}
+
+.cv-query-histogram__item--selection-start::before {
+  left: 0;
+  border-radius: 4px 0 0 4px;
+}
+
+.cv-query-histogram__item--selection-end::before {
+  right: 0;
+  border-radius: 0 4px 4px 0;
+}
+
+.cv-query-histogram__bar {
+  align-self: end;
+  width: 100%;
+  min-width: 10px;
+  min-height: 3px;
+  border-radius: 3px 3px 1px 1px;
+  background: #f97316;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+  transition:
+    background-color 120ms ease,
+    box-shadow 120ms ease,
+    transform 120ms ease;
+}
+
+.cv-query-histogram__bar:hover,
+.cv-query-histogram__bar:focus-visible {
+  background: var(--cv-primary-strong);
+  box-shadow: 0 0 0 2px rgba(234, 88, 12, 0.16);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.cv-query-histogram__bar--active {
+  background: var(--cv-primary-strong);
+}
+
+.cv-query-histogram__bar--empty {
+  background: rgba(148, 163, 184, 0.28);
+  cursor: crosshair;
+  box-shadow: none;
+  pointer-events: auto;
+}
+
+.cv-query-histogram__bar--selected {
+  background: var(--cv-primary-strong);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--cv-primary) 32%, transparent);
+}
+
+.cv-query-histogram__value {
+  opacity: 0;
+  transform: translateY(2px);
+}
+
+.cv-query-histogram__bar--active + .cv-query-histogram__axis,
+.cv-query-histogram__item:hover .cv-query-histogram__axis,
+.cv-query-histogram__item:focus-within .cv-query-histogram__axis {
+  color: #0f172a;
+}
+
+.cv-query-result-bar {
+  display: flex;
+  position: sticky;
+  top: 0;
+  z-index: 25;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 28px;
+  margin: 0;
+  border: 1px solid #e5e8ef;
+  border-bottom: 0;
+  border-radius: 6px 6px 0 0;
+  background: rgba(251, 252, 253, 0.98);
+  box-shadow: 0 1px 0 rgba(211, 218, 230, 0.7);
+  padding: 0 6px 0 10px;
+  backdrop-filter: blur(6px);
+}
+
+.cv-query-result-bar__page {
+  display: inline-flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+.cv-query-result-bar__summary {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 4px;
+  color: #69707d;
+  font-size: 11.5px;
+  font-weight: 650;
+  white-space: nowrap;
+}
+
+.cv-query-result-bar__summary em {
+  color: #69707d;
+  font-style: normal;
+  font-weight: 600;
+}
+
+.cv-query-result-bar__page-size {
+  display: inline-flex;
+  position: relative;
+  flex: 0 0 auto;
+  align-items: center;
+  margin-left: 2px;
+  padding-left: 8px;
+}
+
+.cv-query-result-bar__page-size::before {
+  content: "";
+  position: absolute;
+  top: 5px;
+  bottom: 5px;
+  left: 0;
+  width: 1px;
+  background: #edf1f6;
+}
+
+.cv-query-result-bar__inline-action {
+  display: inline-flex;
+  position: relative;
+  flex: 0 0 auto;
+  align-items: center;
+  margin-left: 2px;
+  padding-left: 8px;
+}
+
+.cv-query-result-bar__inline-action::before {
+  content: "";
+  position: absolute;
+  top: 5px;
+  bottom: 5px;
+  left: 0;
+  width: 1px;
+  background: #edf1f6;
+}
+
+.cv-query-result-bar__inline-action .cv-query-result-action {
+  min-height: 22px;
+  line-height: 22px;
+}
+
+.cv-query-result-actions {
+  display: inline-flex;
+  flex: 0 1 auto;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+}
+
+.cv-query-result-actions__group {
+  display: inline-flex;
+  position: relative;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+}
+
+.cv-query-result-actions__group + .cv-query-result-actions__group {
+  padding-left: 10px;
+}
+
+.cv-query-result-actions__group + .cv-query-result-actions__group::before {
+  content: "";
+  position: absolute;
+  top: 5px;
+  bottom: 5px;
+  left: 0;
+  width: 1px;
+  background: #e5e8ef;
+}
+
+.cv-query-result-actions__group--view {
+  gap: 10px;
+}
+
+.cv-query-result-action {
+  display: inline-flex;
+  min-height: 24px;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--cv-primary-strong);
+  padding: 0;
+  cursor: pointer;
+  font-size: 11.5px;
+  font-weight: 650;
+  line-height: 1;
+}
+
+.cv-query-result-action--text {
+  min-width: 0;
+}
+
+.cv-query-result-action--icon {
+  width: 24px;
+  min-width: 24px;
+  height: 24px;
+  min-height: 24px;
+  padding: 0;
+}
+
+.cv-query-result-action--icon:hover,
+.cv-query-result-action--icon:focus-visible,
+.cv-query-result-action--icon[aria-pressed="true"],
+.cv-query-result-action--icon[aria-expanded="true"] {
+  background: var(--cv-primary-tint);
+  text-decoration: none;
+}
+
+.cv-query-result-action:hover,
+.cv-query-result-action:focus-visible,
+.cv-query-result-action[aria-expanded="true"] {
+  background: transparent;
+  color: var(--cv-primary-strong);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  outline: none;
+}
+
+.cv-query-result-action[aria-pressed="true"] {
+  background: transparent;
+  color: var(--cv-primary-strong);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.cv-query-result-action:disabled {
+  background: transparent;
+  cursor: not-allowed;
+  opacity: 0.45;
+  text-decoration: none;
+}
+
+.cv-query-result-action svg {
+  color: currentColor;
+  opacity: 0.5;
+}
+
+.cv-query-result-action__spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  flex: 0 0 auto;
+  border: 1.5px solid transparent;
+  border-top-color: currentColor;
+  border-right-color: currentColor;
+  border-radius: 999px;
+  opacity: 0;
+}
+
+.cv-query-result-action__spinner--active {
+  opacity: 0.72;
+  animation: cv-query-result-action-spin 0.72s linear infinite;
+}
+
+.cv-query-result-action__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@keyframes cv-query-result-action-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .cv-query-alert {
@@ -1997,83 +3150,610 @@ textarea {
 
 .cv-query-result-stack {
   display: grid;
-  gap: 12px;
-  margin-top: 12px;
+  gap: 0;
+  margin-top: 0;
+  min-width: 0;
+  overflow: visible;
 }
 
-.cv-query-column-config {
+.cv-query-result-table-shell {
   position: relative;
-  margin-left: auto;
+  display: grid;
+  min-width: 0;
 }
 
-.cv-query-column-config__panel {
-  position: absolute;
-  z-index: 20;
-  top: calc(100% + 6px);
-  right: 0;
-  width: min(360px, 72vw);
-  border: 1px solid var(--cv-border);
-  border-radius: 10px;
-  background: #ffffff;
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
-  padding: 8px;
+.cv-query-result-table-scroll {
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: visible;
+  overscroll-behavior-x: contain;
+  overscroll-behavior-y: auto;
 }
 
-.cv-query-column-config__header {
+.cv-query-result-table-header {
+  position: sticky;
+  top: 28px;
+  z-index: 24;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid #e5e8ef;
+  border-bottom-color: #d3dae6;
+  border-radius: 6px 6px 0 0;
+  background: #f5f7fa;
+  overscroll-behavior-x: contain;
+  scrollbar-width: none;
+}
+
+.cv-query-result-table-header::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+
+.cv-query-fields-panel-anchor {
+  position: relative;
+  z-index: 42;
+}
+
+.cv-query-fields-panel-anchor--open {
+  z-index: 40;
+}
+
+.cv-query-fields-panel-anchor .euiPopover,
+.cv-query-fields-panel-anchor .euiPopover__anchor {
+  display: inline-flex;
+}
+
+body .cv-query-fields-panel__popover-panel {
+  right: 16px !important;
+  left: auto !important;
+  width: min(368px, calc(100vw - 32px)) !important;
+  max-width: calc(100vw - 32px) !important;
+  overflow: hidden;
+  border: 1px solid #d3dae6 !important;
+  border-radius: 4px !important;
+  box-shadow:
+    0 10px 24px rgba(52, 55, 65, 0.12),
+    0 1px 2px rgba(52, 55, 65, 0.04) !important;
+  transition:
+    width 140ms ease,
+    max-width 140ms ease;
+}
+
+body .cv-query-fields-panel__popover-panel:has(.cv-query-fields-panel__stats) {
+  width: min(520px, calc(100vw - 32px)) !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body .cv-query-fields-panel__popover-panel {
+    transition: none;
+  }
+}
+
+.cv-query-fields-panel {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 2px 2px 8px;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.14);
+  width: 100%;
+  min-width: 0;
+  max-height: min(440px, calc(100vh - 120px));
+  flex-direction: column;
+  overflow: hidden;
+  background: #ffffff;
 }
 
-.cv-query-column-config__header strong {
-  color: #0f172a;
-  font-size: 12px;
-}
-
-.cv-query-column-config__list {
+.cv-query-fields-panel__header {
   display: grid;
-  gap: 2px;
-  max-height: 300px;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 6px;
+  min-height: 32px;
+  padding: 6px 8px 6px 10px;
+  border-bottom: 1px solid #eef2f7;
+  background: #ffffff;
+}
+
+.cv-query-fields-panel__header strong {
+  min-width: 0;
+  color: #343741;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.cv-query-fields-panel__header span {
+  display: inline-grid;
+  min-width: 22px;
+  height: 20px;
+  place-items: center;
+  border-radius: 4px;
+  background: #eef2f7;
+  color: #343741;
+  padding: 0 5px;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.cv-query-fields-panel__close {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  width: 24px !important;
+  min-width: 24px !important;
+  height: 24px !important;
+  border: 0 !important;
+  border-radius: 4px !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  color: #69707d !important;
+}
+
+.cv-query-fields-panel__close svg {
+  width: 14px !important;
+  height: 14px !important;
+}
+
+.cv-query-fields-panel__search {
+  padding: 7px 8px 4px;
+}
+
+.cv-query-fields-panel__search .euiFieldSearch {
+  min-height: 28px !important;
+  height: 28px !important;
+  border: 0 !important;
+  border-radius: 4px !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  font-size: 11.5px !important;
+}
+
+.cv-query-fields-panel__search .euiFormControlLayout {
+  min-height: 28px !important;
+  height: 28px !important;
+  border: 1px solid #d3dae6 !important;
+  border-radius: 4px !important;
+  background: #fcfdff !important;
+  box-shadow: none !important;
+}
+
+.cv-query-fields-panel__search .euiFormControlLayout__childrenWrapper {
+  min-height: 26px !important;
+  height: 26px !important;
+  border: 0 !important;
+  border-radius: 3px !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+.cv-query-fields-panel__search .euiFormControlLayout:focus-within,
+.cv-query-fields-panel__search .euiFormControlLayout.euiFormControlLayout-isFocused,
+.cv-query-fields-panel__search .euiFormControlLayout--focused {
+  border-color: #b9c4d2 !important;
+  background: #ffffff !important;
+  box-shadow: none !important;
+}
+
+.cv-query-fields-panel__search .euiFieldSearch:focus,
+.cv-query-fields-panel__search .euiFieldSearch:focus-visible {
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.cv-query-fields-panel__search .euiFormControlLayout::before,
+.cv-query-fields-panel__search .euiFormControlLayout::after,
+.cv-query-fields-panel__search .euiFormControlLayout__childrenWrapper::before,
+.cv-query-fields-panel__search .euiFormControlLayout__childrenWrapper::after {
+  box-shadow: none !important;
+}
+
+.cv-query-fields-panel__search .euiFormControlLayoutClearButton {
+  width: 22px !important;
+  height: 22px !important;
+  border: 0 !important;
+  border-radius: 4px !important;
+  background: transparent !important;
+  color: #69707d !important;
+  padding: 0 !important;
+}
+
+.cv-query-fields-panel__search .euiFormControlLayoutClearButton:hover,
+.cv-query-fields-panel__search .euiFormControlLayoutClearButton:focus-visible {
+  background: #eef1f6 !important;
+  color: #343741 !important;
+  outline: none !important;
+}
+
+.cv-query-fields-panel__body {
+  display: grid;
+  flex: 1 1 auto;
+  min-height: 116px;
+  border-top: 1px solid #eef2f7;
   overflow: auto;
-  padding-top: 6px;
+  padding: 4px 4px 5px;
+  scrollbar-gutter: stable;
 }
 
-.cv-query-column-config__item {
-  display: grid;
-  grid-template-columns: 16px minmax(0, 1fr) auto;
+.cv-query-fields-panel__tabs {
+  display: grid !important;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   align-items: center;
-  gap: 8px;
-  min-height: 28px;
-  padding: 4px 6px;
-  border-radius: 7px;
-  color: #334155;
-  font-size: 12px;
-  cursor: pointer;
+  gap: 0;
+  min-height: 31px;
+  border-bottom: 0 !important;
+  background: #ffffff;
+  padding: 0 8px;
 }
 
-.cv-query-column-config__item:hover {
-  background: #f8fafc;
+.cv-query-fields-panel__tab {
+  position: relative;
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  min-width: 0;
+  width: 100%;
+  max-width: none;
+  min-height: 30px !important;
+  height: 30px !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  color: #69707d !important;
+  outline: none !important;
+  padding: 0 4px !important;
+  font-size: 11px !important;
+  font-weight: 650 !important;
+  line-height: 30px !important;
 }
 
-.cv-query-column-config__item span {
+.cv-query-fields-panel__tab::before {
+  display: none !important;
+}
+
+.cv-query-fields-panel__tab::after {
+  content: "";
+  position: absolute;
+  right: 8px;
+  bottom: 0;
+  left: 8px;
+  height: 2px;
+  border: 0 !important;
+  border-bottom: 0 !important;
+  border-radius: 2px 2px 0 0;
+  background: transparent;
+  box-shadow: none !important;
+}
+
+.cv-query-fields-panel__tab .euiTab__content {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.cv-query-fields-panel__tab .euiTab__content > span {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.cv-query-column-config__item em {
-  color: #94a3b8;
-  font-style: normal;
+.cv-query-fields-panel__tab strong {
+  flex: 0 0 auto;
+  min-width: 0;
+  border-radius: 0;
+  background: transparent;
+  color: #8a95a6;
+  padding: 0;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 30px;
+  text-align: center;
+}
+
+.cv-query-fields-panel__tab:hover,
+.cv-query-fields-panel__tab:focus,
+.cv-query-fields-panel__tab:focus-visible {
+  background: transparent !important;
+  box-shadow: none !important;
+  color: #343741 !important;
+  outline: none !important;
+  text-decoration: none !important;
+}
+
+.cv-query-fields-panel__tab.euiTab-isSelected,
+.cv-query-fields-panel__tab[aria-selected="true"] {
+  color: var(--cv-primary-strong) !important;
+}
+
+.cv-query-fields-panel__tab.euiTab-isSelected::after,
+.cv-query-fields-panel__tab[aria-selected="true"]::after {
+  background: var(--cv-primary);
+}
+
+.cv-query-fields-panel__tab.euiTab-isSelected strong,
+.cv-query-fields-panel__tab[aria-selected="true"] strong {
+  color: var(--cv-primary-strong);
+}
+
+.cv-query-fields-panel__group-list {
+  display: grid;
+  gap: 0;
+  padding: 1px 0 4px;
+}
+
+.cv-query-fields-panel__item {
+  display: block;
+  min-height: 29px;
+  border-radius: 3px;
+  padding: 1px 3px 1px 6px;
+}
+
+.cv-query-fields-panel__item:hover,
+.cv-query-fields-panel__item:focus-within {
+  background: #f5f7fa;
+}
+
+.cv-query-fields-panel__item--expanded {
+  background: #f8fafc;
+}
+
+.cv-query-fields-panel__item-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 4px;
+  min-height: 27px;
+}
+
+.cv-query-fields-panel__field {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr);
+  align-items: center;
+  gap: 3px;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: #343741;
+  padding: 4px 0;
+  cursor: pointer;
+  text-align: left;
+}
+
+.cv-query-fields-panel__field:hover,
+.cv-query-fields-panel__field:focus-visible {
+  color: var(--cv-primary-strong);
+  outline: none;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.cv-query-fields-panel__field--disabled,
+.cv-query-fields-panel__field:disabled,
+.cv-query-fields-panel__field--disabled:hover,
+.cv-query-fields-panel__field:disabled:hover,
+.cv-query-fields-panel__field--disabled:focus-visible,
+.cv-query-fields-panel__field:disabled:focus-visible {
+  color: #69707d;
+  cursor: default;
+  text-decoration: none;
+}
+
+.cv-query-fields-panel__field-toggle {
+  width: 14px;
+  height: 14px;
+  color: #69707d;
+}
+
+.cv-query-fields-panel__field:hover .cv-query-fields-panel__field-toggle,
+.cv-query-fields-panel__field:focus-visible .cv-query-fields-panel__field-toggle {
+  color: var(--cv-primary-strong);
+}
+
+.cv-query-fields-panel__field-toggle--empty {
+  display: block;
+}
+
+.cv-query-fields-panel__field-name {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  font-weight: 520;
+}
+
+.cv-query-fields-panel__actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 22px;
+  gap: 0;
+}
+
+.cv-query-fields-panel__icon-button {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  width: 20px !important;
+  min-width: 20px !important;
+  height: 20px !important;
+  border: 0 !important;
+  border-radius: 3px !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  color: #69707d !important;
+}
+
+.cv-query-fields-panel__icon-button svg {
+  width: 14px !important;
+  height: 14px !important;
+}
+
+.cv-query-fields-panel__icon-button:hover,
+.cv-query-fields-panel__icon-button:focus-visible {
+  background: var(--cv-primary-tint) !important;
+  box-shadow: none !important;
+  color: var(--cv-primary-strong) !important;
+  outline: 1px solid var(--cv-primary-focus) !important;
+  outline-offset: 0 !important;
+}
+
+.cv-query-fields-panel__close:hover,
+.cv-query-fields-panel__close:focus-visible {
+  background: var(--cv-primary-tint) !important;
+  box-shadow: none !important;
+  color: var(--cv-primary-strong) !important;
+  outline: 1px solid var(--cv-primary-focus) !important;
+  outline-offset: 0 !important;
+}
+
+.cv-query-fields-panel__close:focus:not(:focus-visible) {
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+.cv-query-fields-panel__icon-button:disabled {
+  background: transparent !important;
+  box-shadow: none !important;
+  color: #c5ccd6 !important;
+  cursor: not-allowed !important;
+}
+
+.cv-query-fields-panel__empty {
+  display: grid;
+  min-height: 82px;
+  place-items: center;
+  color: #98a2b3;
+  font-size: 12px;
+}
+
+.cv-query-fields-panel__stats {
+  margin: 1px 1px 5px 12px;
+  border-left: 2px solid #dce5ef;
+  padding: 2px 0 3px 8px;
+}
+
+.cv-query-fields-panel__stats-header {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 5px;
+  min-height: 22px;
+  color: #69707d;
+  font-size: 10.5px;
+  font-weight: 650;
+}
+
+.cv-query-fields-panel__stats-header span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cv-query-fields-panel__stats-cancel {
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--cv-primary-strong);
+  cursor: pointer;
+  font: inherit;
+  font-size: 10.5px;
+  font-weight: 650;
+  line-height: 18px;
+  padding: 0 4px;
+}
+
+.cv-query-fields-panel__stats-cancel:hover,
+.cv-query-fields-panel__stats-cancel:focus-visible {
+  background: var(--cv-primary-soft);
+  outline: none;
+}
+
+.cv-query-fields-panel__stats .cv-query-field-stats {
+  max-height: none;
+  overflow: visible;
+  padding: 1px 0 0;
+}
+
+.cv-query-fields-panel__stats .cv-query-field-stats__item {
+  grid-template-columns: minmax(13ch, 1fr) minmax(58px, 92px) minmax(6ch, 7ch) auto;
+  gap: 7px;
+  min-height: 25px;
+  padding: 2px 0;
+}
+
+.cv-query-fields-panel__stats .cv-query-field-stats__value {
   font-size: 11px;
+}
+
+.cv-query-fields-panel__stats .cv-query-field-stats__meta {
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0;
+  font-size: 10px;
+}
+
+.cv-query-fields-panel__stats .cv-query-field-stats__meta strong {
+  font-size: 10.5px;
+  text-align: right;
+}
+
+.cv-query-fields-panel__stats .cv-query-field-stats__meta span {
+  display: none;
+}
+
+.cv-query-fields-panel__stats .cv-query-field-stats__actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.cv-query-fields-panel__stats .cv-query-field-stats__action {
+  width: 20px;
+  height: 20px;
+}
+
+.cv-query-fields-panel__footer {
+  display: flex;
+  flex: 0 0 auto;
+  justify-content: flex-start;
+  padding: 5px 6px;
+  border-top: 1px solid #eef2f7;
+  background: #ffffff;
+}
+
+.cv-query-fields-panel__reset {
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #8a95a6;
+  padding: 4px 6px;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 550;
+  line-height: 1.2;
+}
+
+.cv-query-fields-panel__reset:hover,
+.cv-query-fields-panel__reset:focus-visible {
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-strong);
+  text-decoration: none;
+  outline: none;
 }
 
 .cv-query-result-table {
   width: 100%;
   border-collapse: separate;
   border-spacing: 0 2px;
+}
+
+.cv-query-result-table-shell .cv-query-result-table {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 .cv-query-result-table th {
@@ -2095,28 +3775,22 @@ textarea {
 }
 
 .cv-query-result-table__row--active {
-  background: #fffaf5;
+  background: #f8fbff;
   box-shadow: none;
 }
 
 .cv-query-result-table__row--active td:first-child {
-  position: relative;
-  padding-left: 9px;
+  position: sticky;
+  padding-left: 4px !important;
 }
 
 .cv-query-result-table__row--active td:first-child::before {
-  content: "";
-  position: absolute;
-  top: 6px;
-  bottom: 6px;
-  left: 2px;
-  width: 3px;
-  border-radius: 999px;
-  background: var(--cv-primary);
+  content: none;
+  display: none;
 }
 
 .cv-query-result-table__row--active td:first-child {
-  border-top-left-radius: 8px;
+  border-top-left-radius: 0;
 }
 
 .cv-query-result-table__row--active td:last-child {
@@ -2128,26 +3802,69 @@ textarea {
 }
 
 .cv-query-result-table__row:hover {
-  background: #fff7ed;
+  background: #f8fbff;
 }
 
 .cv-query-result-table__row:focus {
-  outline: 2px solid color-mix(in srgb, var(--cv-primary) 28%, transparent);
-  outline-offset: -2px;
+  outline: none;
+}
+
+.cv-query-result-table__row:focus-visible td {
+  background: #fbfcfd;
+  box-shadow:
+    inset 0 1px 0 #d3dae6,
+    inset 0 -1px 0 #d3dae6;
 }
 
 .cv-query-result-table__detail-row td {
-  padding: 4px 8px 10px 16px;
-  border-bottom: 0;
+  padding: 0;
+  border-bottom-color: #d3dae6;
   border-bottom-right-radius: 8px;
   border-bottom-left-radius: 8px;
-  background: transparent;
+  background: #ffffff;
 }
 
 .cv-query-result-table__level {
-  color: var(--cv-primary-strong);
   font-weight: 700;
   white-space: nowrap;
+}
+
+.cv-query-result-table__level .cv-query-truncate-text {
+  display: inline-flex;
+  max-width: 100%;
+  min-height: 18px;
+  align-items: center;
+  border-radius: 3px;
+  background: #f5f7fa;
+  color: #69707d;
+  padding: 0 5px;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 18px;
+  text-transform: lowercase;
+}
+
+.cv-query-result-table__level--error .cv-query-truncate-text {
+  background: #fff5f5;
+  color: #bd271e;
+  box-shadow: inset 0 0 0 1px #f0c4c0;
+}
+
+.cv-query-result-table__level--warning .cv-query-truncate-text {
+  background: #fff8e5;
+  color: #9d6500;
+  box-shadow: inset 0 0 0 1px #f1d39a;
+}
+
+.cv-query-result-table__level--info .cv-query-truncate-text {
+  background: #eef7ff;
+  color: #005a9e;
+  box-shadow: inset 0 0 0 1px #c7e4fa;
+}
+
+.cv-query-result-table__level--debug .cv-query-truncate-text {
+  background: #f5f7fa;
+  color: #69707d;
 }
 
 .cv-query-result-table__empty {
@@ -2468,53 +4185,238 @@ textarea {
 }
 
 .cv-query-detail--inline {
+  position: sticky;
+  left: 0;
+  width: 100%;
+  max-width: none;
   margin: 0;
-  border-radius: 8px;
-  border-color: color-mix(in srgb, var(--cv-primary) 12%, var(--cv-border));
-  background: #ffffff;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  gap: 0;
+  border: 0;
+  border-top: 1px solid #dfe5ef;
+  border-radius: 0;
+  background: #fbfcfd;
+  padding: 0;
+  box-shadow: none;
 }
 
 .cv-query-detail__header {
+  position: static;
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
+  align-items: center;
   gap: 12px;
-  align-items: center;
+  width: 100%;
+  max-width: none;
+  min-height: 25px;
+  padding: 5px 12px 0 16px;
+  border-bottom: 0;
+  background: #fbfcfd;
 }
 
-.cv-query-detail__header > div {
-  display: flex;
+.cv-query-detail__title {
+  display: none;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
+  min-width: 0;
 }
 
-.cv-query-detail__header span {
-  color: #64748b;
-  font-size: 12px;
+.cv-query-detail__title strong {
+  display: inline-flex;
+  min-height: 18px;
+  align-items: center;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: #343741;
+  padding: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10.5px;
+  font-weight: 650;
+}
+
+.cv-query-detail__title span {
+  display: inline-flex;
+  min-height: 16px;
+  align-items: center;
+  overflow: hidden;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: #69707d;
+  padding: 0;
+  font-size: 10.5px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cv-query-detail__title span::before {
+  content: "·";
+  margin-right: 6px;
+  color: #98a2b3;
+}
+
+.cv-query-detail__view-switch {
+  display: inline-flex;
+  flex: 0 0 auto;
+  gap: 10px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.cv-query-detail__actions {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: flex-start;
+  margin-left: 0;
+}
+
+.cv-query-detail__action {
+  display: inline-flex;
+  min-height: 22px;
+  align-items: center;
+  gap: 4px;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--cv-primary-strong);
+  cursor: pointer;
+  padding: 0 5px;
+  font-size: 11.5px;
+  font-weight: 650;
+  line-height: 22px;
+}
+
+.cv-query-detail__action svg,
+.cv-query-detail__action .euiIcon {
+  color: currentColor !important;
+  opacity: 0.74;
+}
+
+.cv-query-detail__action:hover,
+.cv-query-detail__action:focus-visible {
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-strong);
+  outline: none;
+  text-decoration: none;
+}
+
+.cv-query-detail__view {
+  position: relative;
+  min-height: 22px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: #69707d;
+  padding: 0 0 4px;
+  font-size: 11.5px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.cv-query-detail__view:hover,
+.cv-query-detail__view:focus-visible {
+  background: transparent;
+  color: var(--cv-primary-strong);
+  text-decoration: none;
+  outline: none;
+}
+
+.cv-query-detail__view--active {
+  background: transparent;
+  color: var(--cv-primary-strong);
+  box-shadow: inset 0 -2px 0 var(--cv-primary);
+  text-decoration: none;
 }
 
 .cv-query-detail__body {
-  max-height: 360px;
-  overflow: auto;
   gap: 0;
-  border: 1px solid rgba(148, 163, 184, 0.16);
-  border-radius: 9px;
-  background: #ffffff;
+  width: 100%;
+  max-width: none;
+  border: 0;
+  border-radius: 0;
+  background: #fbfcfd;
+  padding: 0 16px 9px 16px;
+}
+
+.cv-query-detail__focus {
+  display: grid;
+  gap: 6px;
+}
+
+.cv-query-detail__message {
+  display: grid;
+  grid-template-columns: minmax(184px, 240px) minmax(0, 1fr);
+  gap: 14px;
+  align-items: start;
+  border: 0;
+  border-bottom: 1px solid #eef1f6;
+  background: transparent;
+  padding: 5px 0 8px;
+}
+
+.cv-query-detail__message > span {
+  color: #69707d;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.55;
+}
+
+.cv-query-detail__message > .cv-query-detail__field-cell {
+  align-self: start;
+  line-height: 1.55;
+}
+
+.cv-query-detail__message code {
+  min-width: 0;
+  color: #1f2937;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12.5px;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.cv-query-detail__fields {
+  display: grid;
+  overflow: hidden;
+  border: 0;
+  border-top: 0;
+  border-radius: 0;
+  background: transparent;
 }
 
 .cv-query-detail__json {
-  max-height: 360px;
-  background: #ffffff;
+  width: 100%;
+  max-width: none;
+  overflow-x: auto;
+  overflow-y: visible;
+  border: 0;
+  border-radius: 0;
+  border-bottom: 1px solid #eef1f6;
+  background: #fbfcfd;
+  padding: 8px 14px 10px 16px;
+  overscroll-behavior-x: contain;
+  overscroll-behavior-y: auto;
 }
 
 .cv-query-detail__row {
+  position: relative;
   display: grid;
-  grid-template-columns: minmax(150px, 220px) minmax(0, 1fr);
-  gap: 10px;
-  align-items: center;
-  min-height: 30px;
-  padding: 6px 8px;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+  grid-template-columns: minmax(184px, 240px) minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
+  min-height: 26px;
+  padding: 3px 6px 3px 0;
+  border-bottom: 1px solid #f0f3f7;
+}
+
+.cv-query-detail__row:hover {
+  background: #f7faff;
 }
 
 .cv-query-detail__row:last-child {
@@ -2522,63 +4424,93 @@ textarea {
 }
 
 .cv-query-detail__row--nested {
-  grid-template-columns: minmax(130px, 200px) minmax(0, 1fr);
-  padding-left: 22px;
-  background: #fffaf5;
+  grid-template-columns: minmax(172px, 224px) minmax(0, 1fr);
+  padding-left: 24px;
+  background: transparent;
+}
+
+.cv-query-detail__row--nested::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 13px;
+  width: 1px;
+  background: #e5e8ef;
+}
+
+.cv-query-detail__row--nested strong {
+  position: relative;
 }
 
 .cv-query-detail__row--nested strong::before {
-  content: "↳ ";
-  color: #94a3b8;
-  font-weight: 500;
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: -12px;
+  width: 9px;
+  height: 1px;
+  background: #e5e8ef;
 }
 
 .cv-query-detail__row strong {
   overflow: hidden;
-  color: var(--cv-primary-strong);
+  color: #475569;
   font-size: 12px;
-  font-weight: 650;
+  font-weight: 700;
   line-height: 1.5;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+.cv-query-detail__field-cell {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 98px;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  padding-right: 0;
+}
+
+.cv-query-detail__key-text,
 .cv-query-detail__key-button {
+  display: block;
+  box-sizing: border-box;
   max-width: 100%;
-  border: 0;
-  border-radius: 5px;
-  padding: 0 3px;
-  background: transparent;
-  color: inherit;
-  font: inherit;
-  text-align: left;
+  overflow: hidden;
+  color: #475569;
   text-overflow: ellipsis;
   white-space: nowrap;
-  overflow: hidden;
+}
+
+.cv-query-detail__key-text {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  padding-right: 0;
+}
+
+.cv-query-detail__key-button {
+  border: 0;
+  border-radius: 3px;
+  padding: 0 2px;
+  background: transparent;
+  font: inherit;
+  text-align: left;
   cursor: pointer;
 }
 
 .cv-query-detail__key-button:hover {
-  background: var(--cv-primary-soft);
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-strong);
 }
 
-.cv-query-detail__row span,
+.cv-query-detail__value-text,
 .cv-query-detail__value-button {
   color: #334155;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 12px;
   line-height: 1.5;
   min-width: 0;
-}
-
-.cv-query-detail__value-actions {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  width: 100%;
-  min-width: 0;
-  max-width: 100%;
-  overflow: hidden;
 }
 
 .cv-query-detail__value-button {
@@ -2588,8 +4520,8 @@ textarea {
   min-width: 0;
   max-width: 100%;
   border: 0;
-  border-radius: 5px;
-  padding: 0 3px;
+  border-radius: 3px;
+  padding: 0 2px;
   background: transparent;
   text-align: left;
   overflow: hidden;
@@ -2600,165 +4532,319 @@ textarea {
 
 .cv-query-detail__value-text {
   display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  min-width: 0;
+  max-width: 100%;
+  overflow: visible;
+  overflow-wrap: anywhere;
+  text-overflow: clip;
+  white-space: pre-wrap;
+}
+
+.cv-query-detail__value-cell {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  gap: 7px;
+}
+
+.cv-query-detail__value-cell .cv-query-detail__value-text {
+  flex: 1 1 auto;
+}
+
+.cv-query-detail__nested-toggle {
+  flex: 0 0 auto;
+  min-height: 18px;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  color: #69707d;
+  cursor: pointer;
+  padding: 0 2px;
+  font-size: 10.5px;
+  font-weight: 650;
+  line-height: 18px;
+  opacity: 0.82;
+}
+
+.cv-query-detail__nested-toggle:hover,
+.cv-query-detail__nested-toggle:focus-visible {
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-strong);
+  opacity: 1;
+  outline: none;
+}
+
+.cv-query-detail__row--metadata-toggle {
+  min-height: 30px;
+  background: transparent;
+}
+
+.cv-query-detail__row--metadata-toggle:hover {
+  background: var(--cv-primary-tint);
+}
+
+.cv-query-detail__metadata-toggle {
+  justify-self: start;
+  min-height: 20px;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  color: #69707d;
+  cursor: pointer;
+  padding: 0 2px;
+  font-size: 10.5px;
+  font-weight: 650;
+  opacity: 0.82;
+}
+
+.cv-query-detail__metadata-toggle:hover,
+.cv-query-detail__metadata-toggle:focus-visible {
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-strong);
+  opacity: 1;
+  outline: none;
+}
+
+.cv-query-detail__row-actions {
+  position: static;
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 2px;
+  width: 98px;
+  min-width: 98px;
+  padding-left: 0;
+  background: transparent;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 120ms ease;
+}
+
+.cv-query-detail__icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  background: transparent;
+  color: #69707d;
+  padding: 0;
+  opacity: 1;
+  cursor: pointer;
+  transition: border-color 120ms ease, background-color 120ms ease, color 120ms ease, opacity 120ms ease;
+}
+
+.cv-query-detail__icon-button--quick {
+  color: #69707d;
+  opacity: 0;
+}
+
+.cv-query-detail__icon-button--secondary {
+  display: none;
+  color: #98a2b3;
+  opacity: 0.72;
+  pointer-events: none;
+}
+
+.cv-query-detail__message:hover .cv-query-detail__icon-button--secondary,
+.cv-query-detail__message:focus-within .cv-query-detail__icon-button--secondary,
+.cv-query-detail__row:hover .cv-query-detail__icon-button--secondary,
+.cv-query-detail__row:focus-within .cv-query-detail__icon-button--secondary {
+  display: inline-flex;
+  opacity: 0.72;
+  pointer-events: auto;
+}
+
+.cv-query-detail__message:hover .cv-query-detail__icon-button--quick,
+.cv-query-detail__message:focus-within .cv-query-detail__icon-button--quick,
+.cv-query-detail__row:hover .cv-query-detail__icon-button--quick,
+.cv-query-detail__row:focus-within .cv-query-detail__icon-button--quick,
+.cv-query-detail__field-cell:hover .cv-query-detail__icon-button--quick,
+.cv-query-detail__field-cell:focus-within .cv-query-detail__icon-button--quick {
+  color: var(--cv-primary-strong);
+  opacity: 0.9;
+}
+
+.cv-query-detail__message:hover .cv-query-detail__row-actions,
+.cv-query-detail__message:focus-within .cv-query-detail__row-actions,
+.cv-query-detail__row:hover .cv-query-detail__row-actions,
+.cv-query-detail__row:focus-within .cv-query-detail__row-actions,
+.cv-query-detail__field-cell:hover .cv-query-detail__row-actions,
+.cv-query-detail__field-cell:focus-within .cv-query-detail__row-actions {
+  opacity: 1;
+  pointer-events: auto;
+  background: transparent;
+}
+
+.cv-query-detail__icon-button:hover {
+  border-color: transparent;
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-strong);
+}
+
+.cv-query-detail__icon-button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--cv-primary) 24%, transparent);
+  outline-offset: 1px;
 }
 
 .cv-query-detail__link-button {
   flex: none;
-  border: 1px solid color-mix(in srgb, var(--cv-primary) 18%, var(--cv-border));
-  border-radius: 999px;
-  background: #ffffff;
-  color: var(--cv-primary-strong);
-  padding: 0 6px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #64748b;
+  padding: 0 5px;
   font-size: 11px;
-  line-height: 20px;
+  font-weight: 700;
+  line-height: 22px;
+  opacity: 0;
   cursor: pointer;
+  transition: opacity 120ms ease, background-color 120ms ease;
+}
+
+.cv-query-detail__row:hover .cv-query-detail__link-button,
+.cv-query-detail__row:focus-within .cv-query-detail__link-button {
+  opacity: 1;
 }
 
 .cv-query-detail__link-button:hover {
-  background: var(--cv-primary-soft);
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-text);
 }
 
 .cv-query-field-stats-modal {
-  width: min(520px, calc(100vw - 24px));
-}
-
-.cv-query-confirm-backdrop {
-  z-index: 48;
-  background: rgba(15, 23, 42, 0.28);
-}
-
-.cv-query-field-stats-confirm {
-  width: min(640px, calc(100vw - 24px));
-  padding: 14px;
-  border-radius: 12px;
-  background: #ffffff;
-}
-
-.cv-query-field-stats-confirm__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 12px;
-}
-
-.cv-query-field-stats-confirm__body {
-  display: grid;
-  gap: 6px;
-  margin: 12px 0;
-  padding: 10px;
-  border: 1px solid color-mix(in srgb, var(--cv-primary) 18%, var(--cv-border));
-  border-radius: 8px;
-  background: #fffaf5;
-}
-
-.cv-query-field-stats-confirm__body-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 8px;
-}
-
-.cv-query-field-stats-confirm__body-header span {
-  color: #64748b;
-  font-size: 12px;
-}
-
-.cv-query-field-stats-confirm__copy {
-  flex: 0 0 auto;
-  min-height: 24px;
-  border: 1px solid color-mix(in srgb, var(--cv-primary) 22%, var(--cv-border));
-  border-radius: 7px;
-  background: #ffffff;
-  color: var(--cv-primary-strong);
-  padding: 0 8px;
-  font-size: 12px;
-  font-weight: 700;
-  cursor: pointer;
-}
-
-.cv-query-field-stats-confirm__copy:hover {
-  background: var(--cv-primary-soft);
-}
-
-.cv-query-field-stats-confirm__body code {
-  max-height: 110px;
-  overflow: auto;
-  color: #334155;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 12px;
-  line-height: 1.5;
-  overflow-wrap: anywhere;
-  white-space: pre-wrap;
+  width: min(420px, calc(100vw - 24px));
 }
 
 .cv-query-field-stats {
   display: grid;
-  gap: 6px;
-  max-height: min(520px, calc(100vh - 190px));
+  gap: 0;
+  max-height: min(420px, calc(100vh - 190px));
   overflow: auto;
-  padding: 10px;
+  padding: 4px 10px 8px;
 }
 
 .cv-query-field-stats__item {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(96px, 140px) 96px;
+  grid-template-columns: minmax(0, 1fr) minmax(48px, 72px) minmax(17ch, 18ch) max-content;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   width: 100%;
-  border: 1px solid transparent;
-  border-radius: 7px;
-  background: #ffffff;
-  padding: 6px 8px;
+  min-height: 29px;
+  border: 0;
+  border-bottom: 1px solid #eef1f6;
+  border-radius: 0;
+  background: transparent;
+  padding: 3px 0;
   text-align: left;
-  cursor: pointer;
 }
 
-.cv-query-field-stats__item:hover {
-  border-color: color-mix(in srgb, var(--cv-primary) 22%, var(--cv-border));
-  background: #fffaf5;
+.cv-query-field-stats__item > * {
+  min-width: 0;
+}
+
+.cv-query-field-stats__item:hover,
+.cv-query-field-stats__item:focus-within {
+  background: color-mix(in srgb, var(--cv-primary-soft) 58%, #ffffff);
 }
 
 .cv-query-field-stats__value {
+  display: block;
   overflow: hidden;
   color: #334155;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 12px;
+  font-size: 11.5px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+.cv-query-field-stats__value-anchor {
+  display: block !important;
+  min-width: 0;
+  overflow: hidden;
+}
+
 .cv-query-field-stats__bar {
   min-width: 0;
-  height: 6px;
+  height: 3px;
   overflow: hidden;
   border-radius: 999px;
-  background: #edf0f4;
+  background: color-mix(in srgb, var(--cv-primary) 14%, #ffffff);
 }
 
 .cv-query-field-stats__bar span {
   display: block;
   height: 100%;
   border-radius: inherit;
-  background: var(--cv-primary);
+  background: linear-gradient(90deg, var(--cv-primary-strong), var(--cv-primary));
 }
 
 .cv-query-field-stats__meta {
-  display: inline-flex;
-  justify-content: flex-end;
+  display: grid;
+  grid-template-columns: 6.8ch minmax(0, 1fr);
   align-items: baseline;
   gap: 6px;
   min-width: 0;
+  overflow: hidden;
   color: #64748b;
   font-size: 11px;
+  font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 
 .cv-query-field-stats__meta strong {
-  color: #334155;
+  min-width: 0;
+  color: var(--cv-primary-strong);
   font-size: 12px;
+  overflow: hidden;
+  text-align: right;
+  text-overflow: ellipsis;
+}
+
+.cv-query-field-stats__meta span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cv-query-field-stats__actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 2px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease;
+}
+
+.cv-query-field-stats__item:hover .cv-query-field-stats__actions,
+.cv-query-field-stats__item:focus-within .cv-query-field-stats__actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.cv-query-field-stats__action {
+  display: inline-grid;
+  width: 22px;
+  height: 22px;
+  place-items: center;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: color-mix(in srgb, var(--cv-primary-strong) 58%, #8a95a6);
+  cursor: pointer;
+  padding: 0;
+}
+
+.cv-query-field-stats__action:hover,
+.cv-query-field-stats__action:focus-visible {
+  background: var(--cv-primary-soft);
+  color: var(--cv-primary-strong);
+  outline: none;
 }
 
 .cv-query-link-panel {
@@ -3169,7 +5255,7 @@ textarea {
 }
 
 .cv-query-detail__value-button:hover {
-  background: var(--cv-primary-soft);
+  background: var(--cv-primary-tint);
   color: var(--cv-primary-strong);
 }
 
@@ -3180,9 +5266,199 @@ textarea {
 
 .cv-query-pagination {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  justify-content: flex-end;
   gap: 12px;
+  min-width: 0;
+  padding-top: 5px;
+}
+
+.cv-query-pagination--toolbar {
+  flex: 0 1 auto;
+  gap: 8px;
+  padding-top: 0;
+}
+
+.cv-query-pagination--footer {
+  flex: 0 0 auto;
+  gap: 8px;
+  padding-top: 0;
+}
+
+.cv-query-page-size {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 5px;
+  min-width: 0;
+  min-height: 22px;
+  overflow: visible;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: #69707d;
+  font-size: 11.5px;
+  font-weight: 500;
+  padding: 0;
+}
+
+.cv-query-page-size__label {
+  margin: 0 2px 0 0;
+  color: #69707d;
+  font-size: 10.5px;
+  font-weight: 650;
+  line-height: 20px;
+}
+
+.cv-query-page-size__option {
+  display: inline-flex;
+  position: relative;
+  align-items: center;
+  min-height: 22px;
+  overflow: hidden;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #69707d;
+  cursor: pointer;
+  padding: 0;
+}
+
+.cv-query-page-size__option input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.cv-query-page-size__option span {
+  display: inline-flex;
+  min-width: 28px;
+  justify-content: center;
+  padding: 0 6px;
+  line-height: 22px;
+}
+
+.cv-query-page-size__option:hover {
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-strong);
+  text-decoration: none;
+}
+
+.cv-query-page-size__option:focus-within {
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-strong);
+  outline: none;
+  text-decoration: none;
+  box-shadow: none;
+}
+
+.cv-query-page-size__option--active {
+  border-color: transparent;
+  background: var(--cv-primary-soft);
+  color: var(--cv-primary-strong);
+  font-weight: 700;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--cv-primary) 24%, var(--cv-border));
+}
+
+.cv-query-page-size__option--active::after {
+  content: none;
+}
+
+.cv-query-page-size__option:has(input:disabled) {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+.cv-query-pagination__pager {
+  display: inline-flex;
+  position: relative;
+  align-items: center;
+  justify-content: flex-end;
+  flex: 0 0 auto;
+  gap: 3px;
+  min-width: 0;
+}
+
+.cv-query-page-size + .cv-query-pagination__pager {
+  padding-left: 9px;
+}
+
+.cv-query-page-size + .cv-query-pagination__pager::before {
+  content: "";
+  position: absolute;
+  top: 5px;
+  bottom: 5px;
+  left: 0;
+  width: 1px;
+  background: #edf1f6;
+}
+
+.cv-query-pagination__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  width: 72px;
+  min-width: 72px;
+  min-height: 24px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--cv-primary-strong);
+  padding: 0 5px;
+  cursor: pointer;
+  font-size: 11.5px;
+  font-weight: 650;
+  line-height: 24px;
+}
+
+.cv-query-pagination__button svg {
+  color: currentColor;
+  opacity: 0.66;
+}
+
+.cv-query-pagination__button:hover,
+.cv-query-pagination__button:focus-visible {
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-strong);
+  outline: none;
+  text-decoration: none;
+}
+
+.cv-query-pagination__button:disabled {
+  background: transparent;
+  color: #98a2b3;
+  cursor: not-allowed;
+  opacity: 0.72;
+  text-decoration: none;
+}
+
+.cv-query-pagination__button:disabled:hover,
+.cv-query-pagination__button:disabled:focus-visible {
+  background: transparent;
+  color: #98a2b3;
+  outline: none;
+}
+
+.cv-query-pagination__button:disabled svg {
+  opacity: 0.56;
+}
+
+.cv-query-pagination__page {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  min-width: 64px;
+  color: #69707d;
+  font-size: 11.5px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  line-height: 24px;
+  text-align: center;
+  white-space: nowrap;
 }
 
 .cv-query-empty-text {
@@ -3192,7 +5468,11 @@ textarea {
 }
 
 .cv-query-empty-text--spaced {
-  margin-top: 12px;
+  margin-top: 2px;
+  min-height: 24px;
+  border-radius: 6px;
+  background: #f8fafc;
+  padding: 5px 8px;
 }
 
 .cv-query-workspace > .cv-query-panel:first-child {
@@ -3654,6 +5934,436 @@ textarea {
 
 .cv-report-modal--wide {
   width: min(960px, 100%);
+}
+
+.cv-report-modal-backdrop.cv-query-field-stats-backdrop {
+  align-items: flex-start;
+  justify-content: flex-end;
+  padding: 92px 14px 16px;
+  background: transparent;
+  pointer-events: none;
+}
+
+.cv-report-modal-backdrop.cv-query-condition-modal-backdrop {
+  background: rgba(52, 55, 65, 0.08);
+}
+
+.cv-report-modal-backdrop.cv-query-save-modal-backdrop {
+  background: rgba(52, 55, 65, 0.08);
+}
+
+.cv-report-modal-backdrop.cv-query-confirm-modal-backdrop {
+  background: rgba(52, 55, 65, 0.08);
+}
+
+.cv-report-modal.cv-query-confirm-modal {
+  width: min(420px, calc(100vw - 32px));
+  max-height: min(260px, calc(100vh - 48px));
+  overflow: hidden;
+  border: 1px solid #d3dae6;
+  border-radius: 6px;
+  background: #ffffff;
+  box-shadow: 0 14px 34px rgba(52, 55, 65, 0.16);
+  padding: 0;
+}
+
+.cv-query-confirm-modal__header {
+  align-items: center;
+  margin: 0;
+  border-bottom: 1px solid #e5e8ef;
+  background: #fbfcfd;
+  padding: 8px 10px 8px 12px;
+}
+
+.cv-query-confirm-modal__header .cv-panel-title {
+  color: #343741;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.cv-query-confirm-modal__close {
+  display: grid;
+  flex: 0 0 auto;
+  width: 26px;
+  height: 26px;
+  place-items: center;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #69707d;
+  cursor: pointer;
+  padding: 0;
+}
+
+.cv-query-confirm-modal__close:hover,
+.cv-query-confirm-modal__close:focus-visible {
+  background: #eef1f6;
+  color: #343741;
+  outline: none;
+}
+
+.cv-query-confirm-modal__body {
+  display: grid;
+  gap: 12px;
+  padding: 12px;
+}
+
+.cv-query-confirm-modal__text-action {
+  min-height: 26px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #69707d;
+  cursor: pointer;
+  padding: 0 1px;
+  font-family: var(--cv-font-ui);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.cv-query-confirm-modal__text-action:hover,
+.cv-query-confirm-modal__text-action:focus-visible {
+  color: var(--cv-primary-strong);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  outline: none;
+}
+
+.cv-query-confirm-modal__text-action--danger {
+  color: #bd271e;
+}
+
+.cv-query-confirm-modal__text-action--danger:hover,
+.cv-query-confirm-modal__text-action--danger:focus-visible {
+  color: #8f1f18;
+}
+
+.cv-report-modal.cv-query-save-modal {
+  width: min(520px, calc(100vw - 32px));
+  max-height: min(360px, calc(100vh - 48px));
+  overflow: hidden;
+  border: 1px solid #d8dee8;
+  border-radius: 4px;
+  background: #ffffff;
+  box-shadow:
+    0 10px 24px rgba(52, 55, 65, 0.12),
+    0 2px 5px rgba(52, 55, 65, 0.05);
+  padding: 0;
+}
+
+.cv-query-save-modal__header {
+  align-items: center;
+  margin: 0;
+  border-bottom: 1px solid #eef1f6;
+  background: #fbfcfd;
+  padding: 7px 9px 7px 11px;
+}
+
+.cv-query-save-modal__header .cv-panel-title {
+  color: #343741;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.cv-query-save-modal__close {
+  display: grid;
+  flex: 0 0 auto;
+  width: 26px;
+  height: 26px;
+  place-items: center;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #69707d;
+  cursor: pointer;
+  padding: 0;
+}
+
+.cv-query-save-modal__close:hover,
+.cv-query-save-modal__close:focus-visible {
+  background: #eef1f6;
+  color: #343741;
+  outline: none;
+}
+
+.cv-query-save-modal__body {
+  display: grid;
+  gap: 9px;
+  padding: 9px 12px 12px;
+}
+
+.cv-query-save-modal__field {
+  display: grid;
+  gap: 4px;
+  color: #69707d;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.cv-query-save-modal__field .euiFormControlLayout {
+  min-height: 30px;
+  border: 1px solid #d8dee8;
+  border-radius: 4px;
+  background: #ffffff;
+  box-shadow: none;
+}
+
+.cv-query-save-modal__field .euiFormControlLayout:focus-within {
+  border-color: #b9c4d2;
+  box-shadow: none;
+}
+
+.cv-query-save-modal__field .euiFieldText {
+  min-height: 30px !important;
+  border: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  color: #343741 !important;
+  padding: 0 9px !important;
+  font-size: 12px !important;
+  font-weight: 600 !important;
+}
+
+.cv-query-save-modal__field .euiFieldText:focus,
+.cv-query-save-modal__field .euiFieldText:focus-visible {
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.cv-query-save-modal__preview {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+  color: #69707d;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.cv-query-save-modal__preview code {
+  display: block;
+  max-height: 76px;
+  min-height: 30px;
+  overflow: auto;
+  border: 1px solid #edf1f6;
+  border-radius: 4px;
+  background: #fcfdff;
+  color: #343741;
+  padding: 7px 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11.5px;
+  font-weight: 600;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.cv-query-save-modal .cv-query-modal__footer {
+  margin-top: 0;
+}
+
+.cv-query-save-modal__text-action {
+  min-height: 26px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #69707d;
+  cursor: pointer;
+  padding: 0 1px;
+  font-family: var(--cv-font-ui);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.cv-query-save-modal__text-action:hover,
+.cv-query-save-modal__text-action:focus-visible {
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-strong);
+  text-decoration: none;
+  outline: none;
+}
+
+.cv-query-save-modal__text-action--primary {
+  color: var(--cv-primary-strong);
+}
+
+.cv-report-modal.cv-query-field-stats-modal {
+  width: min(420px, calc(100vw - 24px));
+  max-height: min(68vh, 520px);
+  overflow: hidden;
+  border: 1px solid #d8dee8;
+  border-radius: 4px;
+  background: #ffffff;
+  box-shadow: 0 8px 20px rgba(52, 55, 65, 0.12);
+  padding: 0;
+  pointer-events: auto;
+}
+
+.cv-query-field-stats-modal .cv-query-field-stats__header {
+  align-items: center;
+  margin: 0;
+  border-bottom: 1px solid #eef1f6;
+  background: #ffffff;
+  padding: 7px 8px 6px 10px;
+}
+
+.cv-query-field-stats-modal .cv-query-field-stats__header > div {
+  min-width: 0;
+}
+
+.cv-query-field-stats-modal .cv-panel-title {
+  max-width: 100%;
+  overflow: hidden;
+  color: #343741;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12.5px;
+  font-weight: 700;
+}
+
+.cv-query-field-stats__meta-line {
+  display: inline-flex;
+  max-width: 100%;
+  min-width: 0;
+  align-items: center;
+  gap: 5px;
+  overflow: hidden;
+  color: #69707d;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.25;
+  white-space: nowrap;
+}
+
+.cv-query-field-stats__meta-line span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cv-query-field-stats__meta-line span + span::before {
+  content: "·";
+  margin-right: 5px;
+  color: #98a2b3;
+}
+
+.cv-query-field-stats__header-actions {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 6px;
+}
+
+.cv-query-field-stats__cancel {
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--cv-primary-strong);
+  cursor: pointer;
+  padding: 0;
+  font-size: 11.5px;
+  font-weight: 650;
+  line-height: 1;
+}
+
+.cv-query-field-stats__cancel:hover,
+.cv-query-field-stats__cancel:focus-visible {
+  color: color-mix(in srgb, var(--cv-primary-strong) 82%, #7c2d12);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  outline: none;
+}
+
+.cv-query-field-stats__close {
+  display: grid;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #69707d;
+  cursor: pointer;
+  padding: 0;
+}
+
+.cv-query-field-stats__close:hover,
+.cv-query-field-stats__close:focus-visible {
+  background: #eef1f6;
+  color: #343741;
+  outline: none;
+}
+
+.cv-query-field-stats-modal .cv-query-field-stats {
+  max-height: calc(min(68vh, 520px) - 48px);
+  background: #ffffff;
+  padding: 4px 10px 8px;
+}
+
+.cv-query-field-stats-modal .cv-query-field-stats__item {
+  grid-template-columns: minmax(0, 1fr) minmax(48px, 66px) minmax(17ch, 18ch) max-content;
+  gap: 7px;
+  min-height: 29px;
+  padding: 3px 0;
+}
+
+.cv-query-field-stats-modal .cv-query-field-stats__value {
+  color: #343741;
+  font-size: 11.5px;
+}
+
+.cv-query-field-stats-modal .cv-query-field-stats__meta {
+  color: #69707d;
+  font-size: 11px;
+}
+
+.cv-query-field-stats-modal .cv-query-field-stats__meta strong {
+  color: var(--cv-primary-strong);
+  font-size: 11.5px;
+}
+
+.cv-query-field-stats-modal .cv-query-field-stats__action {
+  width: 22px;
+  height: 22px;
+  color: color-mix(in srgb, var(--cv-primary-strong) 58%, #8a95a6);
+}
+
+.cv-query-field-stats-modal .cv-query-field-stats__action:hover,
+.cv-query-field-stats-modal .cv-query-field-stats__action:focus-visible {
+  background: var(--cv-primary-soft);
+  color: var(--cv-primary-strong);
+}
+
+.cv-query-field-stats-loading {
+  display: grid;
+  gap: 0;
+}
+
+.cv-query-field-stats-loading__row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 62px 44px;
+  align-items: center;
+  gap: 7px;
+  min-height: 29px;
+  border-bottom: 1px solid #eef1f6;
+}
+
+.cv-query-field-stats-loading__row:last-child {
+  border-bottom: 0;
+}
+
+.cv-query-field-stats-loading__row .cv-query-skeleton {
+  height: 10px;
+}
+
+.cv-query-field-stats-loading__row .cv-query-skeleton:nth-child(2) {
+  height: 3px;
+}
+
+.cv-query-field-stats-loading__row .cv-query-skeleton:nth-child(3) {
+  width: 34px;
+  justify-self: end;
 }
 
 .cv-report-error-list {
@@ -6627,7 +9337,7 @@ textarea {
 }
 
 .cv-permission-root-modal__stat strong {
-  font-family: "Space Grotesk", sans-serif;
+  font-family: var(--cv-font-ui);
   font-size: 22px;
   line-height: 1;
   color: var(--cv-primary-strong);
@@ -7573,4 +10283,4287 @@ textarea {
 .cv-login-submit {
   width: 100%;
   justify-content: center;
+}
+
+/* Kibana-like query workbench skin */
+html.cv-query-overscroll-guard,
+body.cv-query-overscroll-guard {
+  overscroll-behavior-x: none;
+}
+
+html:has(.cv-query-page),
+body:has(.cv-query-page),
+body:has(.cv-query-page) #root,
+body:has(.cv-query-page) .cv-shell,
+body:has(.cv-query-page) .cv-shell__main,
+body:has(.cv-query-page) .cv-shell__workspace,
+body:has(.cv-query-page) .cv-shell__content,
+body:has(.cv-query-page) .cv-shell__canvas,
+.cv-query-page,
+.cv-query-shell,
+.cv-query-main,
+.cv-query-workspace {
+  overscroll-behavior-x: contain;
+}
+
+body:has(.cv-query-page) .cv-shell__main {
+  scrollbar-gutter: stable;
+}
+
+.cv-query-page {
+  gap: 8px;
+  color: #1f2937;
+}
+
+.cv-query-page .cv-page-toolbar {
+  min-height: 28px;
+  margin: 0;
+  padding: 0 2px;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.cv-query-page .cv-breadcrumb {
+  color: #69707d;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.cv-query-page .cv-breadcrumb__current {
+  color: #343741;
+  font-weight: 700;
+}
+
+.cv-query-shell {
+  --cv-query-sidebar-collapsed-width: 52px;
+  --cv-query-sidebar-expanded-width: 252px;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0;
+  align-items: start;
+}
+
+.cv-query-sidebar {
+  top: 8px;
+  z-index: 30;
+  width: var(--cv-query-sidebar-collapsed-width);
+  min-width: var(--cv-query-sidebar-collapsed-width);
+  max-width: var(--cv-query-sidebar-expanded-width);
+  height: 132px;
+  max-height: 132px;
+  overflow: hidden;
+  padding: 6px;
+  border-color: #d3dae6;
+  border-radius: 6px;
+  background: #ffffff;
+  box-shadow: 0 1px 2px rgba(52, 55, 65, 0.08);
+  transition:
+    width 160ms ease,
+    min-width 160ms ease,
+    max-height 160ms ease,
+    padding 160ms ease,
+    box-shadow 160ms ease,
+    border-color 160ms ease;
+}
+
+.cv-query-sidebar:hover,
+.cv-query-sidebar:focus-within:not(:focus) {
+  z-index: 120;
+  width: var(--cv-query-sidebar-expanded-width);
+  min-width: var(--cv-query-sidebar-expanded-width);
+  height: auto;
+  max-height: calc(100vh - 98px);
+  overflow-x: hidden;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+  padding: 10px;
+  border-color: #fed7aa;
+  box-shadow: 0 12px 28px rgba(52, 55, 65, 0.16);
+}
+
+.cv-query-sidebar__rail {
+  position: absolute;
+  inset: 6px;
+  display: grid;
+  grid-template-rows: 28px auto;
+  align-content: center;
+  justify-items: center;
+  gap: 8px;
+  padding: 0;
+  color: #343741;
+  pointer-events: none;
+  transition: opacity 120ms ease, visibility 120ms ease;
+}
+
+.cv-query-sidebar:hover .cv-query-sidebar__rail,
+.cv-query-sidebar:focus-within:not(:focus) .cv-query-sidebar__rail {
+  opacity: 0;
+  visibility: hidden;
+}
+
+.cv-query-sidebar__rail-toggle {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border: 1px solid #fed7aa;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 1px 2px rgba(52, 55, 65, 0.08);
+}
+
+.cv-query-sidebar__rail-chevrons {
+  position: relative;
+  width: 17px;
+  height: 14px;
+}
+
+.cv-query-sidebar__rail-chevrons::before,
+.cv-query-sidebar__rail-chevrons::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  width: 7px;
+  height: 7px;
+  border-top: 2px solid var(--cv-primary);
+  border-right: 2px solid var(--cv-primary);
+  transform: rotate(45deg);
+}
+
+.cv-query-sidebar__rail-chevrons::before {
+  left: 1px;
+}
+
+.cv-query-sidebar__rail-chevrons::after {
+  left: 7px;
+  opacity: 0.62;
+}
+
+.cv-query-sidebar__rail-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  color: #343741;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1;
+  text-orientation: mixed;
+  writing-mode: vertical-rl;
+}
+
+.cv-query-sidebar .cv-panel-header,
+.cv-query-sidebar__body {
+  width: calc(var(--cv-query-sidebar-expanded-width) - 20px);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 120ms ease 40ms, visibility 120ms ease 40ms;
+}
+
+.cv-query-sidebar:hover .cv-panel-header,
+.cv-query-sidebar:focus-within:not(:focus) .cv-panel-header,
+.cv-query-sidebar:hover .cv-query-sidebar__body,
+.cv-query-sidebar:focus-within:not(:focus) .cv-query-sidebar__body {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.cv-query-sidebar .cv-panel-header,
+.cv-query-panel .cv-panel-header {
+  min-height: 28px;
+  margin-bottom: 6px;
+  padding: 0;
+}
+
+.cv-query-panel {
+  border: 1px solid #d3dae6;
+  border-radius: 6px;
+  background: #ffffff;
+  box-shadow: 0 1px 2px rgba(52, 55, 65, 0.08);
+}
+
+.cv-query-main {
+  gap: 6px;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.cv-query-log-tabs {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 26px;
+  padding: 1px 2px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  overflow: visible;
+  overscroll-behavior-x: contain;
+}
+
+.cv-query-log-tab-list {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  gap: 4px;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+}
+
+.cv-query-source-anchor {
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+
+.cv-query-source-anchor .euiPopover,
+.cv-query-source-anchor .euiPopover__anchor {
+  display: inline-flex;
+}
+
+.cv-query-source-trigger {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  width: auto;
+  height: 26px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--cv-primary-text);
+  cursor: pointer;
+  padding: 0 7px;
+  box-shadow: none;
+  font-size: 11.5px;
+  font-weight: 650;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease;
+}
+
+.cv-query-source-trigger span {
+  display: inline-flex;
+  align-items: center;
+}
+
+.cv-query-source-trigger svg,
+.cv-query-source-trigger .euiIcon {
+  color: currentColor;
+  opacity: 0.74 !important;
+}
+
+.cv-query-source-trigger__chevron {
+  margin-left: -2px;
+  opacity: 0.58 !important;
+}
+
+.cv-query-source-trigger:hover,
+.cv-query-source-trigger:focus-visible,
+.cv-query-source-trigger--open {
+  border-color: transparent;
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-text-strong);
+  box-shadow: none;
+  outline: none;
+}
+
+.cv-query-source-popover-panel {
+  z-index: 140 !important;
+  width: min(336px, calc(100vw - 24px)) !important;
+  max-width: calc(100vw - 24px);
+  border: 1px solid #d8dee8 !important;
+  border-radius: 4px !important;
+  box-shadow:
+    0 8px 18px rgba(52, 55, 65, 0.1),
+    0 1px 2px rgba(52, 55, 65, 0.04) !important;
+}
+
+.cv-query-source-popover {
+  display: grid;
+  max-height: min(70vh, 560px);
+  background: #ffffff;
+  color: #343741;
+}
+
+.cv-query-source-popover__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 34px;
+  padding: 6px 9px;
+  border-bottom: 1px solid #e5e8ef;
+  background: #ffffff;
+}
+
+.cv-query-source-popover__header > div {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+}
+
+.cv-query-source-popover__header strong {
+  color: #343741;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.cv-query-source-popover__header span {
+  color: #69707d;
+  font-size: 11.5px;
+}
+
+.cv-query-source-popover__header .cv-secondary-button {
+  min-height: 20px;
+  padding: 0 2px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--cv-primary-text);
+  box-shadow: none;
+  font-size: 11.5px;
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.cv-query-source-popover__header .cv-secondary-button:hover,
+.cv-query-source-popover__header .cv-secondary-button:focus-visible {
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-text-strong);
+  text-decoration: none;
+  outline: none;
+}
+
+.cv-query-source-popover__search {
+  padding: 6px 7px 5px;
+  border-bottom: 1px solid #eef2f7;
+  background: #ffffff;
+}
+
+.cv-query-source-popover__search .euiFormControlLayout {
+  min-height: 26px !important;
+  border: 1px solid #d8dee8 !important;
+  border-radius: 4px !important;
+  background: #fbfcfd !important;
+  box-shadow: none !important;
+}
+
+.cv-query-source-popover__search .euiFormControlLayout__childrenWrapper {
+  min-height: 26px !important;
+  border: 0 !important;
+  border-radius: 4px !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+.cv-query-source-popover__search .euiFormControlLayout::before,
+.cv-query-source-popover__search .euiFormControlLayout::after,
+.cv-query-source-popover__search .euiFormControlLayout__childrenWrapper::before,
+.cv-query-source-popover__search .euiFormControlLayout__childrenWrapper::after {
+  box-shadow: none !important;
+}
+
+.cv-query-source-popover__search .euiFormControlLayout.euiFormControlLayout-isFocused,
+.cv-query-source-popover__search .euiFormControlLayout--focused,
+.cv-query-source-popover__search .euiFormControlLayout:focus-within {
+  border-color: #b9c4d2 !important;
+  background: #ffffff !important;
+  box-shadow: none !important;
+}
+
+.cv-query-source-popover__search .euiFieldSearch {
+  height: 26px !important;
+  min-height: 26px !important;
+  color: #343741 !important;
+  font-size: 12px !important;
+  font-weight: 500 !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.cv-query-source-popover__search .euiFieldSearch:focus,
+.cv-query-source-popover__search .euiFieldSearch:focus-visible {
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.cv-query-source-popover__search .euiFieldSearch::placeholder {
+  color: #98a2b3 !important;
+}
+
+.cv-query-source-popover__search .euiFormControlLayoutClearButton {
+  width: 18px !important;
+  min-width: 18px !important;
+  inline-size: 18px !important;
+  height: 18px !important;
+  padding: 0 !important;
+  border-radius: 999px !important;
+  background: #edf1f6 !important;
+  color: #69707d !important;
+  box-shadow: none !important;
+}
+
+.cv-query-source-popover__search .euiFormControlLayoutClearButton:hover,
+.cv-query-source-popover__search .euiFormControlLayoutClearButton:focus-visible {
+  background: #e2e8f0 !important;
+  color: #343741 !important;
+  outline: none !important;
+}
+
+.cv-query-source-popover__search .euiFormControlLayoutClearButton svg,
+.cv-query-source-popover__search .euiFormControlLayoutClearButton .euiIcon {
+  color: currentColor !important;
+  opacity: 0.82 !important;
+}
+
+.cv-query-source-popover__body {
+  overflow: auto;
+  scrollbar-gutter: stable;
+  padding: 6px;
+}
+
+.cv-query-source-popover .cv-query-tree {
+  min-height: 0;
+  gap: 4px;
+}
+
+.cv-query-source-popover .cv-query-tree__group {
+  gap: 4px;
+}
+
+.cv-query-source-popover .cv-query-tree__children {
+  margin-left: 8px;
+  padding-left: 14px;
+}
+
+.cv-query-source-popover .cv-query-tree__tables {
+  margin-left: 16px;
+  padding-left: 16px;
+}
+
+.cv-query-source-popover .cv-query-tree__instance,
+.cv-query-source-popover .cv-query-tree__database,
+.cv-query-source-popover .cv-query-tree__table {
+  border-radius: 4px;
+}
+
+.cv-query-source-popover .cv-query-tree__instance {
+  min-height: 28px;
+  gap: 8px;
+  padding: 0 8px;
+  color: #343741;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.cv-query-source-popover .cv-query-tree__database {
+  min-height: 26px;
+  color: #343741;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.cv-query-source-popover .cv-query-tree__table {
+  min-height: 24px;
+  padding-right: 6px;
+  color: #343741;
+  font-weight: 600;
+}
+
+.cv-query-source-popover .cv-query-tree__instance:hover,
+.cv-query-source-popover .cv-query-tree__database:hover,
+.cv-query-source-popover .cv-query-tree__table:hover {
+  background: #f7f9fc;
+}
+
+.cv-query-source-popover .cv-query-tree__instance-mark,
+.cv-query-source-popover .cv-query-tree__database-dot,
+.cv-query-source-popover .cv-query-tree__table-dot {
+  flex: 0 0 auto;
+  background: #c4ccd8;
+  box-shadow: none;
+}
+
+.cv-query-source-popover .cv-query-tree__instance-mark {
+  width: 7px;
+  height: 7px;
+  border-radius: 2px;
+}
+
+.cv-query-source-popover .cv-query-tree__database-dot {
+  width: 6px;
+  height: 6px;
+}
+
+.cv-query-source-popover .cv-query-tree__table-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 2px;
+}
+
+.cv-query-source-popover .cv-query-tree__children::before,
+.cv-query-source-popover .cv-query-tree__tables::before,
+.cv-query-source-popover .cv-query-tree__database-rail,
+.cv-query-source-popover .cv-query-tree__table-rail {
+  background: #e5e8ef;
+}
+
+.cv-query-source-popover .cv-query-tree__instance--active,
+.cv-query-source-popover .cv-query-tree__database--active {
+  color: #343741;
+}
+
+.cv-query-source-popover .cv-query-tree__instance--active .cv-query-tree__instance-mark,
+.cv-query-source-popover .cv-query-tree__database--active .cv-query-tree__database-dot,
+.cv-query-source-popover .cv-query-tree__table--active .cv-query-tree__table-dot {
+  background: var(--cv-primary);
+  box-shadow: none;
+}
+
+.cv-query-source-popover .cv-query-tree__table--active {
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-text);
+  box-shadow: none;
+}
+
+.cv-query-log-tab {
+  margin: 0;
+  overflow: hidden;
+  border-color: transparent;
+  border-bottom: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: #343741;
+  box-shadow: none;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease;
+}
+
+.cv-query-log-tab:hover {
+  border-color: transparent;
+  background: #f5f7fa;
+  box-shadow: none;
+}
+
+.cv-query-log-tab--active {
+  border-color: transparent;
+  background: #f5f7fa;
+  color: #343741;
+  box-shadow: none;
+}
+
+.cv-query-log-tab__main {
+  display: flex;
+  gap: 5px;
+  min-height: 26px;
+  min-width: 0;
+  max-width: 168px;
+  align-items: center;
+  padding: 0 8px;
+}
+
+.cv-query-log-tab__icon {
+  flex: 0 0 auto;
+  color: #69707d !important;
+  opacity: 0.68 !important;
+}
+
+.cv-query-log-tab__main strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #343741;
+  font-size: 11.5px;
+  font-weight: 650;
+}
+
+.cv-query-log-tab--active .cv-query-log-tab__main strong {
+  color: #343741;
+}
+
+.cv-query-log-tab__close {
+  display: inline-grid;
+  place-items: center;
+  width: 20px;
+  border-left-color: transparent;
+  color: #98a2b3;
+  font-size: 13px;
+  opacity: 0;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease,
+    opacity 120ms ease;
+}
+
+.cv-query-log-tab--active .cv-query-log-tab__close {
+  border-left-color: transparent;
+}
+
+.cv-query-log-tab:hover .cv-query-log-tab__close,
+.cv-query-log-tab:focus-within .cv-query-log-tab__close {
+  opacity: 1;
+}
+
+.cv-query-log-tab__close:hover,
+.cv-query-log-tab__close:focus-visible {
+  background: #f5f7fa;
+  color: #343741;
+  outline: none;
+}
+
+.cv-query-panel--command {
+  position: relative;
+  z-index: 20;
+  overflow: visible;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  padding: 4px 0 2px;
+}
+
+.cv-query-panel--command.cv-query-panel--dropdown-open {
+  z-index: 80;
+}
+
+.cv-query-workspace {
+  position: relative;
+  z-index: 1;
+}
+
+.cv-query-filter-composer {
+  position: relative;
+  z-index: 90;
+  overflow: visible;
+}
+
+.cv-query-panel .cv-query-command-header {
+  align-items: center;
+  min-height: 20px;
+  margin-bottom: 4px;
+}
+
+.cv-query-command-header .cv-panel-title {
+  color: #343741;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.cv-query-action-row--utility {
+  --cv-query-utility-action-height: 24px;
+  align-items: center;
+  flex-wrap: nowrap;
+  gap: 6px;
+  height: var(--cv-query-command-control-height, 34px);
+  margin-left: auto;
+}
+
+.cv-query-action-row--utility .euiPopover,
+.cv-query-action-row--utility .euiPopover__anchor {
+  display: inline-flex;
+  align-items: center;
+  height: var(--cv-query-utility-action-height);
+}
+
+.cv-query-action-row--utility .cv-query-text-action {
+  display: inline-flex;
+  align-items: center;
+  height: var(--cv-query-utility-action-height);
+  min-height: var(--cv-query-utility-action-height);
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--cv-primary-text);
+  padding: 0 5px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 650;
+  line-height: var(--cv-query-utility-action-height);
+  text-decoration: none;
+}
+
+.cv-query-action-row--utility .cv-query-text-action:hover,
+.cv-query-action-row--utility .cv-query-text-action:focus-visible {
+  background: transparent;
+  color: var(--cv-primary-text-strong);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.cv-query-action-row--utility .cv-query-text-action:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 1px var(--cv-primary-focus);
+}
+
+.cv-query-action-row--utility .cv-query-text-action[aria-expanded="true"] {
+  background: transparent;
+  color: var(--cv-primary-text-strong);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  box-shadow: none;
+}
+
+.cv-query-action-row--utility .cv-query-text-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+}
+
+.cv-query-action-row--utility .cv-query-text-action[aria-busy="true"] {
+  cursor: progress;
+  opacity: 0.72;
+}
+
+.cv-query-action-row--utility .cv-query-text-action--share {
+  justify-content: flex-start;
+  min-width: 0;
+}
+
+.cv-query-action-row--utility .cv-secondary-button {
+  min-height: 28px;
+  border-color: #d3dae6;
+  border-radius: 4px;
+  background: #ffffff;
+  color: #343741;
+  font-weight: 600;
+}
+
+.cv-query-action-row--utility .cv-secondary-button:hover {
+  border-color: #98a2b3;
+  background: #f5f7fa;
+}
+
+.cv-query-command-row {
+  --cv-query-command-control-height: 38px;
+  --cv-query-time-picker-width: clamp(280px, 22vw, 312px);
+  grid-template-columns: minmax(320px, 1fr) var(--cv-query-time-picker-width) auto auto;
+  gap: 6px;
+  align-items: center;
+}
+
+.cv-query-command-tools {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: max-content;
+}
+
+.cv-query-command-tools .cv-query-action-row--utility {
+  margin-left: 0;
+}
+
+.cv-query-sql {
+  height: var(--cv-query-command-control-height);
+  min-height: var(--cv-query-command-control-height);
+  border-color: #d3dae6;
+  border-radius: 4px;
+  background: #ffffff;
+  box-shadow: none;
+}
+
+.cv-query-sql:focus-within {
+  border-color: var(--cv-primary);
+  box-shadow: 0 0 0 1px var(--cv-primary);
+}
+
+.cv-query-sql__badge {
+  gap: 6px;
+  min-width: 68px;
+  padding: 0 9px;
+  border-right-color: #d3dae6;
+  border-radius: 3px 0 0 3px;
+  background: #f5f7fa;
+  color: #343741;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.cv-query-sql__tip {
+  border: 0;
+  background: transparent;
+  color: #98a2b3;
+  opacity: 0.72;
+}
+
+.cv-query-sql__tip svg {
+  pointer-events: none;
+}
+
+.cv-query-sql__tip:hover,
+.cv-query-sql__tip:focus-visible {
+  background: transparent;
+  color: #69707d;
+  opacity: 1;
+}
+
+.cv-query-sql input {
+  height: calc(var(--cv-query-command-control-height) - 2px);
+  color: #1f2937;
+  font-size: 12.5px;
+}
+
+.cv-query-sql__clear {
+  height: 30px;
+  border-radius: 4px;
+}
+
+.cv-query-time-picker {
+  --cv-query-time-control-height: var(--cv-query-command-control-height, 34px);
+  --cv-query-time-step-width: 28px;
+  position: relative;
+  display: grid;
+  grid-template-columns: var(--cv-query-time-step-width) minmax(0, 1fr) var(--cv-query-time-step-width);
+  align-items: stretch;
+  width: 100%;
+  height: var(--cv-query-time-control-height);
+  min-width: 0;
+}
+
+.cv-query-time-picker .euiPopover,
+.cv-query-time-picker .euiPopover__anchor {
+  display: block;
+  width: 100%;
+  height: var(--cv-query-time-control-height);
+  min-width: 0;
+}
+
+.cv-query-time-step,
+.cv-query-time-button {
+  appearance: none;
+  box-sizing: border-box;
+  height: var(--cv-query-time-control-height);
+  min-height: var(--cv-query-time-control-height);
+  border: 1px solid #d3dae6;
+  background: #ffffff;
+  color: #343741;
+  box-shadow: none;
+  cursor: pointer;
+  font: inherit;
+  line-height: 1;
+  outline: none;
+}
+
+.cv-query-time-step {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  min-width: 0;
+  padding: 0;
+  background: #ffffff;
+  color: #69707d;
+}
+
+.cv-query-time-step svg {
+  pointer-events: none;
+  color: currentColor !important;
+  opacity: 0.86;
+}
+
+.cv-query-time-step:first-child {
+  border-radius: 4px 0 0 4px;
+}
+
+.cv-query-time-step:last-child {
+  border-radius: 0 4px 4px 0;
+}
+
+.cv-query-time-step:hover,
+.cv-query-time-step:focus-visible,
+.cv-query-time-button:hover,
+.cv-query-time-button:focus-visible {
+  position: relative;
+  z-index: 1;
+  border-color: #b9c4d2;
+  background: #fbfcfd;
+  color: var(--cv-primary-text);
+}
+
+.cv-query-time-step:disabled,
+.cv-query-time-button--loading {
+  cursor: wait;
+  opacity: 0.62;
+}
+
+.cv-query-time-button {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: calc(100% + 2px);
+  margin: 0 -1px;
+  border-radius: 0;
+  padding: 0 8px;
+  text-align: left;
+}
+
+.cv-query-time-button__icon {
+  flex: 0 0 auto;
+  color: #69707d !important;
+  opacity: 0.82;
+}
+
+.cv-query-time-button:hover .cv-query-time-button__icon,
+.cv-query-time-button:focus-visible .cv-query-time-button__icon {
+  color: var(--cv-primary-text) !important;
+  opacity: 0.9;
+}
+
+.cv-query-time-button__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cv-query-time-button__label {
+  color: #343741;
+  font-size: 12.5px;
+  font-weight: 650;
+}
+
+.cv-query-time-popover-panel {
+  --cv-query-time-popover-width: min(356px, calc(100vw - 24px));
+  width: var(--cv-query-time-popover-width) !important;
+  min-width: var(--cv-query-time-popover-width) !important;
+  max-width: var(--cv-query-time-popover-width) !important;
+  inline-size: var(--cv-query-time-popover-width) !important;
+  min-inline-size: var(--cv-query-time-popover-width) !important;
+  max-inline-size: var(--cv-query-time-popover-width) !important;
+  overflow: hidden !important;
+  border: 1px solid #d8dee8 !important;
+  border-radius: 4px !important;
+  background: #ffffff !important;
+  font-size: 12px !important;
+  box-shadow:
+    0 12px 24px rgba(52, 55, 65, 0.1),
+    0 1px 2px rgba(52, 55, 65, 0.05) !important;
+}
+
+.cv-query-time-popover-panel--wide {
+  width: var(--cv-query-time-popover-width) !important;
+  min-width: var(--cv-query-time-popover-width) !important;
+  max-width: var(--cv-query-time-popover-width) !important;
+  inline-size: var(--cv-query-time-popover-width) !important;
+  min-inline-size: var(--cv-query-time-popover-width) !important;
+  max-inline-size: var(--cv-query-time-popover-width) !important;
+}
+
+.cv-query-time-popover {
+  display: grid;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  color: #343741;
+  font-family: var(--cv-font-ui);
+  font-size: 12px;
+}
+
+.cv-query-time-popover button,
+.cv-query-time-popover input,
+.cv-query-time-popover select {
+  font-family: inherit;
+  outline: none;
+}
+
+.cv-query-time-section {
+  padding: 0;
+}
+
+.cv-query-time-section--quick {
+  padding: 0;
+}
+
+.cv-query-time-body {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.cv-query-time-popover--calendar-open .cv-query-time-body {
+  display: block;
+  min-height: 0;
+}
+
+.cv-query-time-body__controls {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.cv-query-time-body__controls--absolute-first {
+  display: grid;
+  gap: 0;
+}
+
+.cv-query-time-popover--calendar-open .cv-query-time-body__controls--absolute-first {
+  display: grid;
+  align-content: start;
+  gap: 0;
+  border-right: 0;
+  background: #ffffff;
+  padding: 0;
+}
+
+.cv-query-time-quick-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  align-items: center;
+}
+
+.cv-query-time-quick {
+  position: relative;
+  min-width: 0;
+  min-height: 20px;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--cv-primary-text);
+  cursor: pointer;
+  padding: 0 4px;
+  text-align: center;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 20px;
+  white-space: nowrap;
+}
+
+.cv-query-time-popover--calendar-open .cv-query-time-section--quick {
+  padding: 0;
+}
+
+.cv-query-time-popover--calendar-open .cv-query-time-preset-row {
+  display: flex;
+}
+
+.cv-query-time-popover--calendar-open .cv-query-time-absolute-block {
+  border-bottom: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.cv-query-time-absolute-block {
+  display: grid;
+  gap: 0;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.cv-query-time-preset-row {
+  display: flex;
+  min-width: 0;
+  min-height: 26px;
+  align-items: center;
+  gap: 6px;
+  overflow: visible;
+  border: 0;
+  border-bottom: 1px solid #eef2f7;
+  border-radius: 0;
+  background: #ffffff;
+  padding: 3px 9px;
+}
+
+.cv-query-time-absolute-presets {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 3px;
+  min-width: 0;
+}
+
+.cv-query-time-preset-row__separator {
+  width: 1px;
+  height: 13px;
+  flex: 0 0 auto;
+  background: #e9eef5;
+}
+
+.cv-query-time-absolute-preset {
+  position: relative;
+  min-height: 20px;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--cv-primary-text);
+  cursor: pointer;
+  padding: 0 4px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 20px;
+  white-space: nowrap;
+}
+
+.cv-query-time-absolute-preset:hover,
+.cv-query-time-absolute-preset:focus-visible,
+.cv-query-time-quick:hover,
+.cv-query-time-quick:focus-visible {
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-text-strong);
+  text-decoration: none;
+  box-shadow: none;
+  outline: none;
+}
+
+.cv-query-time-absolute-preset--active,
+.cv-query-time-absolute-preset--active:hover,
+.cv-query-time-absolute-preset--active:focus-visible,
+.cv-query-time-quick--active,
+.cv-query-time-quick--active:hover,
+.cv-query-time-quick--active:focus-visible {
+  background: var(--cv-primary-soft);
+  color: var(--cv-primary-text-strong);
+  text-decoration: none;
+  box-shadow: none;
+  font-weight: 700;
+}
+
+.cv-query-time-absolute-preset--active:hover,
+.cv-query-time-absolute-preset--active:focus-visible,
+.cv-query-time-quick--active:hover,
+.cv-query-time-quick--active:focus-visible {
+  background: color-mix(in srgb, var(--cv-primary) 14%, #ffffff);
+}
+
+.cv-query-time-absolute-preset--active::before,
+.cv-query-time-quick--active::before {
+  content: none;
+}
+
+.cv-query-time-absolute-range {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0;
+  align-items: stretch;
+  min-width: 0;
+  overflow: hidden;
+  margin: 6px 8px;
+  border: 1px solid #e5e8ef;
+  border-radius: 4px;
+  background: #fbfcfd;
+  transition:
+    border-color 0.12s ease,
+    box-shadow 0.12s ease;
+}
+
+.cv-query-time-absolute-range:focus-within {
+  border-color: #d3dae6;
+  box-shadow: none;
+}
+
+.cv-query-time-absolute-field {
+  position: relative;
+  display: grid;
+  min-width: 0;
+  min-height: 34px;
+  grid-template-columns: 42px minmax(0, 1fr);
+  gap: 7px;
+  align-content: center;
+  align-items: center;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: #343741;
+  cursor: text;
+  padding: 4px 10px;
+  transition:
+    background-color 0.12s ease,
+    border-color 0.12s ease,
+    box-shadow 0.12s ease,
+    color 0.12s ease;
+}
+
+.cv-query-time-absolute-field + .cv-query-time-absolute-field {
+  border-top: 1px solid #eef2f7;
+  border-left: 0;
+}
+
+.cv-query-time-absolute-field:hover {
+  border-color: transparent;
+  background: #ffffff;
+}
+
+.cv-query-time-absolute-field:focus-within {
+  border-color: transparent;
+  background: #ffffff;
+  box-shadow: none;
+}
+
+.cv-query-time-absolute-field--active {
+  border-color: transparent;
+  background: #ffffff;
+  box-shadow: none;
+}
+
+.cv-query-time-absolute-field:focus-within::after,
+.cv-query-time-absolute-field--active::after {
+  content: none;
+}
+
+.cv-query-time-absolute-field--active .cv-query-time-absolute-label {
+  color: var(--cv-primary-text);
+}
+
+.cv-query-time-absolute-label {
+  display: flex;
+  min-width: 0;
+  height: auto;
+  align-items: center;
+  gap: 0;
+  justify-content: flex-start;
+  border-right: 0;
+  background: transparent;
+  color: #69707d;
+  padding: 0;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 26px;
+  text-transform: none;
+}
+
+.cv-query-time-absolute-label svg {
+  width: 12px;
+  height: 12px;
+  color: #98a2b3;
+}
+
+.cv-query-time-absolute-input-wrap {
+  position: relative;
+  width: 100%;
+  min-width: 0;
+}
+
+.cv-query-time-absolute-input-wrap .euiFormControlLayout,
+.cv-query-time-absolute-input-wrap .euiFormControlLayout__childrenWrapper {
+  width: 100%;
+  min-height: 26px !important;
+  height: 26px !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+.cv-query-time-absolute-input-wrap .euiFormControlLayout.euiFormControlLayout-isFocused,
+.cv-query-time-absolute-input-wrap .euiFormControlLayout--focused,
+.cv-query-time-absolute-input-wrap .euiFormControlLayout:focus-within {
+  border: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+.cv-query-time-absolute-input.euiFieldText {
+  min-height: 26px !important;
+  height: 26px !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  outline: none !important;
+  color: #343741 !important;
+  padding: 0 !important;
+  font-size: 12px !important;
+  font-variant-numeric: tabular-nums;
+  font-weight: 650 !important;
+  line-height: 26px !important;
+}
+
+.cv-query-time-absolute-input.euiFieldText:focus,
+.cv-query-time-absolute-input.euiFieldText:focus-visible {
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.cv-query-time-absolute-calendar {
+  display: grid;
+  gap: 0;
+  align-self: start;
+  justify-items: center;
+  max-width: 100%;
+  margin-top: 0;
+  overflow-x: visible;
+  overscroll-behavior-x: contain;
+  background: #ffffff;
+  border-top: 1px solid #f1f3f6;
+  padding: 4px 9px 7px;
+}
+
+.cv-query-time-popover--calendar-open .cv-query-time-absolute-range {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0;
+  overflow: hidden;
+  margin: 6px 8px;
+  border: 1px solid #e5e8ef;
+  border-radius: 4px;
+  background: #fbfcfd;
+}
+
+.cv-query-time-popover--calendar-open .cv-query-time-absolute-field {
+  min-height: 34px;
+  grid-template-columns: 42px minmax(0, 1fr);
+  gap: 7px;
+  align-content: center;
+  align-items: center;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 4px 10px;
+  transition:
+    background-color 0.12s ease,
+    border-color 0.12s ease,
+    box-shadow 0.12s ease,
+    color 0.12s ease;
+}
+
+.cv-query-time-popover--calendar-open .cv-query-time-absolute-field + .cv-query-time-absolute-field {
+  border-top: 1px solid #eef2f7;
+  border-left: 0;
+}
+
+.cv-query-time-popover--calendar-open .cv-query-time-absolute-field:hover {
+  border-color: transparent;
+  background: #ffffff;
+}
+
+.cv-query-time-popover--calendar-open .cv-query-time-absolute-field:focus-within,
+.cv-query-time-popover--calendar-open .cv-query-time-absolute-field--active {
+  border-color: transparent;
+  background: #ffffff;
+  box-shadow: none;
+}
+
+.cv-query-time-popover--calendar-open .cv-query-time-absolute-label {
+  padding: 0;
+  font-size: 11px;
+}
+
+.cv-query-time-popover--calendar-open .cv-query-time-absolute-input.euiFieldText {
+  min-height: 26px !important;
+  height: 26px !important;
+  font-size: 12px !important;
+  line-height: 26px !important;
+}
+
+.cv-query-time-popover-panel .euiTabs,
+.cv-query-time-popover-panel .euiTab,
+.cv-query-time-popover-panel [role="tablist"],
+.cv-query-time-popover-panel [role="tab"],
+.cv-query-time-absolute-calendar .euiTabs,
+.cv-query-time-absolute-calendar .euiTab,
+.cv-query-time-absolute-calendar [role="tablist"],
+.cv-query-time-absolute-calendar [role="tab"] {
+  display: none !important;
+}
+
+body:has(.cv-query-time-popover-panel) .euiDatePopoverContent .euiTabs,
+body:has(.cv-query-time-popover-panel) .euiDatePopoverContent .euiTab,
+body:has(.cv-query-time-popover-panel) .euiDatePopoverContent [role="tablist"],
+body:has(.cv-query-time-popover-panel) .euiDatePopoverContent [role="tab"] {
+  display: none !important;
+}
+
+body .cv-query-date-picker-calendar.react-datepicker {
+  display: flex !important;
+  flex-direction: row !important;
+  justify-content: center !important;
+  gap: 7px !important;
+  width: auto !important;
+  justify-self: center;
+  margin: 0 auto !important;
+  border: 0 !important;
+  padding: 0 !important;
+  font-family: var(--cv-font-ui);
+  font-size: 10px;
+}
+
+.cv-query-time-absolute-calendar .euiDatePicker,
+.cv-query-time-absolute-calendar .euiFormControlLayout,
+.cv-query-time-absolute-calendar .euiFormControlLayout__childrenWrapper {
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+.cv-query-time-absolute-calendar .euiDatePicker {
+  display: grid !important;
+  width: fit-content !important;
+  max-width: 100% !important;
+  justify-items: center !important;
+  justify-self: center !important;
+}
+
+body .cv-query-date-picker-calendar--inline.react-datepicker {
+  overflow: hidden;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent;
+  box-shadow: none !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__header {
+  border-bottom: 0 !important;
+  background: transparent !important;
+  padding-bottom: 2px !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__current-month,
+body .cv-query-date-picker-calendar .react-datepicker-time__header {
+  color: #343741 !important;
+  font-size: 11px !important;
+  font-weight: 700 !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__month-container {
+  width: 218px;
+  margin-top: 0 !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__header--custom {
+  padding: 2px 4px 0 !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__month {
+  margin: 0;
+  padding: 1px 3px 3px;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__day-names,
+body .cv-query-date-picker-calendar .react-datepicker__week {
+  display: grid;
+  grid-template-columns: repeat(7, 24px);
+  justify-content: center;
+  column-gap: 2px;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__day-names {
+  margin: 0 4px 1px !important;
+  border-radius: 0;
+  background: transparent;
+  padding: 1px 0;
+}
+
+.cv-query-date-picker-header {
+  display: grid;
+  grid-template-columns: 17px minmax(0, 1fr) 17px;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 0;
+}
+
+.cv-query-date-picker-header strong {
+  min-width: 0;
+  overflow: hidden;
+  color: #343741;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.cv-query-date-picker-header__step {
+  display: grid;
+  width: 17px;
+  height: 17px;
+  place-items: center;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #69707d;
+  cursor: pointer;
+  padding: 0;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.cv-query-date-picker-header__step:hover,
+.cv-query-date-picker-header__step:focus-visible {
+  background: #f5f7fa;
+  color: var(--cv-primary-text);
+}
+
+.cv-query-date-picker-header__step:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__day-name,
+body .cv-query-date-picker-calendar .react-datepicker__day {
+  display: grid !important;
+  place-items: center !important;
+  width: 24px !important;
+  height: 18px !important;
+  margin: 0 !important;
+  border-radius: 3px !important;
+  font-size: 10px !important;
+  line-height: 18px !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__day-name {
+  font-size: 0 !important;
+  overflow: hidden;
+  color: #69707d !important;
+  font-weight: 600 !important;
+  text-align: center;
+  text-overflow: clip;
+  white-space: nowrap;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__day-name::first-letter {
+  font-size: 10px !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__day-name > span[aria-hidden="true"] {
+  display: block;
+  width: 100%;
+  font-size: 0 !important;
+  overflow: hidden;
+  text-align: center;
+  text-overflow: clip;
+  white-space: nowrap;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__day-name > span[aria-hidden="true"]::first-letter {
+  font-size: 10px !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__day:hover,
+body .cv-query-date-picker-calendar .react-datepicker__day:focus {
+  background: var(--cv-primary-tint) !important;
+  color: var(--cv-primary-text) !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__day--outside-month {
+  background: transparent !important;
+  color: #98a2b3 !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__day--disabled,
+body .cv-query-date-picker-calendar .react-datepicker__day--excluded {
+  background: transparent !important;
+  color: #c4ccd8 !important;
+  cursor: not-allowed !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__day--disabled:hover,
+body .cv-query-date-picker-calendar .react-datepicker__day--excluded:hover {
+  background: transparent !important;
+  color: #c4ccd8 !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__day--in-range,
+body .cv-query-date-picker-calendar .react-datepicker__day--in-selecting-range {
+  background: color-mix(in srgb, var(--cv-primary) 5%, #ffffff) !important;
+  color: #343741 !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__day--today:not(.react-datepicker__day--selected) {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--cv-primary) 20%, transparent) !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__day--selected,
+body .cv-query-date-picker-calendar .react-datepicker__day--keyboard-selected {
+  border-radius: 3px !important;
+  background: var(--cv-primary) !important;
+  background-color: var(--cv-primary) !important;
+  color: #ffffff !important;
+  box-shadow: none !important;
+  font-weight: 650 !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__day--selected:hover,
+body .cv-query-date-picker-calendar .react-datepicker__day--selected:focus,
+body .cv-query-date-picker-calendar .react-datepicker__day--keyboard-selected:hover,
+body .cv-query-date-picker-calendar .react-datepicker__day--keyboard-selected:focus {
+  background: var(--cv-primary-strong) !important;
+  color: #ffffff !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__time-container {
+  width: 54px !important;
+  margin: 0 !important;
+  border-left: 1px solid #eef2f7 !important;
+  border-radius: 0;
+  background: transparent;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__time,
+body .cv-query-date-picker-calendar .react-datepicker__time-box {
+  width: 54px !important;
+  background: transparent !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__time-list {
+  width: 54px !important;
+  height: 130px !important;
+  block-size: 130px !important;
+  flex: 0 0 130px !important;
+  flex-grow: 0 !important;
+  align-items: flex-start !important;
+  gap: 0 !important;
+  margin: 0 !important;
+  padding: 1px 0 1px 5px !important;
+  scroll-padding-block: 8px !important;
+  scrollbar-gutter: stable;
+  overscroll-behavior: contain;
+  scrollbar-color: #d3dae6 transparent;
+  scrollbar-width: thin;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__time-list-item {
+  display: grid !important;
+  place-items: center !important;
+  width: 42px !important;
+  height: 18px !important;
+  min-height: 18px !important;
+  block-size: 18px !important;
+  box-sizing: border-box !important;
+  margin: 0 0 1px !important;
+  border-radius: 3px !important;
+  padding: 0 !important;
+  color: #343741 !important;
+  font-size: 10px !important;
+  font-weight: 600 !important;
+  line-height: 18px !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__time-list::-webkit-scrollbar {
+  width: 4px;
+  height: 0;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__time-list::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: #d3dae6;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__time-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__time-list-item:hover,
+body .cv-query-date-picker-calendar .react-datepicker__time-list-item:focus {
+  background: var(--cv-primary-tint) !important;
+  color: var(--cv-primary-text) !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__time-list-item--selected {
+  background: var(--cv-primary-soft) !important;
+  background-color: var(--cv-primary-soft) !important;
+  color: var(--cv-primary-text-strong) !important;
+  box-shadow: none !important;
+  font-weight: 650 !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__time-list-item--selected:not(.react-datepicker__time-list-item--disabled) {
+  background: var(--cv-primary-soft) !important;
+  background-color: var(--cv-primary-soft) !important;
+  color: var(--cv-primary-text-strong) !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__time-list-item--selected:hover,
+body .cv-query-date-picker-calendar .react-datepicker__time-list-item--selected:focus {
+  background: color-mix(in srgb, var(--cv-primary) 14%, #ffffff) !important;
+  color: var(--cv-primary-text-strong) !important;
+}
+
+body .cv-query-date-picker-calendar .react-datepicker__time-list-item--selected.react-datepicker__time-list-item--disabled {
+  color: #ffffff !important;
+}
+
+.cv-query-time-popover__footer {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content max-content;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 8px 6px;
+  border-top: 1px solid #f6f7f9;
+  background: #ffffff;
+}
+
+.cv-query-time-popover__hint {
+  min-width: 0;
+  overflow: hidden;
+  color: #69707d;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 10px;
+  font-weight: 600;
+  opacity: 0.74;
+}
+
+.cv-query-time-popover__hint[role="alert"] {
+  color: #bd271e;
+}
+
+.cv-query-time-popover__footer .cv-secondary-button {
+  min-height: 21px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #69707d;
+  box-shadow: none;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 0 6px;
+}
+
+.cv-query-time-popover__footer .cv-secondary-button:hover,
+.cv-query-time-popover__footer .cv-secondary-button:focus-visible {
+  background: #f5f7fa;
+  color: #343741;
+  box-shadow: none;
+  outline: none;
+}
+
+.cv-query-time-popover__footer .cv-action-button {
+  min-width: 0;
+  min-height: 21px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  box-shadow: none;
+  color: var(--cv-primary-text);
+  font-size: 11px;
+  font-weight: 700;
+  padding: 0 6px;
+}
+
+.cv-query-time-popover__footer .cv-action-button:hover,
+.cv-query-time-popover__footer .cv-action-button:focus-visible {
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-text-strong);
+  box-shadow: none;
+  outline: none;
+}
+
+body .euiDatePopoverContent {
+  color: #343741;
+  font-family: var(--cv-font-ui);
+  font-size: 12px;
+}
+
+body .euiDatePopoverContent .euiTabs {
+  min-height: 30px;
+  border-bottom: 1px solid #eef2f7;
+  padding: 0 6px;
+}
+
+body .euiDatePopoverContent .euiTab {
+  min-height: 30px;
+  color: #4f5666;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 0 8px;
+}
+
+body .euiDatePopoverContent .euiTab:hover,
+body .euiDatePopoverContent .euiTab:focus-visible {
+  color: var(--cv-primary-text);
+  text-decoration: none;
+}
+
+body .euiDatePopoverContent .euiTab-isSelected,
+body .euiDatePopoverContent .euiTab[aria-selected="true"] {
+  color: var(--cv-primary-text);
+  font-weight: 650;
+}
+
+body .euiDatePopoverContent .euiTab-isSelected::before,
+body .euiDatePopoverContent .euiTab-isSelected::after,
+body .euiDatePopoverContent .euiTab[aria-selected="true"]::before,
+body .euiDatePopoverContent .euiTab[aria-selected="true"]::after {
+  height: 1px;
+  background-color: var(--cv-primary);
+}
+
+.cv-query-run-button {
+  gap: 5px;
+  width: 82px;
+  min-width: 82px;
+  height: var(--cv-query-command-control-height, 34px);
+  min-height: var(--cv-query-command-control-height, 34px);
+  border-radius: 4px;
+  background: var(--cv-primary);
+  box-shadow: none;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.cv-query-run-button:hover {
+  background: var(--cv-primary-strong);
+}
+
+.cv-query-run-button svg {
+  color: currentColor;
+}
+
+.cv-query-kibana {
+  gap: 4px;
+  margin-top: 4px;
+  padding: 0 2px;
+  border-top: 0;
+}
+
+.cv-query-filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 6px;
+  min-height: 24px;
+  min-width: 0;
+  overflow: visible;
+}
+
+.cv-query-filter-bar .euiPopover,
+.cv-query-filter-bar .euiPopover__anchor {
+  display: inline-flex;
+  flex: 0 0 auto;
+  min-width: 0;
+}
+
+.cv-query-add-filter-anchor {
+  display: inline-flex;
+  flex: 0 0 auto;
+  min-width: 0;
+}
+
+.cv-query-add-filter {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  min-height: 22px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--cv-primary-text);
+  padding: 0 4px 0 2px;
+  cursor: pointer;
+  font-size: 11.5px;
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.cv-query-add-filter:hover,
+.cv-query-add-filter:focus-visible,
+.cv-query-add-filter--active {
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-text-strong);
+  text-decoration: none;
+  outline: none;
+}
+
+.cv-query-add-filter:hover,
+.cv-query-add-filter:focus-visible {
+  text-decoration: none;
+}
+
+.cv-query-add-filter--active {
+  background: transparent;
+  box-shadow: none;
+}
+
+.cv-query-add-filter svg {
+  color: currentColor;
+}
+
+.cv-query-filter-pills {
+  flex: 1 1 auto;
+  gap: 4px;
+  min-height: 22px;
+}
+
+.cv-query-builder__preview-wrap {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  margin-left: auto;
+}
+
+.cv-query-filter-bar__tools {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  margin-left: auto;
+}
+
+.cv-query-builder__preview-wrap + .cv-query-filter-bar__tools {
+  margin-left: 4px;
+}
+
+.cv-query-filter-bar__tools .cv-query-action-row--utility {
+  margin-left: 0;
+}
+
+.cv-query-builder__preview-trigger {
+  display: inline-flex;
+  min-height: 22px;
+  align-items: center;
+  gap: 3px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--cv-primary-text);
+  padding: 0 4px;
+  cursor: pointer;
+  font-size: 11.5px;
+  font-weight: 650;
+}
+
+.cv-query-builder__preview-trigger:hover,
+.cv-query-builder__preview-trigger:focus-visible {
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-text-strong);
+  text-decoration: none;
+  outline: none;
+}
+
+.cv-query-builder__preview-trigger svg {
+  color: currentColor;
+  opacity: 0.66;
+}
+
+.cv-query-preview-popover-panel {
+  z-index: 250;
+  width: min(520px, calc(100vw - 32px));
+  overflow: hidden !important;
+  border: 1px solid #d8dee8 !important;
+  border-radius: 4px !important;
+  background: #ffffff !important;
+  box-shadow: 0 10px 24px rgba(52, 55, 65, 0.12) !important;
+}
+
+.cv-query-filter-pill {
+  min-height: 22px;
+  border-color: #d3dae6;
+  border-radius: 4px;
+  background: #ffffff;
+  color: #343741;
+  font-family: var(--cv-font-ui);
+  font-size: 12px;
+  line-height: 1;
+}
+
+.cv-query-filter-pill--active {
+  border-color: #d3dae6;
+  background: #ffffff;
+  color: #343741;
+  box-shadow: none;
+}
+
+.cv-query-filter-pill--disabled {
+  border-color: #d3dae6;
+  background: #f5f7fa;
+  color: #69707d;
+}
+
+.cv-query-filter-pill__main {
+  height: 22px;
+  gap: 5px;
+  padding: 0 7px;
+  font-family: var(--cv-font-ui);
+  font-size: 12px;
+  line-height: 1;
+}
+
+.cv-query-filter-pill__main strong {
+  max-width: 220px;
+  color: #1f2937;
+  font-size: 12px;
+  line-height: 1.2;
+}
+
+.cv-query-filter-pill__main em {
+  color: #69707d;
+  font-size: 12px;
+  line-height: 1.2;
+}
+
+.cv-query-filter-pill__main span:last-child {
+  font-size: 12px;
+  line-height: 1.2;
+}
+
+.cv-query-filter-pill__toggle,
+.cv-query-filter-pill__remove {
+  min-height: 22px;
+  border-left: 0;
+  color: #69707d;
+  font-family: var(--cv-font-ui);
+  line-height: 1;
+}
+
+.cv-query-filter-pill > .euiToolTipAnchor {
+  display: inline-flex;
+  align-items: stretch;
+}
+
+.cv-query-filter-pill__toggle {
+  display: inline-grid;
+  width: 22px;
+  min-width: 22px;
+  place-items: center;
+  padding: 0;
+  color: #69707d;
+  opacity: 0.54;
+  pointer-events: auto;
+  transition:
+    background-color 0.12s ease,
+    color 0.12s ease,
+    opacity 0.12s ease;
+}
+
+.cv-query-filter-pill__remove {
+  width: 22px;
+  min-width: 22px;
+  padding: 0;
+  place-items: center;
+}
+
+.cv-query-filter-pill:hover .cv-query-filter-pill__toggle,
+.cv-query-filter-pill:focus-within .cv-query-filter-pill__toggle,
+.cv-query-filter-pill--disabled .cv-query-filter-pill__toggle {
+  opacity: 0.72;
+}
+
+.cv-query-filter-pill:hover .cv-query-filter-pill__toggle:hover,
+.cv-query-filter-pill:focus-within .cv-query-filter-pill__toggle:focus-visible {
+  opacity: 1;
+}
+
+.cv-query-filter-pill__toggle:hover,
+.cv-query-filter-pill__remove:hover {
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-text);
+}
+
+.cv-query-filter-composer {
+  grid-template-columns: minmax(124px, 136px) minmax(238px, 294px) auto;
+  gap: 5px;
+  width: fit-content;
+  max-width: 100%;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.cv-query-filter-composer--inline {
+  flex: 0 1 auto;
+  min-width: min(100%, 498px);
+}
+
+.cv-query-filter-composer-popover-panel {
+  z-index: 260;
+  width: min(516px, calc(100vw - 24px)) !important;
+  overflow: visible !important;
+  border: 1px solid #e3e8f0 !important;
+  border-radius: 4px !important;
+  background: #ffffff !important;
+  box-shadow:
+    0 8px 16px rgba(52, 55, 65, 0.08),
+    0 1px 2px rgba(52, 55, 65, 0.04) !important;
+}
+
+.cv-query-filter-composer-popover-panel .cv-query-filter-composer {
+  width: 100%;
+  padding: 4px 5px;
+}
+
+.cv-query-filter-composer input,
+.cv-query-filter-composer select {
+  min-height: 30px;
+  border-color: transparent;
+  border-radius: 0;
+  background-color: transparent;
+  padding-left: 9px;
+  padding-right: 9px;
+}
+
+.cv-query-filter-composer input,
+.cv-query-filter-composer select,
+.cv-query-filter-composer .cv-query-compact-select {
+  min-height: 28px !important;
+  height: 28px !important;
+}
+
+body .cv-query-filter-composer input.euiFieldText,
+body .cv-query-filter-composer select.euiSelect,
+.cv-query-filter-composer .euiFormControlLayout,
+.cv-query-filter-composer .euiFormControlLayout__childrenWrapper {
+  min-height: 28px !important;
+  height: 28px !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+.cv-query-filter-composer .euiFormControlLayout:focus-within,
+.cv-query-filter-composer .euiFormControlLayout.euiFormControlLayout-isFocused,
+.cv-query-filter-composer .euiFormControlLayout--focused {
+  border: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+body .cv-query-filter-composer input.euiFieldText:focus,
+body .cv-query-filter-composer input.euiFieldText:focus-visible,
+body .cv-query-filter-composer select.euiSelect:focus,
+body .cv-query-filter-composer select.euiSelect:focus-visible {
+  outline: none;
+  box-shadow: none !important;
+}
+
+.cv-query-filter-composer .euiSuperSelect,
+.cv-query-builder-form__field .euiSuperSelect {
+  width: 100%;
+  min-width: 0;
+}
+
+.cv-query-filter-composer .euiSuperSelect .euiFormControlLayout,
+.cv-query-builder-form__field .euiSuperSelect .euiFormControlLayout {
+  min-height: 28px;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.cv-query-builder-form__field .euiSuperSelect .euiFormControlLayout {
+  min-height: 32px;
+  border-radius: 4px;
+  background: #f8fafc;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.24);
+}
+
+.cv-query-condition-modal .cv-query-builder-form__field .euiSuperSelect .euiFormControlLayout {
+  min-height: 30px;
+  border: 1px solid #d6dde8;
+  border-radius: 4px;
+  background: #fcfdff;
+  box-shadow: none;
+}
+
+.cv-query-filter-composer .euiSuperSelect .euiFormControlLayout:focus-within,
+.cv-query-builder-form__field .euiSuperSelect .euiFormControlLayout:focus-within {
+  box-shadow: none;
+}
+
+.cv-query-builder-form__field .euiSuperSelect .euiFormControlLayout:focus-within {
+  box-shadow: inset 0 0 0 1px #98a2b3;
+}
+
+.cv-query-condition-modal .cv-query-builder-form__field .euiSuperSelect .euiFormControlLayout:focus-within {
+  border-color: #98a2b3;
+  box-shadow: none;
+}
+
+.cv-query-compact-select {
+  min-height: 30px !important;
+  height: 30px !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  color: #343741 !important;
+  padding: 0 24px 0 8px !important;
+  font-size: 12px !important;
+  font-weight: 600 !important;
+}
+
+.cv-query-compact-select:focus,
+.cv-query-compact-select:focus-visible,
+.cv-query-compact-select[aria-expanded="true"],
+.cv-query-histogram-interval__select:focus,
+.cv-query-histogram-interval__select:focus-visible,
+.cv-query-histogram-interval__select[aria-expanded="true"] {
+  outline: none !important;
+  box-shadow: inset 0 0 0 1px #98a2b3 !important;
+}
+
+.cv-query-filter-composer .cv-query-compact-select:focus,
+.cv-query-filter-composer .cv-query-compact-select:focus-visible,
+.cv-query-filter-composer .cv-query-compact-select[aria-expanded="true"] {
+  box-shadow: none !important;
+}
+
+.cv-query-builder-form__field .cv-query-compact-select {
+  min-height: 32px !important;
+  height: 32px !important;
+  border-radius: 4px !important;
+}
+
+.cv-query-condition-modal .cv-query-builder-form__field .cv-query-compact-select {
+  min-height: 30px !important;
+  height: 30px !important;
+  border-radius: 4px !important;
+  padding-left: 9px !important;
+}
+
+.cv-query-compact-select .euiButtonContent {
+  min-width: 0;
+}
+
+.cv-query-compact-select__value,
+.cv-query-compact-select__option,
+.cv-query-compact-select .euiButtonContent__text,
+.cv-query-compact-select .euiSuperSelectControl__text {
+  display: block;
+  overflow: hidden;
+  color: inherit;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px !important;
+  font-weight: 600 !important;
+  line-height: 16px !important;
+}
+
+body .cv-query-compact-select__panel {
+  border: 1px solid #e3e8f0 !important;
+  border-radius: 4px !important;
+  background: #ffffff !important;
+  box-shadow:
+    0 8px 16px rgba(52, 55, 65, 0.08),
+    0 1px 2px rgba(52, 55, 65, 0.04) !important;
+}
+
+body .cv-query-compact-select__panel .euiSuperSelect__listbox {
+  max-height: 236px;
+  padding: 4px;
+}
+
+body .cv-query-compact-select__panel button.cv-query-compact-select__item {
+  display: flex !important;
+  width: 100%;
+  min-height: 26px;
+  height: 26px;
+  align-items: center;
+  border: 0 !important;
+  border-radius: 3px;
+  background: transparent !important;
+  box-shadow: none !important;
+  color: #343741;
+  cursor: pointer;
+  padding: 0 7px !important;
+  text-align: left;
+  font-size: 12px !important;
+  font-weight: 600 !important;
+  line-height: 26px !important;
+  outline: none !important;
+}
+
+body .cv-query-compact-select__panel button.cv-query-compact-select__item[aria-selected="true"] {
+  background: var(--cv-primary-tint) !important;
+  color: var(--cv-primary-text);
+}
+
+body .cv-query-compact-select__panel button.cv-query-compact-select__item:hover,
+body .cv-query-compact-select__panel button.cv-query-compact-select__item:focus,
+body .cv-query-compact-select__panel button.cv-query-compact-select__item:focus-visible {
+  background: #f5f7fa !important;
+  outline: none !important;
+}
+
+body .cv-query-compact-select__panel .cv-query-compact-select__item .euiListItemLayout__content {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  align-items: center;
+  padding: 0;
+}
+
+body .cv-query-compact-select__panel .cv-query-compact-select__item .euiListItemLayout,
+body .cv-query-compact-select__panel .cv-query-compact-select__item .euiListItemLayout__inner,
+body .cv-query-compact-select__panel .cv-query-compact-select__item .euiListItemLayout__title,
+body .cv-query-compact-select__panel .cv-query-compact-select__item .cv-query-compact-select__option {
+  min-height: 0 !important;
+  font-size: 12px !important;
+  font-weight: 600 !important;
+  line-height: 26px !important;
+}
+
+body .cv-query-compact-select__panel .cv-query-compact-select__item .euiListItemLayout__icon {
+  width: 14px;
+  height: 14px;
+  margin-right: 6px;
+  color: currentColor;
+}
+
+.cv-query-filter-composer input:focus,
+.cv-query-filter-composer select:focus {
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.cv-query-filter-composer__clause {
+  grid-template-columns: 74px 1fr;
+  gap: 0;
+}
+
+.cv-query-filter-composer__operator select {
+  border-radius: 0;
+  padding-right: 24px;
+}
+
+.cv-query-filter-composer__value input {
+  border-radius: 0;
+}
+
+.cv-query-builder__preview {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+  padding: 8px;
+  color: #69707d;
+  font-size: 11px;
+}
+
+.cv-query-builder__preview strong {
+  flex: 0 0 auto;
+  color: #343741;
+}
+
+.cv-query-builder__preview code {
+  display: block;
+  min-width: 0;
+  max-height: 148px;
+  overflow: auto;
+  overscroll-behavior: contain;
+  border: 1px solid #edf0f5;
+  border-radius: 4px;
+  background: #fbfcfd;
+  color: #343741;
+  padding: 7px 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11.5px;
+  font-weight: 600;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.cv-query-builder__preview-actions {
+  display: inline-flex;
+  justify-content: flex-end;
+  gap: 10px;
+  min-width: 0;
+}
+
+.cv-query-builder__preview-action {
+  flex: 0 0 auto;
+  min-height: 24px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #69707d;
+  cursor: pointer;
+  font: inherit;
+  font-size: 11.5px;
+  font-weight: 650;
+}
+
+.cv-query-builder__preview-action--primary {
+  color: var(--cv-primary-text);
+}
+
+.cv-query-builder__preview-action:hover,
+.cv-query-builder__preview-action:focus-visible {
+  color: var(--cv-primary-text-strong);
+  text-decoration: underline;
+  outline: none;
+}
+
+.cv-query-workspace {
+  gap: 6px;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.cv-query-workspace > .cv-query-panel {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.cv-query-workspace > .cv-query-panel--results:not(.cv-query-panel--workspace-empty) {
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.cv-query-workspace > .cv-query-panel--histogram {
+  padding: 4px 10px 6px;
+}
+
+.cv-query-workspace > .cv-query-panel--workspace-empty {
+  padding: 0;
+  border: 1px solid #e5e8ef;
+  border-radius: 4px;
+  background: #fbfcfd;
+  box-shadow: none;
+}
+
+.cv-query-workspace > .cv-query-panel--workspace-empty:first-child {
+  border-color: #d3dae6;
+}
+
+.cv-query-panel--workspace-empty .cv-query-empty-state {
+  min-height: 120px;
+}
+
+.cv-query-panel--histogram-collapsed {
+  padding-bottom: 4px !important;
+}
+
+.cv-query-histogram-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: #69707d;
+  font-size: 11.5px;
+  font-weight: 600;
+  min-width: 0;
+}
+
+.cv-query-histogram-status {
+  display: inline-flex;
+  align-items: center;
+  min-height: 20px;
+}
+
+.cv-query-histogram-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  width: 100%;
+  min-height: 22px;
+  min-width: 0;
+}
+
+.cv-query-histogram-toolbar--selection {
+  min-height: 24px;
+  align-items: center;
+}
+
+.cv-query-histogram-toolbar__primary {
+  display: inline-flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: 6px;
+}
+
+.cv-query-histogram-actions {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 2px;
+  min-width: 0;
+}
+
+.cv-query-histogram-selection-actions {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 2px;
+}
+
+.cv-query-histogram-toolbar--selection .cv-query-histogram-toolbar__primary {
+  gap: 8px;
+}
+
+.cv-query-histogram-toolbar--selection .cv-query-histogram-summary {
+  flex: 0 1 auto;
+}
+
+.cv-query-histogram-toolbar--selection .cv-query-histogram-selection-actions {
+  gap: 3px;
+}
+
+.cv-query-histogram-interval {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  color: #69707d;
+  font-size: 10.5px;
+  font-weight: 500;
+}
+
+.cv-query-histogram-interval > span:first-child {
+  color: inherit;
+}
+
+.cv-query-histogram-interval .euiFormControlLayout {
+  width: 92px;
+  min-height: 22px;
+  height: 22px;
+  border-radius: 3px;
+  background: transparent;
+  box-shadow: none;
+}
+
+.cv-query-histogram-interval .euiPopover,
+.cv-query-histogram-interval .euiPopover__anchor,
+.cv-query-histogram-interval .euiFormControlLayout__childrenWrapper {
+  min-height: 22px;
+  height: 22px;
+}
+
+.cv-query-histogram-interval:hover .euiFormControlLayout {
+  background: #f5f7fa;
+  box-shadow: none;
+}
+
+.cv-query-histogram-interval .euiFormControlLayout:focus-within {
+  background: #f5f7fa;
+  box-shadow: none;
+}
+
+body .cv-query-histogram-interval__select {
+  min-height: 22px !important;
+  height: 22px !important;
+  border: 0 !important;
+  background-color: transparent !important;
+  box-shadow: none !important;
+  color: #343741 !important;
+  padding: 0 20px 0 5px !important;
+  font-size: 11px !important;
+  font-weight: 650 !important;
+}
+
+body .cv-query-histogram-interval__select:focus,
+body .cv-query-histogram-interval__select:focus-visible,
+body .cv-query-histogram-interval__select[aria-expanded="true"] {
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+body .cv-query-histogram-interval__select.euiSuperSelectControl {
+  min-height: 22px !important;
+  height: 22px !important;
+}
+
+.cv-query-histogram-interval__value,
+.cv-query-histogram-interval__option,
+.cv-query-histogram-interval__select .euiButtonContent__text,
+.cv-query-histogram-interval__select .euiSuperSelectControl__text {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px !important;
+  font-weight: 650 !important;
+  line-height: 15px !important;
+}
+
+body .cv-query-histogram-interval__panel {
+  width: 128px !important;
+  border: 1px solid #d3dae6 !important;
+  border-radius: 4px !important;
+  box-shadow: 0 10px 24px rgba(52, 55, 65, 0.14) !important;
+}
+
+body .cv-query-histogram-interval__panel .euiSuperSelect__listbox {
+  max-height: 240px;
+  padding: 4px;
+}
+
+body .cv-query-histogram-interval__panel button.cv-query-histogram-interval__item {
+  display: flex !important;
+  width: 100%;
+  min-height: 24px;
+  height: 24px;
+  align-items: center;
+  border: 0 !important;
+  border-radius: 3px;
+  background: transparent !important;
+  box-shadow: none !important;
+  color: #343741;
+  cursor: pointer;
+  padding: 0 8px !important;
+  text-align: left;
+  font-size: 11px !important;
+  font-weight: 650 !important;
+  line-height: 24px !important;
+  outline: none !important;
+}
+
+body .cv-query-histogram-interval__panel button.cv-query-histogram-interval__item[aria-selected="true"] {
+  background: var(--cv-primary-soft) !important;
+  color: var(--cv-primary-strong);
+}
+
+body .cv-query-histogram-interval__panel button.cv-query-histogram-interval__item:hover,
+body .cv-query-histogram-interval__panel button.cv-query-histogram-interval__item:focus,
+body .cv-query-histogram-interval__panel button.cv-query-histogram-interval__item:focus-visible {
+  background: #f5f7fa !important;
+}
+
+body .cv-query-histogram-interval__panel button.cv-query-histogram-interval__item[aria-selected="true"]:hover,
+body .cv-query-histogram-interval__panel button.cv-query-histogram-interval__item[aria-selected="true"]:focus,
+body .cv-query-histogram-interval__panel button.cv-query-histogram-interval__item[aria-selected="true"]:focus-visible {
+  background: color-mix(in srgb, var(--cv-primary-soft) 72%, #ffffff) !important;
+}
+
+body .cv-query-histogram-interval__panel .cv-query-histogram-interval__item .euiListItemLayout__content {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  align-items: center;
+  padding: 0;
+}
+
+body .cv-query-histogram-interval__panel .cv-query-histogram-interval__item .euiListItemLayout,
+body .cv-query-histogram-interval__panel .cv-query-histogram-interval__item .euiListItemLayout__inner,
+body .cv-query-histogram-interval__panel .cv-query-histogram-interval__item .euiListItemLayout__title {
+  min-height: 0 !important;
+  font-size: 11px !important;
+  font-weight: 650 !important;
+  line-height: 24px !important;
+}
+
+.cv-query-histogram-interval__bucket {
+  color: #98a2b3;
+  white-space: nowrap;
+}
+
+.cv-query-histogram-action {
+  display: inline-flex;
+  min-height: 20px;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  padding: 0 3px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--cv-primary-strong);
+  cursor: pointer;
+  font-size: 11.5px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.cv-query-histogram-action--icon {
+  width: 22px;
+  min-width: 22px;
+  height: 22px;
+  min-height: 22px;
+  padding: 0;
+}
+
+.cv-query-histogram-action--text {
+  min-width: 0;
+  padding: 0 5px;
+}
+
+.cv-query-histogram-action:hover,
+.cv-query-histogram-action:focus-visible {
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-strong);
+  text-decoration: none;
+  outline: none;
+}
+
+.cv-query-histogram-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+  text-decoration: none;
+}
+
+.cv-query-histogram-action svg {
+  color: currentColor;
+  opacity: 0.58;
+}
+
+.cv-query-histogram-action--icon svg {
+  opacity: 0.66;
+}
+
+.cv-query-histogram-action__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cv-query-histogram-action--primary {
+  font-weight: 700;
+}
+
+.cv-query-histogram-toolbar--selection .cv-query-histogram-action {
+  min-height: 22px;
+  padding: 0 5px;
+}
+
+.cv-query-histogram-toolbar--selection .cv-query-histogram-action svg {
+  opacity: 0.5;
+}
+
+.cv-query-histogram-action--muted {
+  color: #8a95a6;
+  font-weight: 500;
+}
+
+.cv-query-histogram-action--muted:hover,
+.cv-query-histogram-action--muted:focus-visible {
+  color: var(--cv-primary-strong);
+}
+
+.cv-query-histogram-selection-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  max-width: 100%;
+  min-height: 22px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: #69707d;
+  white-space: nowrap;
+}
+
+.cv-query-histogram-selection-summary::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--cv-primary);
+}
+
+.cv-query-histogram-selection-summary strong {
+  color: #1f2937;
+  font-weight: 700;
+}
+
+.cv-query-histogram-selection-summary span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cv-query-histogram {
+  display: block;
+  position: relative;
+  width: 100%;
+  height: 112px;
+  margin-top: 1px;
+  padding: 0;
+}
+
+.cv-query-histogram__chart {
+  height: 112px;
+  min-width: 0;
+}
+
+.cv-query-histogram .echChart {
+  overflow: visible;
+}
+
+.cv-query-histogram .echChartPointerContainer {
+  cursor: crosshair;
+}
+
+.cv-query-histogram__selection-overlay {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 3;
+  min-width: 8px;
+  border-radius: 3px;
+  background: transparent;
+  cursor: zoom-in;
+}
+
+.cv-query-histogram__selection-overlay:focus-visible {
+  outline: 1px solid var(--cv-primary-focus);
+  outline-offset: -1px;
+}
+
+.cv-query-histogram__selection-overlay[aria-disabled="true"] {
+  cursor: wait;
+}
+
+.cv-query-histogram .echTooltip {
+  border-color: #d3dae6;
+  border-radius: 4px;
+  box-shadow: 0 8px 20px rgba(52, 55, 65, 0.14);
+}
+
+body:has(:is(
+  .cv-query-time-popover-panel,
+  .cv-query-saved__popover-panel,
+  .cv-query-filter-composer-popover-panel,
+  .cv-query-fields-panel__popover-panel,
+  .cv-query-result-column-menu-panel,
+  .cv-query-field-stats-backdrop,
+  .cv-query-save-modal-backdrop,
+  .cv-query-condition-modal-backdrop,
+  .cv-query-source-popover-panel
+)) .cv-query-histogram .echTooltip {
+  display: none !important;
+}
+
+body:has(:is(
+  .cv-query-time-popover-panel,
+  .cv-query-saved__popover-panel,
+  .cv-query-filter-composer-popover-panel,
+  .cv-query-fields-panel__popover-panel,
+  .cv-query-result-column-menu-panel,
+  .cv-query-field-stats-backdrop,
+  .cv-query-save-modal-backdrop,
+  .cv-query-condition-modal-backdrop,
+  .cv-query-source-popover-panel
+)) .cv-query-histogram .echChartPointerContainer {
+  pointer-events: none !important;
+}
+
+.cv-query-histogram-tooltip {
+  min-width: 168px;
+  padding: 8px 9px;
+  color: #343741;
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.cv-query-histogram-tooltip__range {
+  color: #343741;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.cv-query-histogram-tooltip__metric {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 6px;
+  color: #69707d;
+  white-space: nowrap;
+}
+
+.cv-query-histogram-tooltip__metric strong {
+  color: #343741;
+  font-weight: 700;
+}
+
+.cv-query-histogram-tooltip__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--cv-primary);
+}
+
+.cv-query-result-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 28px;
+  margin: 0;
+  border: 0;
+  border-bottom: 1px solid #e5e8ef;
+  border-radius: 0;
+  background: #fbfcfd;
+  box-shadow: none;
+  padding: 0 6px 0 10px;
+}
+
+.cv-query-result-bar__page {
+  display: inline-flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+.cv-query-result-bar__summary {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 4px;
+  overflow: hidden;
+  color: #69707d;
+  font-size: 11.5px;
+  font-weight: 600;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cv-query-result-bar__summary em {
+  color: #98a2b3;
+  font-style: normal;
+  font-weight: 500;
+}
+
+.cv-query-result-bar__loading {
+  display: inline-flex;
+  position: relative;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 7px;
+  margin-left: 2px;
+  padding-left: 8px;
+  color: #69707d;
+  font-size: 11.5px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.cv-query-result-bar__loading::before {
+  content: "";
+  position: absolute;
+  top: 5px;
+  bottom: 5px;
+  left: 0;
+  width: 1px;
+  background: #edf1f6;
+}
+
+.cv-query-result-bar__loading-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.cv-query-result-bar__cancel,
+.cv-query-result-loading__cancel {
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--cv-primary-strong);
+  cursor: pointer;
+  padding: 0;
+  font-size: 11.5px;
+  font-weight: 650;
+  line-height: 1;
+}
+
+.cv-query-result-bar__cancel:hover,
+.cv-query-result-bar__cancel:focus-visible,
+.cv-query-result-loading__cancel:hover,
+.cv-query-result-loading__cancel:focus-visible {
+  color: var(--cv-primary-strong);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  outline: none;
+}
+
+.cv-query-result-stack {
+  gap: 0;
+  margin-top: 0;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  overflow: visible;
+}
+
+.cv-query-result-table-shell {
+  position: relative;
+  display: grid;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid #d8dee8;
+  border-radius: 4px;
+  background: #ffffff;
+}
+
+.cv-query-result-table-shell--refreshing .cv-query-result-table-scroll {
+  opacity: 0.52;
+  transition: opacity 120ms ease;
+}
+
+.cv-query-result-body-refresh {
+  position: absolute;
+  z-index: 28;
+  top: 64px;
+  right: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+  padding-top: 28px;
+}
+
+.cv-query-result-body-refresh__pill {
+  display: inline-flex;
+  min-height: 28px;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid #d8dee8;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow:
+    0 6px 16px rgba(52, 55, 65, 0.12),
+    0 1px 2px rgba(52, 55, 65, 0.06);
+  color: #4f5666;
+  padding: 0 9px;
+  pointer-events: auto;
+  font-size: 11.5px;
+  font-weight: 650;
+}
+
+.cv-query-result-body-refresh__cancel {
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--cv-primary-strong);
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+}
+
+.cv-query-result-body-refresh__cancel:hover,
+.cv-query-result-body-refresh__cancel:focus-visible {
+  color: var(--cv-primary-strong);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  outline: none;
+}
+
+.cv-query-result-table-scroll {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: visible;
+  overscroll-behavior-x: contain;
+  overscroll-behavior-y: auto;
+}
+
+.cv-query-result-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 32px;
+  border-top: 1px solid #e5e8ef;
+  background: #fbfcfd;
+  padding: 3px 8px 3px 10px;
+}
+
+.cv-query-result-footer__meta {
+  display: inline-flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+}
+
+.cv-query-result-footer__summary {
+  display: inline-flex;
+  flex: 0 1 auto;
+  min-width: 0;
+  align-items: center;
+  gap: 4px;
+  overflow: hidden;
+  color: #69707d;
+  font-size: 11.5px;
+  font-weight: 600;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cv-query-result-footer__summary em {
+  color: #98a2b3;
+  font-style: normal;
+  font-weight: 500;
+}
+
+.cv-query-result-table-header {
+  position: sticky;
+  top: 28px;
+  z-index: 24;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  border: 0;
+  border-bottom-color: #d3dae6;
+  border-radius: 0;
+  background: #f5f7fa;
+  overscroll-behavior-x: contain;
+  scrollbar-width: none;
+}
+
+.cv-query-result-bar + .cv-query-result-table-header {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.cv-query-result-table-header::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+
+.cv-query-result-table {
+  table-layout: fixed;
+  width: 100%;
+  min-width: 100%;
+  border-spacing: 0;
+  border: 1px solid #e5e8ef;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.cv-query-result-stack .cv-query-result-table:first-child,
+.cv-query-panel--results > .cv-query-result-stack:first-child .cv-query-result-table {
+  border-radius: 6px;
+}
+
+.cv-query-result-table-shell .cv-query-result-table:first-child {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.cv-query-result-col--toggle {
+  width: 34px;
+}
+
+.cv-query-result-col--time {
+  width: 152px;
+}
+
+.cv-query-result-col--level {
+  width: 78px;
+}
+
+.cv-query-result-col--id {
+  width: 136px;
+}
+
+.cv-query-result-col--message {
+  width: 360px;
+  min-width: 220px;
+}
+
+.cv-query-result-col--wide {
+  width: 220px;
+}
+
+.cv-query-result-col--meta,
+.cv-query-result-col--field {
+  width: 156px;
+}
+
+.cv-query-result-table th {
+  padding: 8px 10px;
+  border-bottom: 1px solid #d3dae6;
+  background: #f5f7fa;
+  color: #343741;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.cv-query-result-table__toggle-header,
+.cv-query-result-table__toggle-cell {
+  position: sticky;
+  left: 0;
+  width: 34px;
+  min-width: 34px;
+  max-width: 34px;
+  border-right: 1px solid #eef1f6;
+  text-align: center;
+  vertical-align: middle;
+}
+
+.cv-query-result-table__toggle-header {
+  z-index: 3;
+  padding: 0 !important;
+  background: #f5f7fa;
+}
+
+.cv-query-result-table__toggle-cell {
+  z-index: 2;
+  padding: 0 4px !important;
+  background: #ffffff;
+  line-height: 0;
+}
+
+.cv-query-result-table td.cv-query-result-table__toggle-cell {
+  vertical-align: middle;
+}
+
+.cv-query-result-table__row:hover .cv-query-result-table__toggle-cell,
+.cv-query-result-table__row--active .cv-query-result-table__toggle-cell {
+  background: #fbfcfd;
+}
+
+.cv-query-result-table__row--active .cv-query-result-table__toggle-cell {
+  border-top-left-radius: 0;
+  padding-left: 4px !important;
+  box-shadow: none;
+}
+
+.cv-query-result-table__row--active .cv-query-result-table__toggle-cell::before {
+  content: none;
+  display: none;
+}
+
+.cv-query-result-table__toggle-button {
+  position: absolute;
+  top: calc(50% + 0.5px);
+  left: calc(50% + 0.5px);
+  display: inline-flex;
+  width: 20px;
+  height: 20px;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent !important;
+  color: #4f5666;
+  padding: 0;
+  cursor: pointer;
+  line-height: 0;
+  box-shadow: none !important;
+  transform: translate(-50%, -50%);
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+.cv-query-result-table__toggle-button:hover,
+.cv-query-result-table__toggle-button:focus,
+.cv-query-result-table__toggle-button:active,
+.cv-query-result-table__toggle-button[aria-expanded="true"] {
+  border-color: transparent !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  color: var(--cv-primary-strong);
+  outline: none;
+}
+
+.cv-query-result-table__toggle-button:focus-visible {
+  border-color: transparent !important;
+  background: transparent !important;
+  color: var(--cv-primary-strong);
+  outline: none;
+  box-shadow: none !important;
+}
+
+.cv-query-result-table__toggle-button svg,
+.cv-query-result-table__toggle-button .euiIcon {
+  display: block;
+  flex: 0 0 auto;
+  color: currentColor;
+  opacity: 0.72 !important;
+}
+
+.cv-query-result-table__header {
+  cursor: default;
+  user-select: none;
+  transition: background-color 120ms ease, box-shadow 120ms ease, opacity 120ms ease;
+}
+
+.cv-query-result-table__header.cv-query-result-col--time,
+.cv-query-result-table__cell.cv-query-result-col--time {
+  min-width: 132px;
+}
+
+.cv-query-result-table__header.cv-query-result-col--level,
+.cv-query-result-table__cell.cv-query-result-col--level {
+  min-width: 64px;
+}
+
+.cv-query-result-table__header.cv-query-result-col--id,
+.cv-query-result-table__cell.cv-query-result-col--id {
+  min-width: 96px;
+}
+
+.cv-query-result-table__header.cv-query-result-col--message,
+.cv-query-result-table__cell.cv-query-result-col--message {
+  min-width: 220px;
+}
+
+.cv-query-result-table__header.cv-query-result-col--wide,
+.cv-query-result-table__cell.cv-query-result-col--wide {
+  min-width: 160px;
+}
+
+.cv-query-result-table__header.cv-query-result-col--meta,
+.cv-query-result-table__cell.cv-query-result-col--meta,
+.cv-query-result-table__header.cv-query-result-col--field,
+.cv-query-result-table__cell.cv-query-result-col--field {
+  min-width: 104px;
+}
+
+.cv-query-result-table__header:active {
+  cursor: grabbing;
+}
+
+.cv-query-result-table__header--dragging {
+  opacity: 0.52;
+}
+
+.cv-query-result-table__header--drop-target {
+  background: var(--cv-primary-tint);
+  box-shadow: inset 2px 0 0 var(--cv-primary);
+}
+
+.cv-query-result-header-cell {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: center;
+  gap: 0;
+  min-width: 88px;
+  padding-right: 10px;
+  padding-left: 2px;
+}
+
+.cv-query-result-header-cell__grab {
+  position: absolute;
+  top: 50%;
+  left: -2px;
+  width: 8px;
+  height: 14px;
+  opacity: 0;
+  cursor: grab;
+  background-image: radial-gradient(circle, #69707d 1px, transparent 1.5px);
+  background-position: 0 0;
+  background-size: 4px 4px;
+  transform: translateY(-50%);
+  transition: opacity 120ms ease, color 120ms ease;
+}
+
+.cv-query-result-header-cell__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cv-query-result-header-cell__label-menu {
+  display: flex;
+  min-width: 0;
+}
+
+.cv-query-result-header-cell__label-menu > .euiPopover {
+  display: inline-block;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.cv-query-result-header-cell__label-button {
+  display: inline-flex;
+  width: auto;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 22px;
+  align-items: center;
+  gap: 4px;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  color: inherit;
+  padding: 0 3px;
+  cursor: pointer;
+  font: inherit;
+  font-weight: inherit;
+  text-align: left;
+}
+
+.cv-query-result-header-cell__label-button span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cv-query-result-header-cell__label-button svg,
+.cv-query-result-header-cell__label-button .euiIcon {
+  flex: 0 0 auto;
+  color: #69707d;
+  opacity: 0 !important;
+  transition: opacity 120ms ease, color 120ms ease;
+}
+
+.cv-query-result-header-cell__label-button:hover,
+.cv-query-result-header-cell__label-button:focus-visible {
+  background: var(--cv-primary-tint);
+  color: #343741;
+  box-shadow: none;
+  outline: none;
+}
+
+.cv-query-result-header-cell__label-button[aria-expanded="true"] {
+  background: var(--cv-primary-soft);
+  color: var(--cv-primary-strong);
+  box-shadow: none;
+  outline: none;
+}
+
+.cv-query-result-table__header:hover .cv-query-result-header-cell__label-button svg,
+.cv-query-result-table__header:focus-within .cv-query-result-header-cell__label-button svg,
+.cv-query-result-header-cell__label-button[aria-expanded="true"] svg,
+.cv-query-result-table__header:hover .cv-query-result-header-cell__label-button .euiIcon,
+.cv-query-result-table__header:focus-within .cv-query-result-header-cell__label-button .euiIcon,
+.cv-query-result-header-cell__label-button[aria-expanded="true"] .euiIcon {
+  opacity: 0.58 !important;
+}
+
+.cv-query-result-header-cell__label-button[aria-expanded="true"] svg,
+.cv-query-result-header-cell__label-button[aria-expanded="true"] .euiIcon {
+  color: var(--cv-primary-strong);
+  opacity: 0.78 !important;
+}
+
+.cv-query-result-column-menu-panel {
+  z-index: 260;
+  width: 196px;
+  overflow: hidden !important;
+  border: 1px solid #d8dee8 !important;
+  border-radius: 4px !important;
+  background: #ffffff !important;
+  box-shadow:
+    0 8px 18px rgba(52, 55, 65, 0.1),
+    0 1px 2px rgba(52, 55, 65, 0.04) !important;
+}
+
+.cv-query-result-column-menu {
+  display: grid;
+  gap: 1px;
+  padding: 6px;
+}
+
+.cv-query-result-column-menu__title {
+  min-width: 0;
+  overflow: hidden;
+  color: #69707d;
+  padding: 4px 7px 5px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cv-query-result-column-menu__separator {
+  height: 1px;
+  margin: 3px 4px;
+  background: #eef2f7;
+}
+
+.cv-query-result-column-menu__item {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr);
+  gap: 7px;
+  align-items: center;
+  min-height: 27px;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  color: #343741;
+  padding: 0 7px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 550;
+  text-align: left;
+}
+
+.cv-query-result-column-menu__item svg {
+  color: #69707d;
+  opacity: 0.72;
+}
+
+.cv-query-result-column-menu__item:disabled,
+.cv-query-result-column-menu__item[aria-disabled="true"] {
+  cursor: default;
+  color: #98a2b3;
+  opacity: 1;
+}
+
+.cv-query-result-column-menu__item:disabled:hover,
+.cv-query-result-column-menu__item:disabled:focus-visible,
+.cv-query-result-column-menu__item[aria-disabled="true"]:hover,
+.cv-query-result-column-menu__item[aria-disabled="true"]:focus-visible {
+  background: transparent;
+  color: #98a2b3;
+}
+
+.cv-query-result-column-menu__item:hover,
+.cv-query-result-column-menu__item:focus-visible {
+  background: var(--cv-primary-tint);
+  color: var(--cv-primary-strong);
+  outline: none;
+}
+
+.cv-query-result-header-cell__resize {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  bottom: -8px;
+  display: grid;
+  width: 10px;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  color: #98a2b3;
+  cursor: col-resize;
+  opacity: 0;
+  padding: 0;
+  transition: opacity 120ms ease, color 120ms ease;
+}
+
+.cv-query-result-header-cell__resize span {
+  display: block;
+  width: 1px;
+  height: 18px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.cv-query-result-table__header:hover .cv-query-result-header-cell__resize,
+.cv-query-result-table__header:focus-within .cv-query-result-header-cell__resize,
+.cv-query-resizing-column .cv-query-result-header-cell__resize {
+  opacity: 0.52;
+}
+
+.cv-query-result-header-cell__resize:hover,
+.cv-query-result-header-cell__resize:focus-visible {
+  color: #69707d;
+  opacity: 0.86;
+  outline: none;
+}
+
+.cv-query-result-table__header:hover .cv-query-result-header-cell__grab,
+.cv-query-result-table__header:focus-within .cv-query-result-header-cell__grab,
+.cv-query-result-table__header--dragging .cv-query-result-header-cell__grab {
+  opacity: 0.44;
+}
+
+body.cv-query-resizing-column,
+body.cv-query-resizing-column * {
+  cursor: col-resize !important;
+  user-select: none !important;
+}
+
+.cv-query-result-table td {
+  padding: 7px 10px;
+  border-bottom: 1px solid #eef1f6;
+  color: #343741;
+  font-size: 12px;
+}
+
+.cv-query-result-table__cell {
+  overflow: hidden;
+}
+
+.cv-query-result-table__cell .cv-query-truncate-text {
+  max-width: 100%;
+}
+
+.cv-query-result-table__cell.cv-query-result-col--message,
+.cv-query-result-table__cell.cv-query-result-col--wide {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.cv-query-result-table__row:hover {
+  background: #f8fbff;
+}
+
+.cv-query-result-table__row--active {
+  background: #f8fbff;
+  box-shadow: none;
+}
+
+.cv-query-result-table__detail-row td {
+  padding: 0;
+  border-bottom-color: #d3dae6;
+  background: #ffffff;
+}
+
+.cv-query-result-stack .cv-query-result-table-shell .cv-query-result-table {
+  border: 0;
+  border-radius: 0;
+}
+
+.cv-query-result-stack .cv-query-result-table-shell .cv-query-result-table-scroll {
+  border: 0;
+  border-top: 0;
+  border-radius: 0;
+}
+
+.cv-query-result-table--header th {
+  border-bottom: 0;
+}
+
+.cv-query-skeleton {
+  position: relative;
+  display: block;
+  overflow: hidden;
+  border-radius: 3px;
+  background: #eef2f7;
+}
+
+.cv-query-skeleton::after,
+.cv-query-histogram-loading__bar::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.62), transparent);
+  transform: translateX(-100%);
+  animation: cv-query-skeleton-shimmer 1.35s ease-in-out infinite;
+}
+
+.cv-query-histogram-loading {
+  position: relative;
+  display: grid;
+  min-height: 132px;
+  align-items: end;
+  overflow: hidden;
+  border: 1px solid #eef2f7;
+  border-radius: 4px;
+  background: #fbfcfd;
+  padding: 14px 12px 20px;
+}
+
+.cv-query-histogram-loading__axis {
+  position: absolute;
+  right: 12px;
+  bottom: 18px;
+  left: 12px;
+  height: 1px;
+  background: #e5e8ef;
+}
+
+.cv-query-histogram-loading__bars {
+  display: grid;
+  grid-template-columns: repeat(18, minmax(4px, 1fr));
+  align-items: end;
+  gap: 4px;
+  height: 92px;
+}
+
+.cv-query-histogram-loading__bar {
+  position: relative;
+  display: block;
+  min-height: 10px;
+  overflow: hidden;
+  border-radius: 2px 2px 0 0;
+  background: #e7eef5;
+}
+
+.cv-query-result-loading {
+  display: grid;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.cv-query-result-loading__bar {
+  display: flex;
+  min-height: 28px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  border: 1px solid #e5e8ef;
+  border-bottom: 0;
+  border-radius: 6px 6px 0 0;
+  background: #fbfcfd;
+  padding: 0 8px 0 10px;
+}
+
+.cv-query-result-loading__summary {
+  width: 142px;
+  height: 10px;
+}
+
+.cv-query-result-loading__action {
+  width: 62px;
+  height: 18px;
+  border-radius: 4px;
+}
+
+.cv-query-result-loading__table {
+  display: grid;
+  min-width: 640px;
+  overflow: hidden;
+  border: 1px solid #e5e8ef;
+  border-radius: 0 0 6px 6px;
+  background: #ffffff;
+}
+
+.cv-query-result-loading__header,
+.cv-query-result-loading__row {
+  display: grid;
+  grid-template-columns: 168px 78px minmax(220px, 1.4fr) minmax(156px, 0.8fr) minmax(156px, 0.8fr);
+  align-items: center;
+  gap: 18px;
+}
+
+.cv-query-result-loading__header {
+  min-height: 34px;
+  border-bottom: 1px solid #d3dae6;
+  background: #f5f7fa;
+  padding: 0 12px;
+}
+
+.cv-query-result-loading__header .cv-query-skeleton {
+  width: 54px;
+  height: 9px;
+  background: #e3e8f0;
+}
+
+.cv-query-result-loading__rows {
+  display: grid;
+}
+
+.cv-query-result-loading__row {
+  min-height: 35px;
+  border-bottom: 1px solid #eef1f6;
+  padding: 0 12px;
+}
+
+.cv-query-result-loading__row:last-child {
+  border-bottom: 0;
+}
+
+.cv-query-result-loading__row .cv-query-skeleton {
+  height: 10px;
+}
+
+.cv-query-empty-text--spaced {
+  min-height: 34px;
+  border: 1px dashed #d3dae6;
+  border-radius: 4px;
+  background: #fbfcfd;
+  color: #69707d;
+  padding: 8px 10px;
+}
+
+.cv-query-empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 0;
+  min-height: 120px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: #98a2b3;
+  padding: 12px;
+}
+
+.cv-query-empty-state__icon {
+  display: inline-grid;
+  width: 20px;
+  height: 20px;
+  place-items: center;
+  color: #c7d0dd;
+}
+
+.cv-query-empty-state--loading .cv-query-empty-state__icon {
+  color: #98a2b3;
+}
+
+.cv-query-empty-state--empty .cv-query-empty-state__icon {
+  color: #c7d0dd;
+}
+
+.cv-query-empty-state__body {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.cv-query-empty-state__body strong {
+  color: #8a95a6;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.cv-query-empty-state__body p {
+  margin: 0;
+  color: #98a2b3;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+@keyframes cv-query-skeleton-shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cv-query-skeleton::after,
+  .cv-query-histogram-loading__bar::after,
+  .cv-query-result-action__spinner--active {
+    animation: none;
+    content: none;
+  }
+}
+
+@media (hover: none), (pointer: coarse) {
+  .cv-query-filter-pill__toggle {
+    opacity: 0.62;
+    pointer-events: auto;
+  }
+
+  .cv-query-field-stats__actions {
+    opacity: 0.62;
+    pointer-events: auto;
+  }
+
+  .cv-query-detail__row-actions {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .cv-query-detail__icon-button--quick {
+    color: #98a2b3;
+    opacity: 0.48;
+  }
+}
+
+@media (max-width: 1180px) {
+  .cv-query-command-row {
+    grid-template-columns: minmax(0, 1fr) 270px auto auto;
+  }
+
+  .cv-query-filter-composer {
+    grid-template-columns: 220px 356px auto;
+  }
+
+  .cv-query-filter-composer__clause {
+    grid-template-columns: 96px 254px;
+  }
+
+  .cv-query-filter-composer-popover-panel .cv-query-filter-composer {
+    grid-template-columns: minmax(124px, 136px) minmax(238px, 294px) auto;
+  }
+
+  .cv-query-filter-composer-popover-panel .cv-query-filter-composer__clause {
+    grid-template-columns: 74px 1fr;
+  }
+}
+
+@media (max-width: 900px) {
+  .cv-query-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .cv-query-sidebar {
+    position: static;
+    z-index: auto;
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+    height: auto;
+    max-height: none;
+    overflow: visible;
+    padding: 10px;
+  }
+
+  .cv-query-sidebar__rail {
+    display: none;
+  }
+
+  .cv-query-sidebar .cv-panel-header,
+  .cv-query-sidebar__body {
+    width: auto;
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  .cv-query-command-row {
+    grid-template-columns: minmax(0, 1fr) 72px;
+    width: 100%;
+  }
+
+  .cv-query-filter-composer {
+    grid-template-columns: minmax(0, 1fr);
+    width: 100%;
+  }
+
+  .cv-query-sql {
+    grid-column: 1 / -1;
+  }
+
+  .cv-query-time-picker {
+    grid-column: 1;
+  }
+
+  .cv-query-command-row__actions {
+    grid-column: 2;
+    width: auto;
+  }
+
+  .cv-query-command-tools {
+    grid-column: 1 / -1;
+    justify-content: flex-end;
+  }
+
+  .cv-query-filter-composer__clause {
+    grid-template-columns: 104px minmax(0, 1fr);
+  }
+
+  .cv-query-condition-modal .cv-query-builder-form--modal {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .cv-query-pagination {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+
+  .cv-query-page-size,
+  .cv-query-pagination__pager {
+    flex: 0 0 auto;
+  }
+
+  .cv-query-pagination__pager {
+    flex-wrap: wrap;
+  }
+
+  .cv-query-time-picker {
+    grid-template-columns: 28px minmax(0, 1fr) 28px;
+  }
+
+  .cv-query-time-button {
+    min-height: 32px;
+    padding: 0 8px;
+  }
+
+  .cv-query-time-popover--calendar-open .cv-query-time-body {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .cv-query-time-popover--calendar-open .cv-query-time-body__controls--absolute-first {
+    border-right: 0;
+    border-bottom: 0;
+  }
+
+  .cv-query-time-popover--calendar-open .cv-query-time-absolute-range {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .cv-query-time-popover--calendar-open .cv-query-time-absolute-field + .cv-query-time-absolute-field {
+    border-top: 1px solid #eef2f7;
+    border-left: 0;
+  }
+
+  .cv-query-time-absolute-calendar {
+    margin-top: 0;
+    padding-top: 3px;
+    border-top: 1px solid #f0f3f7;
+  }
+
+  .cv-query-time-popover__footer {
+    grid-template-columns: minmax(0, 1fr) max-content max-content;
+  }
+
+  .cv-query-time-popover__footer .cv-secondary-button,
+  .cv-query-time-popover__footer .cv-action-button {
+    width: auto;
+    justify-content: center;
+  }
+
+  .cv-query-run-button {
+    width: 82px;
+    min-width: 82px;
+  }
+
+  .cv-query-filter-bar {
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px 8px;
+  }
+
+  .cv-query-add-filter {
+    width: auto;
+    justify-content: flex-start;
+  }
+
+  .cv-query-filter-pills {
+    order: 4;
+    width: 100%;
+  }
+
+  .cv-query-builder__preview-wrap {
+    width: auto;
+    margin-left: auto;
+  }
+
+  .cv-query-filter-bar__tools {
+    flex: 1 1 auto;
+    width: auto;
+    min-width: 0;
+    justify-content: flex-end;
+    margin-left: auto;
+  }
+
+  .cv-query-filter-bar__tools .cv-query-action-row--utility {
+    flex-wrap: nowrap;
+    justify-content: flex-end;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  .cv-query-histogram,
+  .cv-query-histogram__chart {
+    height: 108px;
+  }
+
+  .cv-query-histogram-toolbar {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .cv-query-histogram-toolbar__primary,
+  .cv-query-histogram-summary,
+  .cv-query-histogram-actions {
+    width: 100%;
+  }
+
+  .cv-query-histogram-toolbar__primary {
+    flex-wrap: wrap;
+    gap: 4px 8px;
+  }
+
+  .cv-query-histogram-actions {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .cv-query-histogram-selection-actions {
+    flex-wrap: wrap;
+  }
+
+  .cv-query-histogram-interval .euiFormControlLayout {
+    width: 100px;
+  }
+
+  .cv-query-histogram-interval__bucket {
+    display: none;
+  }
+
+  .cv-query-histogram-action--text {
+    width: 22px;
+    min-width: 22px;
+    padding: 0;
+  }
+
+  .cv-query-histogram-action__label {
+    display: none;
+  }
+}
+
+@media (max-width: 640px) {
+  body .cv-query-fields-panel__popover-panel,
+  body .cv-query-fields-panel__popover-panel:has(.cv-query-fields-panel__stats) {
+    right: 8px !important;
+    left: auto !important;
+    width: min(520px, calc(100vw - 16px)) !important;
+    max-width: calc(100vw - 16px) !important;
+  }
+
+  .cv-query-fields-panel__stats .cv-query-field-stats__item {
+    grid-template-columns: minmax(10ch, 1fr) minmax(36px, 62px) minmax(6ch, 7ch) auto;
+    gap: 5px;
+  }
+
+  .cv-query-panel--command {
+    padding: 4px 0 2px;
+  }
+
+  .cv-query-time-popover-panel {
+    --cv-query-time-popover-width: min(356px, calc(100vw - 16px));
+  }
+
+  .cv-query-time-absolute-range,
+  .cv-query-time-popover--calendar-open .cv-query-time-absolute-range {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .cv-query-time-absolute-field + .cv-query-time-absolute-field,
+  .cv-query-time-popover--calendar-open .cv-query-time-absolute-field + .cv-query-time-absolute-field {
+    border-top: 1px solid #eef2f7;
+    border-left: 0;
+  }
+
+  .cv-query-log-tabs {
+    padding: 5px 6px;
+  }
+
+  .cv-query-log-tab__main {
+    min-width: 96px;
+  }
+
+  .cv-query-result-bar {
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+
+  .cv-query-result-footer {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    gap: 6px 10px;
+  }
+
+  .cv-query-result-footer__meta {
+    flex: 1 1 100%;
+    flex-wrap: wrap;
+    gap: 5px 8px;
+  }
+
+  .cv-query-result-bar__page {
+    flex: 1 1 auto;
+    max-width: 100%;
+  }
+
+  .cv-query-result-footer__summary {
+    flex: 1 1 100%;
+  }
+
+  .cv-query-result-actions {
+    width: 100%;
+    margin-left: 0;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: flex-start;
+  }
+
+  .cv-query-result-actions .cv-query-result-action--text {
+    width: auto;
+    min-width: 0;
+    padding: 0;
+  }
+
+  .cv-query-result-actions .cv-query-result-action__label {
+    display: inline;
+  }
+
+  .cv-query-fields-panel {
+    max-height: min(300px, calc(100vh - 96px));
+  }
+
+  .cv-query-action-row--utility {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .cv-query-command-tools {
+    justify-content: flex-start;
+  }
+
+  .cv-query-command-header {
+    align-items: flex-start;
+  }
+
+  .cv-query-filter-composer__clause {
+    grid-template-columns: 88px minmax(0, 1fr);
+  }
+
+  .cv-query-filter-pill {
+    width: 100%;
+  }
+
+  .cv-query-filter-pill__main {
+    flex: 1 1 auto;
+  }
+
+  .cv-query-detail__header {
+    align-items: center;
+    flex-direction: row;
+    justify-content: flex-start;
+    min-height: 26px;
+    padding: 4px 8px 2px 12px;
+  }
+
+  .cv-query-detail__actions {
+    margin-left: 0;
+  }
+
+  .cv-query-detail--inline {
+    width: min(100%, calc(100vw - 24px));
+    max-width: calc(100vw - 24px);
+  }
+
+  .cv-query-detail__title {
+    display: none;
+  }
+
+  .cv-query-detail__body {
+    width: 100%;
+    max-width: none;
+    padding: 0 10px 10px 12px;
+  }
+
+  .cv-query-detail__message {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 4px;
+    padding: 0 0 8px;
+  }
+
+  .cv-query-detail__row,
+  .cv-query-detail__row--nested {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .cv-query-detail__field-cell {
+    grid-template-columns: minmax(0, 1fr) 98px;
+    padding-right: 0;
+  }
+
+  .cv-query-detail__row-actions {
+    width: 98px;
+    min-width: 98px;
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+@media (max-width: 520px) {
+  .cv-query-result-actions__group + .cv-query-result-actions__group {
+    padding-left: 0;
+  }
+
+  .cv-query-result-actions__group + .cv-query-result-actions__group::before {
+    content: none;
+  }
+}
+
+@media (max-width: 360px) {
+  .cv-query-time-absolute-range,
+  .cv-query-time-popover--calendar-open .cv-query-time-absolute-range {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .cv-query-time-absolute-field + .cv-query-time-absolute-field,
+  .cv-query-time-popover--calendar-open .cv-query-time-absolute-field + .cv-query-time-absolute-field {
+    border-top: 1px solid #edf1f6;
+    border-left: 0;
+  }
 }

--- a/ui-v2/tests/query-api.test.ts
+++ b/ui-v2/tests/query-api.test.ts
@@ -175,7 +175,8 @@ describe("query api", () => {
               msg: "succ",
               data: {
                 baseFields: ["service"],
-                logFields: ["message"]
+                logFields: ["message"],
+                supportsGlobalMatch: false
               }
             })
         };
@@ -202,6 +203,7 @@ describe("query api", () => {
 
     expect(fields.baseFields).toEqual([{ field: "service", orderField: "service" }]);
     expect(fields.logFields).toEqual([{ field: "message", orderField: "message" }]);
+    expect(fields.supportsGlobalMatch).toBe(false);
     expect(auto.logs).toEqual([{ suggestion: "service:gateway" }]);
   });
 

--- a/ui-v2/tests/query-page.test.tsx
+++ b/ui-v2/tests/query-page.test.tsx
@@ -1,20 +1,154 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { useEffect } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useQueryWorkspace } from "../src/domains/query/hooks/useQueryWorkspace";
+import { buildStructuredConditions, useQueryWorkspace } from "../src/domains/query/hooks/useQueryWorkspace";
 import { TimeRangeProvider } from "../src/shared/state/TimeRangeContext";
 import QueryLinkPage from "../src/domains/query/pages/QueryLinkPage";
-import QueryPage from "../src/domains/query/pages/QueryPage";
+import QueryPage, { HistogramSelectionOverlay } from "../src/domains/query/pages/QueryPage";
 
 describe("query page", () => {
   function selectConditionField(field: string) {
-    fireEvent.click(screen.getByRole("combobox", { name: "字段" }));
+    const scope =
+      screen.queryByRole("dialog", { name: "Edit condition" }) ??
+      screen.queryByRole("dialog", { name: "Create condition" }) ??
+      document.body;
+    fireEvent.click(within(scope).getByRole("combobox", { name: "Field" }));
     fireEvent.click(screen.getByRole("option", { name: new RegExp(`^${field}(\\s| ·|$)`) }));
+  }
+
+  async function waitForQueryPageReady() {
+    return screen.findByRole("tablist", { name: "Log table tabs" });
+  }
+
+  async function openDatasourcePanel() {
+    await waitForQueryPageReady();
+    const sourceButton = screen.getByRole("button", { name: "Sources" });
+    if (sourceButton.getAttribute("aria-expanded") !== "true") {
+      fireEvent.click(sourceButton);
+    }
+    return screen.findByRole("tree", { name: "Instances, databases, and log tables" });
+  }
+
+  function openAddFilterComposer() {
+    if (screen.queryByLabelText("Filter condition editor")) {
+      return;
+    }
+    const addFilterButton = screen.getByRole("button", { name: "Add condition" });
+    if (addFilterButton.getAttribute("aria-expanded") !== "true") {
+      fireEvent.click(addFilterButton);
+    }
+  }
+
+  function selectInlineConditionField(field: string) {
+    const fieldInput = screen.getByRole("combobox", { name: "Field" });
+    fireEvent.click(fieldInput);
+    fireEvent.click(screen.getByRole("option", { name: new RegExp(`^${field}(\\s| ·|$)`) }));
+  }
+
+  function addInlineCondition(field: string, value: string, operator?: string) {
+    openAddFilterComposer();
+    selectInlineConditionField(field);
+    if (operator) {
+      const composer = screen.getByLabelText("Filter condition editor");
+      const operatorButton = within(composer).getByRole("button", { name: /Operator:/ });
+      fireEvent.click(operatorButton);
+      fireEvent.click(screen.getByRole("option", { name: operator }));
+    }
+    fireEvent.change(screen.getByLabelText("Value"), { target: { value } });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+  }
+
+  function getColumnHeaderByText(text: string) {
+    const header = screen.getAllByRole("columnheader").find((item) => item.textContent?.includes(text));
+    expect(header).toBeTruthy();
+    return header!;
+  }
+
+  function getColumnHeaderLabels() {
+    return screen
+      .getAllByRole("columnheader")
+      .map((item) => item.textContent?.replace(/\s+/g, " ").trim() ?? "")
+      .filter(Boolean);
+  }
+
+  function getColumnHeaderMenuButton(header: HTMLElement, label: string) {
+    const button = within(header)
+      .getAllByRole("button")
+      .find((item) => item.getAttribute("title") === label);
+    expect(button).toBeTruthy();
+    return button!;
+  }
+
+  function createAbortError() {
+    return new DOMException("Aborted", "AbortError");
+  }
+
+  function createAbortableFetchResponse(signal?: AbortSignal | null): Promise<Response> {
+    return new Promise((_, reject) => {
+      if (!signal) {
+        return;
+      }
+      if (signal.aborted) {
+        reject(createAbortError());
+        return;
+      }
+      signal.addEventListener("abort", () => reject(createAbortError()), { once: true });
+    });
   }
 
   beforeEach(() => {
     window.localStorage.clear();
     window.history.replaceState({}, "", "/v2/query");
+  });
+
+  it("guards horizontal overscroll gestures on the query document", async () => {
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    expect(document.documentElement).toHaveClass("cv-query-overscroll-guard");
+    expect(document.body).toHaveClass("cv-query-overscroll-guard");
+
+    const escapingWheel = new window.WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaX: 96,
+      deltaY: 2
+    });
+    expect(document.body.dispatchEvent(escapingWheel)).toBe(false);
+    expect(escapingWheel.defaultPrevented).toBe(true);
+
+    const scrollable = document.createElement("div");
+    scrollable.style.overflowX = "auto";
+    Object.defineProperty(scrollable, "clientWidth", { configurable: true, value: 100 });
+    Object.defineProperty(scrollable, "scrollWidth", { configurable: true, value: 300 });
+    Object.defineProperty(scrollable, "scrollLeft", { configurable: true, value: 50 });
+    document.body.appendChild(scrollable);
+
+    const consumableWheel = new window.WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaX: 96,
+      deltaY: 2
+    });
+    expect(scrollable.dispatchEvent(consumableWheel)).toBe(true);
+    expect(consumableWheel.defaultPrevented).toBe(false);
+    scrollable.remove();
+  });
+
+  it("keeps the main SQL query placeholder quiet", async () => {
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    expect(screen.getByPlaceholderText("Search")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("`status` = 500 AND `_raw_log_` like '%timeout%'")).not.toBeInTheDocument();
   });
 
   it("builds visual query text and validates number values by valueType", async () => {
@@ -43,16 +177,32 @@ describe("query page", () => {
     });
 
     expect(workspace?.buildQueryText()).toBe(
-      "service = 'gateway' AND status != 500 AND message like '%timeout%' AND `container.image.name` = 'repo/app:tag'"
+      "`service` = 'gateway' AND `status` != 500 AND `message` like '%timeout%' AND `container.image.name` = 'repo/app:tag'"
     );
 
     act(() => {
       workspace?.setConditions([
-        { id: "cond_global", field: "全局匹配", operator: "=", value: "timeout", valueType: "string" }
+        { id: "cond_global", field: "All fields", operator: "=", value: "timeout", valueType: "string" }
       ]);
     });
 
-    expect(workspace?.buildQueryText()).toBe("_raw_log_ like '%timeout%'");
+    expect(workspace?.buildQueryText()).toBe("`_raw_log_` like '%timeout%'");
+
+    act(() => {
+      workspace?.setConditions([
+        { id: "cond_global_not", field: "All fields", operator: "not like", value: "debug", valueType: "string" }
+      ]);
+    });
+
+    expect(workspace?.buildQueryText()).toBe("`_raw_log_` not like '%debug%'");
+
+    act(() => {
+      workspace?.setConditions([
+        { id: "cond_global_legacy", field: "全局匹配", operator: "like", value: "legacy", valueType: "string" }
+      ]);
+    });
+
+    expect(workspace?.buildQueryText()).toBe("`_raw_log_` like '%legacy%'");
 
     act(() => {
       workspace?.setConditions([
@@ -62,25 +212,131 @@ describe("query page", () => {
 
     const readyWorkspace = workspace;
     expect(readyWorkspace).not.toBeNull();
-    expect(() => readyWorkspace!.buildQueryText()).toThrow("字段 status 需要数字值");
+    expect(() => readyWorkspace!.buildQueryText()).toThrow("Field status requires a number");
   });
 
-  it("defaults the add condition dialog to global match while keeping all controls selectable", async () => {
+  it("builds indexed log fields as column conditions for structured queries", () => {
+    const [condition] = buildStructuredConditions(
+      [{ id: "cond_1", field: "lv", operator: "=", value: "error", valueType: "string" }],
+      {
+        baseFields: [],
+        logFields: [{ field: "lv", orderField: "lv", typ: 0 }],
+        supportsGlobalMatch: false
+      }
+    );
+
+    expect(condition).toMatchObject({
+      field: {
+        fieldKey: "lv",
+        displayName: "lv",
+        source: "column",
+        path: "lv",
+        valueType: "string",
+        isAccelerated: true,
+        acceleratedCol: "lv"
+      },
+      operator: "=",
+      value: "error"
+    });
+  });
+
+  it("defaults the add filter composer to global match while keeping core controls selectable", async () => {
     render(
       <TimeRangeProvider>
         <QueryPage />
       </TimeRangeProvider>
     );
 
-    await screen.findByRole("tree", { name: "实例、数据库与日志表" });
-    fireEvent.click(screen.getByRole("button", { name: "新增条件" }));
+    await waitForQueryPageReady();
+    openAddFilterComposer();
 
-    expect(screen.getByRole("combobox", { name: "字段" })).toHaveTextContent("全局匹配");
-    expect(screen.getByRole("combobox", { name: "运算符" })).toHaveValue("like");
-    expect(screen.getByRole("combobox", { name: "值类型" })).toHaveValue("string");
-    expect(screen.getByLabelText("条件值")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("combobox", { name: "字段" }));
-    expect(screen.getByRole("option", { name: /^全局匹配/ })).toBeInTheDocument();
+    const composer = screen.getByRole("group", { name: "Filter condition editor" });
+    expect(composer).not.toHaveClass("cv-query-filter-composer--inline");
+    expect(composer.closest(".cv-query-filter-bar")).toBeNull();
+    expect(composer.closest(".cv-query-filter-composer-popover-panel")).toBeTruthy();
+    expect(screen.getByRole("combobox", { name: "Field" })).toHaveValue("All fields");
+    expect(screen.getByRole("button", { name: "Operator: like" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Value")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("combobox", { name: "Field" }));
+    expect(screen.getByRole("option", { name: /^All fields/ })).toBeInTheDocument();
+  });
+
+  it("deduplicates the global match option in the field picker", async () => {
+    const defaultFetch = window.fetch;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const rawUrl = typeof input === "string" ? input : input.toString();
+        const url = new URL(rawUrl, "http://localhost");
+        const method = init?.method || "GET";
+        if (method === "GET" && /^\/api\/v2\/storage\/952(7|8)\/analysis-fields$/.test(url.pathname)) {
+          const response = {
+            code: 0,
+            msg: "succ",
+            data: {
+              baseFields: ["All fields", "service", "level"],
+              logFields: ["All fields", "message", "trace_id"]
+            }
+          };
+          return {
+            ok: true,
+            json: async () => response,
+            text: async () => JSON.stringify(response)
+          };
+        }
+        return defaultFetch(input, init);
+      })
+    );
+
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    openAddFilterComposer();
+    fireEvent.click(screen.getByRole("combobox", { name: "Field" }));
+
+    expect(screen.getAllByRole("option", { name: "All fields" })).toHaveLength(1);
+  });
+
+  it("closes the inline field picker from outside clicks", async () => {
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    openAddFilterComposer();
+
+    fireEvent.click(screen.getByRole("combobox", { name: "Field" }));
+    expect(screen.getByRole("listbox", { name: "Field suggestions" })).toBeInTheDocument();
+
+    fireEvent.pointerDown(screen.getByLabelText("Value"));
+    await waitFor(() => {
+      expect(screen.queryByRole("listbox", { name: "Field suggestions" })).not.toBeInTheDocument();
+    });
+    expect(screen.getByLabelText("Filter condition editor")).toBeInTheDocument();
+  });
+
+  it("closes the inline add filter composer from outside clicks", async () => {
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    openAddFilterComposer();
+
+    expect(screen.getByLabelText("Filter condition editor")).toBeInTheDocument();
+    fireEvent.pointerDown(screen.getByLabelText("SQL query"));
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Filter condition editor")).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: "Add condition" })).toBeInTheDocument();
   });
 
   it("shows a quick log library creation entry from the datasource panel", async () => {
@@ -90,12 +346,42 @@ describe("query page", () => {
       </TimeRangeProvider>
     );
 
-    await screen.findByRole("tree", { name: "实例、数据库与日志表" });
+    await openDatasourcePanel();
 
-    expect(screen.getByRole("link", { name: "创建日志库" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "Create log library" })).toHaveAttribute(
       "href",
       "/v2/query/ingestion"
     );
+  });
+
+  it("filters sources by instance, database, and table names", async () => {
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await openDatasourcePanel();
+    const search = screen.getByRole("searchbox", { name: "Search sources" });
+    await waitFor(() => {
+      expect(search).toHaveFocus();
+    });
+
+    fireEvent.change(search, { target: { value: "app" } });
+    expect(screen.getByRole("button", { name: "Table app_logs" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Table logs" })).not.toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: "default" } });
+    expect(screen.getByRole("button", { name: "Database default" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Table logs" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Table app_logs" })).toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: "missing" } });
+    expect(screen.getByText("No data")).toBeInTheDocument();
+
+    fireEvent.keyDown(search, { key: "Escape" });
+    expect(search).toHaveValue("");
+    expect(screen.getByRole("button", { name: "Table logs" })).toBeInTheDocument();
   });
 
   it("keeps the full query controls available on the share page", async () => {
@@ -107,26 +393,92 @@ describe("query page", () => {
       </TimeRangeProvider>
     );
 
-    expect(await screen.findByRole("region", { name: "查询输入" })).toBeInTheDocument();
-    expect(screen.queryByRole("tree", { name: "实例、数据库与日志表" })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "新增条件" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /^最近查询/ })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /^收藏查询/ })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "分享" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "执行查询" })).toBeInTheDocument();
+    expect(await screen.findByRole("region", { name: "Query input" })).toBeInTheDocument();
+    expect(screen.queryByRole("tree", { name: "Instances, databases, and log tables" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add condition" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Recent" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Saved" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Share" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Run" })).toBeInTheDocument();
   });
 
-  it("opens the add condition modal when clicking blank space in the condition area", async () => {
+  it("closes query utility menus from outside clicks and Escape", async () => {
     render(
       <TimeRangeProvider>
         <QueryPage />
       </TimeRangeProvider>
     );
 
-    const conditionRegion = await screen.findByRole("region", { name: "条件清单" });
-    fireEvent.click(conditionRegion);
+    await waitForQueryPageReady();
+    fireEvent.click(screen.getByRole("button", { name: "Recent" }));
+    expect(screen.getByRole("dialog", { name: "Recent queries" })).toBeInTheDocument();
+    fireEvent.pointerDown(document.body);
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Recent queries" })).not.toBeInTheDocument();
+    });
 
-    expect(await screen.findByRole("dialog", { name: "新增条件" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Saved" }));
+    expect(screen.getByRole("dialog", { name: "Saved queries" })).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Saved queries" })).not.toBeInTheDocument();
+    });
+  });
+
+  it("filters recent queries inside the popover", async () => {
+    window.localStorage.setItem(
+      "clickvisual-v2-query-history",
+      JSON.stringify({
+        9527: ["`level` = 'ERROR'", "`service` = 'gateway'"]
+      })
+    );
+
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    fireEvent.click(screen.getByRole("button", { name: "Recent" }));
+    const dialog = screen.getByRole("dialog", { name: "Recent queries" });
+    const search = within(dialog).getByRole("searchbox", { name: "Search recent queries" });
+    await waitFor(() => {
+      expect(search).toHaveFocus();
+    });
+
+    fireEvent.change(search, { target: { value: "service" } });
+    expect(within(dialog).getByText("`service` = 'gateway'")).toBeInTheDocument();
+    expect(within(dialog).queryByText("`level` = 'ERROR'")).not.toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: "missing" } });
+    expect(within(dialog).getByText("No data")).toBeInTheDocument();
+
+    fireEvent.keyDown(search, { key: "Escape" });
+    expect(search).toHaveValue("");
+    expect(within(dialog).getByText("`level` = 'ERROR'")).toBeInTheDocument();
+  });
+
+  it("opens the add filter composer from the filter bar", async () => {
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    openAddFilterComposer();
+
+    expect(screen.getByLabelText("Filter condition editor")).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Field" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Value")).toHaveFocus();
+    });
+    fireEvent.keyDown(screen.getByLabelText("Value"), { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Filter condition editor")).not.toBeInTheDocument();
+    });
   });
 
   it("does not reuse the previous condition field metadata when adding a new condition", async () => {
@@ -136,19 +488,16 @@ describe("query page", () => {
       </TimeRangeProvider>
     );
 
-    await screen.findByRole("tree", { name: "实例、数据库与日志表" });
-    fireEvent.click(screen.getByRole("button", { name: "新增条件" }));
-    selectConditionField("全局匹配");
-    fireEvent.change(screen.getByLabelText("条件值"), { target: { value: "213" } });
-    fireEvent.click(screen.getByRole("button", { name: "确认" }));
+    await waitForQueryPageReady();
+    addInlineCondition("All fields", "213");
 
-    fireEvent.click(screen.getByRole("button", { name: "新增条件" }));
+    openAddFilterComposer();
 
-    expect(await screen.findByRole("dialog", { name: "新增条件" })).toBeInTheDocument();
-    expect(screen.getByRole("combobox", { name: "字段" })).toHaveTextContent("全局匹配");
+    expect(screen.getByLabelText("Filter condition editor")).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Field" })).toHaveValue("All fields");
     expect(screen.queryByText("未匹配字段目录，默认按 JSON 路径查询")).not.toBeInTheDocument();
-    expect(screen.getByRole("combobox", { name: "运算符" })).toBeInTheDocument();
-    expect(screen.getByRole("combobox", { name: "值类型" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Operator: like" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Value")).toBeInTheDocument();
   });
 
   it("syncs visual conditions to the query URL parameter and restores them after reload", async () => {
@@ -158,14 +507,60 @@ describe("query page", () => {
       </TimeRangeProvider>
     );
 
-    await screen.findByRole("tree", { name: "实例、数据库与日志表" });
-    fireEvent.click(screen.getByRole("button", { name: "新增条件" }));
-    selectConditionField("全局匹配");
-    fireEvent.change(screen.getByLabelText("条件值"), { target: { value: "timeout" } });
-    fireEvent.click(screen.getByRole("button", { name: "确认" }));
+    await waitForQueryPageReady();
+    openAddFilterComposer();
+    fireEvent.change(screen.getByLabelText("Value"), { target: { value: "timeout" } });
+    fireEvent.keyDown(screen.getByLabelText("Value"), { key: "Enter" });
 
     await waitFor(() => {
-      expect(new URL(window.location.href).searchParams.get("query")).toBe("_raw_log_ like '%timeout%'");
+      expect(new URL(window.location.href).searchParams.get("query")).toBe("`_raw_log_` like '%timeout%'");
+    });
+  });
+
+  it("turns the generated SQL preview into manual SQL editing", async () => {
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    addInlineCondition("service", "gateway");
+
+    fireEvent.click(screen.getByRole("button", { name: "Inspect SQL" }));
+    const preview = await screen.findByRole("dialog", { name: "SQL preview" });
+    expect(within(preview).getByText("`service` = 'gateway'")).toBeInTheDocument();
+    fireEvent.click(within(preview).getByRole("button", { name: "Use as SQL" }));
+
+    expect(screen.getByLabelText("SQL query")).toHaveValue("`service` = 'gateway'");
+    expect(screen.queryByRole("button", { name: "service = gateway" })).not.toBeInTheDocument();
+  });
+
+  it("keeps global match operators constrained and writes not like to the query URL", async () => {
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    openAddFilterComposer();
+
+    const composer = screen.getByLabelText("Filter condition editor");
+    const operatorButton = within(composer).getByRole("button", { name: "Operator: like" });
+    fireEvent.click(operatorButton);
+
+    expect(screen.getByRole("option", { name: "like" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "not like" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "!=" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("option", { name: "not like" }));
+    fireEvent.change(screen.getByLabelText("Value"), { target: { value: "error" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(screen.getByRole("button", { name: "All fields not like error" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(new URL(window.location.href).searchParams.get("query")).toBe("`_raw_log_` not like '%error%'");
     });
   });
 
@@ -176,22 +571,19 @@ describe("query page", () => {
       </TimeRangeProvider>
     );
 
-    await screen.findByRole("tree", { name: "实例、数据库与日志表" });
-    fireEvent.click(screen.getByRole("button", { name: "新增条件" }));
-    selectConditionField("service");
-    fireEvent.change(screen.getByLabelText("条件值"), { target: { value: "gateway" } });
-    fireEvent.click(screen.getByRole("button", { name: "确认" }));
+    await waitForQueryPageReady();
+    addInlineCondition("service", "gateway");
 
-    expect(screen.getByRole("button", { name: "service / = / gateway" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "service = gateway" })).toBeInTheDocument();
     await waitFor(() => {
-      expect(new URL(window.location.href).searchParams.get("query")).toBe("service = 'gateway'");
+      expect(new URL(window.location.href).searchParams.get("query")).toBe("`service` = 'gateway'");
     });
 
     const fetchMock = vi.mocked(fetch);
     const requestsBeforeDisable = fetchMock.mock.calls.length;
-    fireEvent.click(screen.getByRole("button", { name: "禁用条件 service" }));
-    expect(screen.getByRole("button", { name: "service / = / gateway" })).toBeInTheDocument();
-    expect(screen.getByText("已禁用条件 service")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Disable condition service" }));
+    expect(screen.getByRole("button", { name: "service = gateway" })).toBeInTheDocument();
+    expect(screen.queryByText("Disabled condition service")).not.toBeInTheDocument();
     await waitFor(() => {
       expect(new URL(window.location.href).searchParams.get("query")).toBeNull();
     });
@@ -200,10 +592,10 @@ describe("query page", () => {
     });
 
     const requestsBeforeEnable = fetchMock.mock.calls.length;
-    fireEvent.click(screen.getByRole("button", { name: "启用条件 service" }));
-    expect(screen.getByText("已启用条件 service")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Enable condition service" }));
+    expect(screen.queryByText("Enabled condition service")).not.toBeInTheDocument();
     await waitFor(() => {
-      expect(new URL(window.location.href).searchParams.get("query")).toBe("service = 'gateway'");
+      expect(new URL(window.location.href).searchParams.get("query")).toBe("`service` = 'gateway'");
     });
     await waitFor(() => {
       expect(fetchMock.mock.calls.length).toBeGreaterThan(requestsBeforeEnable);
@@ -219,8 +611,25 @@ describe("query page", () => {
       </TimeRangeProvider>
     );
 
-    await screen.findByRole("tree", { name: "实例、数据库与日志表" });
-    expect(screen.getByRole("button", { name: "service / = / gateway" })).toBeInTheDocument();
+    await waitForQueryPageReady();
+    expect(screen.getByRole("button", { name: "service = gateway" })).toBeInTheDocument();
+  });
+
+  it("keeps quoted numeric-looking URL condition values as strings", async () => {
+    window.history.replaceState({}, "", "/v2/query?query=%60_pod_name_%60%20%3D%20%271234%27");
+
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    expect(screen.getByRole("button", { name: "_pod_name_ = 1234" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Inspect SQL" }));
+    const preview = await screen.findByRole("dialog", { name: "SQL preview" });
+    expect(within(preview).getByText("`_pod_name_` = '1234'")).toBeInTheDocument();
   });
 
   it("maps legacy v1 query URL parameters into the v2 query workspace", async () => {
@@ -332,8 +741,14 @@ describe("query page", () => {
     );
 
     expect(await screen.findByRole("tab", { name: /app_logs/ })).toHaveAttribute("aria-selected", "true");
-    expect(screen.getByRole("button", { name: "全局匹配 / like / aud" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "All fields like aud" })).toBeInTheDocument();
     await screen.findByText("aud matched");
+    await waitFor(() => {
+      expect(document.querySelector(".cv-query-histogram-meta__count")).not.toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(window.location.search).not.toContain("tab=relative");
+    });
 
     const runRequest = requests.find((item) => item.includes("POST /api/v2/query/run"));
     expect(runRequest).toContain('"tid":9528');
@@ -344,6 +759,124 @@ describe("query page", () => {
     expect(runRequest).toContain('"fieldKey":"_raw_log_"');
     expect(runRequest).toContain('"operator":"contains"');
     expect(runRequest).toContain('"value":"aud"');
+  });
+
+  it("applies compact URL query conditions and last run time to top values", async () => {
+    const defaultFetch = window.fetch;
+    const runPayloads: any[] = [];
+    const fieldStatsPayloads: any[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const rawUrl = typeof input === "string" ? input : input.toString();
+        const url = new URL(rawUrl, "http://localhost");
+        const method = init?.method || "GET";
+
+        if (method === "POST" && url.pathname.endsWith("/api/v2/query/run")) {
+          runPayloads.push(JSON.parse(String(init?.body || "{}")));
+        }
+        if (method === "POST" && url.pathname.endsWith("/api/v2/query/field-stats")) {
+          fieldStatsPayloads.push(JSON.parse(String(init?.body || "{}")));
+        }
+
+        return defaultFetch(input, init);
+      })
+    );
+    window.history.replaceState(
+      {},
+      "",
+      "/v2/query/?start=1785218880&end=1785219780&database=default&table=logs&query=%60lv%60%3D%27debug%27"
+    );
+
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    expect(await screen.findByRole("button", { name: "lv = debug" })).toBeInTheDocument();
+    expect(await screen.findByText("timeout")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        runPayloads.some((payload) => payload.st === 1785218880 && payload.et === 1785219780)
+      ).toBe(true);
+    });
+
+    const levelHeader = getColumnHeaderByText("level");
+    fireEvent.click(getColumnHeaderMenuButton(levelHeader, "level"));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Top values" }));
+
+    await waitFor(() => {
+      expect(fieldStatsPayloads).toHaveLength(1);
+    });
+    const payload = fieldStatsPayloads[0];
+    expect(payload.st).toBe(1785218880);
+    expect(payload.et).toBe(1785219780);
+    expect(payload.conditions).toEqual([
+      expect.objectContaining({
+        operator: "=",
+        value: "debug",
+        field: expect.objectContaining({
+          fieldKey: "lv"
+        })
+      })
+    ]);
+  });
+
+  it("applies compact manual SQL query conditions to top values", async () => {
+    const defaultFetch = window.fetch;
+    const logRequests: string[] = [];
+    const fieldStatsPayloads: any[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const rawUrl = typeof input === "string" ? input : input.toString();
+        const url = new URL(rawUrl, "http://localhost");
+        const method = init?.method || "GET";
+
+        if (method === "GET" && url.pathname.endsWith("/api/v1/tables/9527/logs")) {
+          logRequests.push(url.search);
+        }
+        if (method === "POST" && url.pathname.endsWith("/api/v2/query/field-stats")) {
+          fieldStatsPayloads.push(JSON.parse(String(init?.body || "{}")));
+        }
+
+        return defaultFetch(input, init);
+      })
+    );
+
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    await screen.findByText("timeout");
+
+    fireEvent.change(screen.getByLabelText("SQL query"), { target: { value: "`lv`='debug'" } });
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+    await waitFor(() => {
+      expect(logRequests.some((item) => item.includes("query=%60lv%60%3D%27debug%27"))).toBe(true);
+    });
+
+    const levelHeader = getColumnHeaderByText("level");
+    fireEvent.click(getColumnHeaderMenuButton(levelHeader, "level"));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Top values" }));
+
+    await waitFor(() => {
+      expect(fieldStatsPayloads).toHaveLength(1);
+    });
+    expect(fieldStatsPayloads[0].conditions).toEqual([
+      expect.objectContaining({
+        operator: "=",
+        value: "debug",
+        field: expect.objectContaining({
+          fieldKey: "lv"
+        })
+      })
+    ]);
   });
 
   it("ignores stale autocomplete and stale runQuery responses", async () => {
@@ -509,6 +1042,110 @@ describe("query page", () => {
     });
   });
 
+  it("shows a cancellable loading state and aborts in-flight result queries", async () => {
+    const defaultFetch = window.fetch;
+    const querySignals: AbortSignal[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const rawUrl = typeof input === "string" ? input : input.toString();
+        const url = new URL(rawUrl, "http://localhost");
+        const method = init?.method || "GET";
+
+        if (method === "GET" && /^\/api\/v1\/tables\/9527\/(logs|charts)$/.test(url.pathname)) {
+          if (init?.signal) {
+            querySignals.push(init.signal);
+          }
+          return createAbortableFetchResponse(init?.signal);
+        }
+
+        return defaultFetch(input, init);
+      })
+    );
+
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    await waitFor(() => {
+      expect(querySignals).toHaveLength(2);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel query" }));
+
+    await waitFor(() => {
+      expect(querySignals.every((signal) => signal.aborted)).toBe(true);
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Cancel query" })).not.toBeInTheDocument();
+    });
+  });
+
+  it("marks existing result rows as refreshing while a rerun is in flight", async () => {
+    const defaultFetch = window.fetch;
+    const refreshSignals: AbortSignal[] = [];
+    let logsRequests = 0;
+    let chartsRequests = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const rawUrl = typeof input === "string" ? input : input.toString();
+        const url = new URL(rawUrl, "http://localhost");
+        const method = init?.method || "GET";
+
+        if (method === "GET" && url.pathname.endsWith("/api/v1/tables/9527/logs")) {
+          logsRequests += 1;
+          if (logsRequests > 1) {
+            if (init?.signal) {
+              refreshSignals.push(init.signal);
+            }
+            return createAbortableFetchResponse(init?.signal);
+          }
+        }
+
+        if (method === "GET" && url.pathname.endsWith("/api/v1/tables/9527/charts")) {
+          chartsRequests += 1;
+          if (chartsRequests > 1) {
+            if (init?.signal) {
+              refreshSignals.push(init.signal);
+            }
+            return createAbortableFetchResponse(init?.signal);
+          }
+        }
+
+        return defaultFetch(input, init);
+      })
+    );
+
+    const view = render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    expect(await screen.findByText("timeout")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+
+    expect(await screen.findByRole("status", { name: "Refreshing query results" })).toBeInTheDocument();
+    expect(view.container.querySelector(".cv-query-result-table-shell--refreshing")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(refreshSignals).toHaveLength(2);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel result refresh" }));
+    await waitFor(() => {
+      expect(refreshSignals.every((signal) => signal.aborted)).toBe(true);
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole("status", { name: "Refreshing query results" })).not.toBeInTheDocument();
+    });
+  });
+
   it("renders the condition list and modal trigger instead of the raw textarea", async () => {
     render(
       <TimeRangeProvider>
@@ -516,9 +1153,8 @@ describe("query page", () => {
       </TimeRangeProvider>
     );
 
-    await screen.findByRole("tree", { name: "实例、数据库与日志表" });
-    expect(screen.getByRole("heading", { name: "条件" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "新增条件" })).toBeInTheDocument();
+    await waitForQueryPageReady();
+    expect(screen.getByRole("button", { name: "Add condition" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "编辑" })).not.toBeInTheDocument();
     expect(
       screen.queryByPlaceholderText("输入查询语句，例如 level:error AND service:gateway")
@@ -532,32 +1168,60 @@ describe("query page", () => {
       </TimeRangeProvider>
     );
 
-    await screen.findByRole("tree", { name: "实例、数据库与日志表" });
+    await waitForQueryPageReady();
     await waitFor(() => {
       expect(screen.queryByText("未匹配字段目录，默认按 JSON 路径查询")).not.toBeInTheDocument();
     });
-    fireEvent.click(screen.getByRole("button", { name: "新增条件" }));
-    expect(await screen.findByRole("dialog", { name: "新增条件" })).toBeInTheDocument();
-    selectConditionField("service");
-    expect(screen.getAllByText("物理列").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("列查询").length).toBeGreaterThan(0);
-    fireEvent.change(screen.getByLabelText("条件值"), { target: { value: "gateway" } });
-    fireEvent.click(screen.getByRole("button", { name: "确认" }));
-    expect(screen.getByRole("button", { name: "service / = / gateway" })).toBeInTheDocument();
+    addInlineCondition("service", "gateway");
+    expect(screen.getByRole("button", { name: "service = gateway" })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "service / = / gateway" }));
-    expect(await screen.findByRole("dialog", { name: "编辑条件" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "service = gateway" }));
+    const editDialog = await screen.findByRole("dialog", { name: "Edit condition" });
+    expect(editDialog).toBeInTheDocument();
+    expect(within(editDialog).queryByText("Type")).not.toBeInTheDocument();
     selectConditionField("message");
-    expect(screen.getAllByText("解析字段").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("JSON 路径查询").length).toBeGreaterThan(0);
+    expect(screen.queryByText("解析字段")).not.toBeInTheDocument();
+    expect(screen.queryByText("已索引列")).not.toBeInTheDocument();
+    expect(screen.queryByText("未匹配字段目录，默认按 JSON 路径查询")).not.toBeInTheDocument();
     selectConditionField("level");
-    fireEvent.change(screen.getByRole("textbox", { name: "条件值" }), { target: { value: "ERROR" } });
-    fireEvent.click(screen.getByRole("button", { name: "确认" }));
-    expect(screen.getByRole("button", { name: "level / = / ERROR" })).toBeInTheDocument();
+    fireEvent.change(within(editDialog).getByRole("textbox", { name: "Value" }), { target: { value: "ERROR" } });
+    fireEvent.click(within(editDialog).getByRole("button", { name: "Save" }));
+    expect(screen.getByRole("button", { name: "level = ERROR" })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "level / = / ERROR" }));
-    fireEvent.click(screen.getByRole("button", { name: "删除条件" }));
-    expect(screen.queryByRole("button", { name: "level / = / ERROR" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "level = ERROR" }));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(screen.queryByRole("button", { name: "level = ERROR" })).not.toBeInTheDocument();
+  });
+
+  it("keeps the edit condition dialog open when selecting value text beyond the backdrop", async () => {
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    addInlineCondition("service", "gateway-with-a-very-long-value-that-requires-horizontal-drag-selection");
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "service = gateway-with-a-very-long-value-that-requires-horizontal-drag-selection"
+      })
+    );
+    const editDialog = await screen.findByRole("dialog", { name: "Edit condition" });
+    const backdrop = editDialog.parentElement;
+    expect(backdrop).toBeTruthy();
+
+    const valueInput = within(editDialog).getByRole("textbox", { name: "Value" });
+    fireEvent.mouseDown(valueInput);
+    fireEvent.mouseUp(backdrop!);
+    fireEvent.click(backdrop!);
+
+    expect(screen.getByRole("dialog", { name: "Edit condition" })).toBeInTheDocument();
+
+    fireEvent.mouseDown(backdrop!);
+    fireEvent.click(backdrop!);
+    expect(screen.queryByRole("dialog", { name: "Edit condition" })).not.toBeInTheDocument();
   });
 
   it("supports action buttons and renders query results without view switch buttons", async () => {
@@ -567,43 +1231,755 @@ describe("query page", () => {
       </TimeRangeProvider>
     );
 
-    await screen.findByRole("heading", { name: "日志查询" });
-    expect(await screen.findByRole("tablist", { name: "日志表工作区标签" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: /logs/ })).toHaveAttribute("aria-selected", "true");
-    fireEvent.click(screen.getByRole("button", { name: "新增条件" }));
-    selectConditionField("service");
-    fireEvent.change(screen.getByLabelText("条件值"), { target: { value: "gateway" } });
-    fireEvent.click(screen.getByRole("button", { name: "确认" }));
-    expect(screen.getByRole("button", { name: "service / = / gateway" })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "日志表 app_logs" }));
-    expect(await screen.findByRole("tab", { name: /app_logs/ })).toHaveAttribute("aria-selected", "true");
+    await screen.findByRole("heading", { name: "Log query" });
+    expect(await screen.findByRole("tablist", { name: "Log table tabs" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "default.logs" })).toHaveAttribute("aria-selected", "true");
+    addInlineCondition("service", "gateway");
+    expect(screen.getByRole("button", { name: "service = gateway" })).toBeInTheDocument();
+    await openDatasourcePanel();
+    fireEvent.click(screen.getByRole("button", { name: "Table app_logs" }));
+    expect(await screen.findByRole("tab", { name: "default.app_logs" })).toHaveAttribute("aria-selected", "true");
     await waitFor(() => {
-      expect(screen.queryByRole("button", { name: "service / = / gateway" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "service = gateway" })).not.toBeInTheDocument();
     });
-    fireEvent.click(screen.getByRole("tab", { name: /^logs/ }));
+    fireEvent.click(screen.getByRole("tab", { name: "default.logs" }));
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "service / = / gateway" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "service = gateway" })).toBeInTheDocument();
     });
     expect(screen.queryByRole("button", { name: "保存查询" })).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "收藏查询" }));
-    fireEvent.click(screen.getByRole("button", { name: "保存当前查询" }));
-    expect(await screen.findByRole("dialog", { name: "保存查询" })).toBeInTheDocument();
-    fireEvent.change(screen.getByLabelText("收藏名称"), { target: { value: "Gateway 错误" } });
-    fireEvent.click(screen.getByRole("button", { name: "保存" }));
-    expect(await screen.findByText("已保存到收藏查询")).toBeInTheDocument();
-    expect(await screen.findByText("Gateway 错误")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "删除收藏 Gateway 错误" }));
-    expect(await screen.findByText("已删除收藏 Gateway 错误")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "分享" }));
-    expect(await screen.findByText("分享短链已复制")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "执行查询" }));
-    await screen.findByText("共 1 条结果");
+    fireEvent.click(screen.getByRole("button", { name: "Saved" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save current query" }));
+    expect(await screen.findByRole("dialog", { name: "Save query" })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Query name"), { target: { value: "Gateway 错误" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(await screen.findByText("Query saved")).toBeInTheDocument();
+    const savedDialog = await screen.findByRole("dialog", { name: "Saved queries" });
+    const savedSearch = within(savedDialog).getByRole("searchbox", { name: "Search saved queries" });
+    await waitFor(() => {
+      expect(savedSearch).toHaveFocus();
+    });
+    expect(within(savedDialog).getByText("Gateway 错误")).toBeInTheDocument();
+    fireEvent.change(savedSearch, { target: { value: "Gateway" } });
+    expect(within(savedDialog).getByText("Gateway 错误")).toBeInTheDocument();
+    fireEvent.change(savedSearch, { target: { value: "missing" } });
+    expect(within(savedDialog).getByText("No data")).toBeInTheDocument();
+    fireEvent.keyDown(savedSearch, { key: "Escape" });
+    expect(savedSearch).toHaveValue("");
+    expect(within(savedDialog).getByText("Gateway 错误")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Delete saved query Gateway 错误" }));
+    expect(await screen.findByText("Deleted saved query Gateway 错误")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Share" }));
+    expect(await screen.findByText("Share link copied")).toBeInTheDocument();
+    const clipboardWriteText = vi.mocked(navigator.clipboard.writeText);
+    const copiedShareLink = String(clipboardWriteText.mock.calls.at(-1)?.[0] ?? "");
+    const sharedOriginUrl = new URL(copiedShareLink).searchParams.get("from") ?? "";
+    const sharedOrigin = new URL(sharedOriginUrl);
+    expect(sharedOrigin.pathname).toBe("/share");
+    expect(sharedOrigin.searchParams.get("database")).toBe("default");
+    expect(sharedOrigin.searchParams.get("table")).toBe("logs");
+    expect(sharedOrigin.searchParams.get("tid")).toBe("9527");
+    expect(sharedOrigin.searchParams.get("query")).toBe("`service` = 'gateway'");
+    expect(sharedOrigin.searchParams.get("kw")).toBe("`service` = 'gateway'");
+    expect(sharedOrigin.searchParams.get("start")).toMatch(/^\d+$/);
+    expect(sharedOrigin.searchParams.get("end")).toMatch(/^\d+$/);
+    expect(sharedOrigin.searchParams.get("startTime")).toBeNull();
+    expect(sharedOrigin.searchParams.get("endTime")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+    expect((await screen.findAllByText("1 row")).length).toBeGreaterThan(0);
+    const resultSummary = document.querySelector(".cv-query-result-bar__summary");
+    expect(resultSummary).toHaveTextContent("1 row");
+    expect(resultSummary).not.toHaveTextContent("1 - 1");
+    expect(screen.queryByLabelText("Result page controls")).not.toBeInTheDocument();
+    expect(screen.queryByText("Rows per page")).not.toBeInTheDocument();
 
     expect(screen.queryByRole("button", { name: "原始日志" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "聚合统计" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Trace 视图" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "JSON 视图" })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "列配置" })).toBeInTheDocument();
+    const fieldsButton = screen.getByRole("button", { name: "Fields" });
+    expect(fieldsButton).toHaveClass("cv-query-result-action--text");
+    expect(fieldsButton).toHaveTextContent("Fields");
+    expect(screen.queryByRole("button", { name: "Columns" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Expand all" })).not.toBeInTheDocument();
+  });
+
+  it("groups fields and opens top values from the fields panel", async () => {
+    const defaultFetch = window.fetch;
+    const fieldStatsPayloads: any[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const rawUrl = typeof input === "string" ? input : input.toString();
+        const url = new URL(rawUrl, "http://localhost");
+        const method = init?.method || "GET";
+        if (method === "POST" && url.pathname.endsWith("/api/v2/query/field-stats")) {
+          fieldStatsPayloads.push(JSON.parse(String(init?.body || "{}")));
+        }
+        return defaultFetch(input, init);
+      })
+    );
+
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+    expect(await screen.findByText("timeout")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Fields" }));
+    const fieldsDialog = await screen.findByRole("dialog", { name: "Fields" });
+    await waitFor(() => {
+      expect(within(fieldsDialog).getByRole("searchbox", { name: "Search fields" })).toHaveFocus();
+    });
+    expect(within(fieldsDialog).getByRole("tab", { name: "Log Fields 2" })).toHaveAttribute("aria-selected", "true");
+    expect(within(fieldsDialog).getByRole("tab", { name: "Base Fields 2" })).toBeInTheDocument();
+    expect(within(fieldsDialog).getByRole("tab", { name: "All Fields 6" })).toBeInTheDocument();
+    expect(within(fieldsDialog).queryByRole("tab", { name: /Metadata/ })).not.toBeInTheDocument();
+    expect(within(fieldsDialog).queryByText("service")).not.toBeInTheDocument();
+    expect(within(fieldsDialog).getByText("trace_id")).toBeInTheDocument();
+    expect(within(fieldsDialog).queryByText("request_id")).not.toBeInTheDocument();
+    fireEvent.click(within(fieldsDialog).getByRole("tab", { name: "All Fields 6" }));
+    expect(within(fieldsDialog).getByText("request_id")).toBeInTheDocument();
+
+    fireEvent.click(within(fieldsDialog).getByRole("tab", { name: "Base Fields 2" }));
+    fireEvent.click(within(fieldsDialog).getByRole("button", { name: "Add service column" }));
+    expect(screen.getAllByRole("columnheader").some((header) => header.textContent?.includes("service"))).toBe(true);
+    fireEvent.click(within(fieldsDialog).getByRole("button", { name: "Remove service column" }));
+    expect(screen.getAllByRole("columnheader").some((header) => header.textContent?.includes("service"))).toBe(false);
+
+    const search = within(fieldsDialog).getByRole("searchbox", { name: "Search fields" });
+    fireEvent.change(search, { target: { value: "trace" } });
+    expect(within(fieldsDialog).getByText("trace_id")).toBeInTheDocument();
+    expect(within(fieldsDialog).queryByText("service")).not.toBeInTheDocument();
+    expect(within(fieldsDialog).getByRole("tab", { name: "Log Fields 1" })).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.click(within(fieldsDialog).getByRole("button", { name: "Top values for trace_id" }));
+    await waitFor(() => {
+      expect(fieldStatsPayloads).toHaveLength(1);
+    });
+    expect(fieldStatsPayloads[0]).toEqual(
+      expect.objectContaining({
+        field: expect.objectContaining({
+          fieldKey: "trace_id"
+        })
+      })
+    );
+    expect(await within(fieldsDialog).findByRole("region", { name: "trace_id top values" })).toBeInTheDocument();
+    expect(screen.queryByRole("dialog", { name: "trace_id top values" })).not.toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "Fields" })).toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: "" } });
+    fireEvent.click(within(fieldsDialog).getByRole("button", { name: "Top values for message" }));
+    await waitFor(() => {
+      expect(fieldStatsPayloads).toHaveLength(2);
+    });
+    expect(fieldStatsPayloads[1]).toEqual(
+      expect.objectContaining({
+        field: expect.objectContaining({
+          fieldKey: "message"
+        })
+      })
+    );
+    expect(await within(fieldsDialog).findByRole("region", { name: "message top values" })).toBeInTheDocument();
+    expect(within(fieldsDialog).getByRole("region", { name: "trace_id top values" })).toBeInTheDocument();
+
+    fireEvent.click(within(fieldsDialog).getByRole("button", { name: "Top values for trace_id" }));
+    expect(within(fieldsDialog).queryByRole("region", { name: "trace_id top values" })).not.toBeInTheDocument();
+    fireEvent.click(within(fieldsDialog).getByRole("button", { name: "Top values for trace_id" }));
+    expect(within(fieldsDialog).getByRole("region", { name: "trace_id top values" })).toBeInTheDocument();
+    expect(fieldStatsPayloads).toHaveLength(2);
+  });
+
+  it("disables top values for unique and time-related fields", async () => {
+    const defaultFetch = window.fetch;
+    const fieldStatsPayloads: any[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const rawUrl = typeof input === "string" ? input : input.toString();
+        const url = new URL(rawUrl, "http://localhost");
+        const method = init?.method || "GET";
+
+        if (method === "GET" && url.pathname.endsWith("/api/v2/storage/9527/analysis-fields")) {
+          return {
+            ok: true,
+            text: async () =>
+              JSON.stringify({
+                code: 0,
+                msg: "succ",
+                data: {
+                  baseFields: ["time", "_time_nanosecond_", "created_at", "eventTime", "service"],
+                  logFields: ["ts", "event_time", "receivedAt", "timestampMillis", "message", "tid"]
+                }
+              })
+          };
+        }
+
+        if (method === "POST" && url.pathname.endsWith("/api/v2/query/field-stats")) {
+          fieldStatsPayloads.push(JSON.parse(String(init?.body || "{}")));
+        }
+
+        return defaultFetch(input, init);
+      })
+    );
+
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+    expect(await screen.findByText("timeout")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Fields" }));
+    const fieldsDialog = await screen.findByRole("dialog", { name: "Fields" });
+    await within(fieldsDialog).findByText("message");
+
+    ["ts", "event_time", "receivedAt", "timestampMillis", "tid"].forEach((field) => {
+      expect(within(fieldsDialog).getByRole("button", { name: field })).toBeDisabled();
+      expect(within(fieldsDialog).queryByRole("button", { name: `Top values for ${field}` })).not.toBeInTheDocument();
+    });
+    expect(within(fieldsDialog).getByRole("button", { name: "Top values for message" })).toBeEnabled();
+    fireEvent.click(within(fieldsDialog).getByRole("button", { name: "ts" }));
+    expect(fieldStatsPayloads).toHaveLength(0);
+
+    fireEvent.click(within(fieldsDialog).getByRole("tab", { name: /^Base Fields\b/ }));
+    ["time", "_time_nanosecond_", "created_at", "eventTime"].forEach((field) => {
+      expect(within(fieldsDialog).getByRole("button", { name: field })).toBeDisabled();
+      expect(within(fieldsDialog).queryByRole("button", { name: `Top values for ${field}` })).not.toBeInTheDocument();
+    });
+    expect(within(fieldsDialog).getByRole("button", { name: "Top values for service" })).toBeEnabled();
+
+    fireEvent.click(within(fieldsDialog).getByRole("tab", { name: /^Log Fields\b/ }));
+    fireEvent.click(within(fieldsDialog).getByRole("button", { name: "Add event_time column" }));
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Fields" })).not.toBeInTheDocument();
+    });
+
+    const timeHeader = getColumnHeaderByText("time");
+    fireEvent.click(getColumnHeaderMenuButton(timeHeader, "time"));
+    expect(await screen.findByRole("menu", { name: "time column actions" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Add condition" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Top values" })).not.toBeInTheDocument();
+    fireEvent.click(getColumnHeaderMenuButton(timeHeader, "time"));
+    await waitFor(() => {
+      expect(screen.queryByRole("menu", { name: "time column actions" })).not.toBeInTheDocument();
+    });
+
+    const eventTimeHeader = getColumnHeaderByText("event_time");
+    fireEvent.click(getColumnHeaderMenuButton(eventTimeHeader, "event_time"));
+    expect(await screen.findByRole("menu", { name: "event_time column actions" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Add condition" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Top values" })).not.toBeInTheDocument();
+  });
+
+  it("shows and cancels slow top values inside the fields panel", async () => {
+    const defaultFetch = window.fetch;
+    const fieldStatsSignals: AbortSignal[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const rawUrl = typeof input === "string" ? input : input.toString();
+        const url = new URL(rawUrl, "http://localhost");
+        const method = init?.method || "GET";
+
+        if (method === "POST" && url.pathname.endsWith("/api/v2/query/field-stats")) {
+          if (init?.signal) {
+            fieldStatsSignals.push(init.signal);
+          }
+          return createAbortableFetchResponse(init?.signal);
+        }
+
+        return defaultFetch(input, init);
+      })
+    );
+
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+    expect(await screen.findByText("timeout")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Fields" }));
+    const fieldsDialog = await screen.findByRole("dialog", { name: "Fields" });
+    fireEvent.click(within(fieldsDialog).getByRole("button", { name: "Top values for message" }));
+
+    expect(await within(fieldsDialog).findByLabelText("Loading top values")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(fieldStatsSignals).toHaveLength(1);
+    });
+
+    fireEvent.click(within(fieldsDialog).getByRole("button", { name: "Cancel message top values query" }));
+
+    await waitFor(() => {
+      expect(fieldStatsSignals[0].aborted).toBe(true);
+    });
+    await waitFor(() => {
+      expect(within(fieldsDialog).queryByRole("region", { name: "message top values" })).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole("dialog", { name: "Fields" })).toBeInTheDocument();
+  });
+
+  it("keeps pagination reachable at the bottom and separates bulk expand from fields", async () => {
+    const defaultFetch = window.fetch;
+    const requestPaths: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const rawUrl = typeof input === "string" ? input : input.toString();
+        const url = new URL(rawUrl, "http://localhost");
+        const method = init?.method || "GET";
+
+        if (method === "GET" && url.pathname.endsWith("/api/v1/tables/9527/logs")) {
+          const page = Number(url.searchParams.get("page") || "1");
+          const pageSize = Number(url.searchParams.get("pageSize") || "50");
+          requestPaths.push(`${method} ${url.pathname}${url.search}`);
+          return {
+            ok: true,
+            text: async () =>
+              JSON.stringify({
+                code: 0,
+                msg: "succ",
+                data: {
+                  count: 120,
+                  cost: 8,
+                  query: "",
+                  keys: [],
+                  logs: Array.from({ length: Math.min(pageSize, Math.max(120 - (page - 1) * pageSize, 0)) }, (_, index) => {
+                    const absoluteIndex = (page - 1) * pageSize + index + 1;
+                    return {
+                      _time: `2026-04-15 10:${String(index).padStart(2, "0")}:00`,
+                      level: absoluteIndex % 2 ? "INFO" : "ERROR",
+                      message: `page-${page} row-${absoluteIndex}`,
+                      tid: `trace-${absoluteIndex}`
+                    };
+                  })
+                }
+              })
+          };
+        }
+
+        return defaultFetch(input, init);
+      })
+    );
+
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    expect(await screen.findByText("page-1 row-1")).toBeInTheDocument();
+
+    const expandPageButton = screen.getByRole("button", { name: "Expand all" });
+    expect(expandPageButton).toHaveClass("cv-query-result-action--text");
+    expect(expandPageButton).toHaveTextContent("Expand all");
+    expect(expandPageButton.closest(".cv-query-result-bar__page")).toBeTruthy();
+    expect(expandPageButton.closest(".cv-query-result-actions")).toBeNull();
+    fireEvent.click(expandPageButton);
+    expect(screen.getByRole("button", { name: "Expand all" })).toHaveAttribute("aria-busy", "true");
+    expect(document.querySelector(".cv-query-result-action__spinner--active")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Collapse all" })).not.toHaveAttribute("aria-busy");
+    });
+    expect(screen.getAllByLabelText("Log details")).toHaveLength(50);
+
+    const toolbarRows = screen.getByLabelText("Rows per page");
+    expect(toolbarRows.closest(".cv-query-result-bar__page")).toBeTruthy();
+    expect(toolbarRows.closest(".cv-query-result-actions")).toBeNull();
+    expect(screen.getByLabelText("Result page controls")).toBeInTheDocument();
+    const footerPager = screen.getByLabelText("Result page controls footer");
+    expect(footerPager.closest(".cv-query-result-footer")).toBeTruthy();
+    expect(within(footerPager).getByRole("button", { name: "Previous page" })).toBeDisabled();
+
+    fireEvent.click(within(footerPager).getByRole("button", { name: "Next page" }));
+    await waitFor(() => {
+      expect(requestPaths.some((item) => item.includes("page=2") && item.includes("pageSize=50"))).toBe(true);
+    });
+    expect(await screen.findByText("page-2 row-51")).toBeInTheDocument();
+    expect(within(screen.getByLabelText("Result page controls footer")).getByText("2 / 3")).toBeInTheDocument();
+
+    const pageSize200 = within(screen.getByLabelText("Rows per page")).getByText("200").closest("label");
+    expect(pageSize200).toBeTruthy();
+    fireEvent.click(pageSize200!);
+    await waitFor(() => {
+      expect(requestPaths.some((item) => item.includes("page=1") && item.includes("pageSize=200"))).toBe(true);
+    });
+    expect(await screen.findByText("page-1 row-120")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Result page controls")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Result page controls footer")).not.toBeInTheDocument();
+    const singlePageRows = screen.getByLabelText("Rows per page");
+    expect(singlePageRows.closest(".cv-query-result-bar__page")).toBeTruthy();
+    expect(singlePageRows.closest(".cv-query-result-actions")).toBeNull();
+  });
+
+  it("keeps the sticky result header aligned while horizontally scrolling", async () => {
+    const { container } = render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+
+    const headerScroll = await waitFor(() => {
+      const element = container.querySelector<HTMLDivElement>(".cv-query-result-table-header");
+      expect(element).toBeTruthy();
+      return element!;
+    });
+    const bodyScroll = container.querySelector<HTMLDivElement>(".cv-query-result-table-scroll");
+    expect(bodyScroll).toBeTruthy();
+    expect(container.querySelectorAll(".cv-query-result-table--body th")).toHaveLength(0);
+
+    bodyScroll!.scrollLeft = 96;
+    fireEvent.scroll(bodyScroll!);
+    expect(headerScroll.scrollLeft).toBe(96);
+
+    fireEvent.wheel(headerScroll, { deltaX: 64 });
+    expect(bodyScroll!.scrollLeft).toBe(160);
+    expect(headerScroll.scrollLeft).toBe(160);
+
+    bodyScroll!.scrollLeft = 24;
+    headerScroll.scrollLeft = 24;
+    fireEvent.wheel(headerScroll, { deltaY: 32, shiftKey: true });
+    expect(bodyScroll!.scrollLeft).toBe(56);
+    expect(headerScroll.scrollLeft).toBe(56);
+  });
+
+  it("adds a top value from a result column directly as a filter", async () => {
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText("ERROR").length).toBeGreaterThan(0);
+    });
+
+    const tidHeader = screen
+      .getAllByRole("columnheader")
+      .find((header) => header.textContent?.includes("tid"));
+    expect(tidHeader).toBeTruthy();
+    const tidMenuButton = within(tidHeader!)
+      .getAllByRole("button")
+      .find((button) => button.getAttribute("title") === "tid");
+    expect(tidMenuButton).toBeTruthy();
+    fireEvent.click(tidMenuButton!);
+    expect(await screen.findByRole("menu", { name: "tid column actions" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Top values" })).not.toBeInTheDocument();
+    fireEvent.click(tidMenuButton!);
+    await waitFor(() => {
+      expect(screen.queryByRole("menu", { name: "tid column actions" })).not.toBeInTheDocument();
+    });
+
+    const levelHeader = screen
+      .getAllByRole("columnheader")
+      .find((header) => header.textContent?.includes("level"));
+    expect(levelHeader).toBeTruthy();
+    const levelMenuButton = within(levelHeader!)
+      .getAllByRole("button")
+      .find((button) => button.getAttribute("title") === "level");
+    expect(levelMenuButton).toBeTruthy();
+    fireEvent.click(levelMenuButton!);
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Top values" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "level top values" });
+    expect(within(dialog).getByRole("button", { name: "Close top values" })).toBeInTheDocument();
+    expect(within(dialog).queryByRole("button", { name: "Close" })).not.toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "level top values" })).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(levelMenuButton!);
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Top values" }));
+    const reopenedDialog = await screen.findByRole("dialog", { name: "level top values" });
+    expect(within(reopenedDialog).getByText("ERROR")).not.toHaveAttribute("title");
+    const clipboardWriteText = vi.mocked(navigator.clipboard.writeText);
+    fireEvent.click(await within(reopenedDialog).findByRole("button", { name: "Copy level value ERROR" }));
+    await waitFor(() => {
+      expect(clipboardWriteText.mock.calls.at(-1)?.[0]).toBe("ERROR");
+    });
+    expect(screen.getByRole("dialog", { name: "level top values" })).toBeInTheDocument();
+    fireEvent.click(await within(reopenedDialog).findByRole("button", { name: "Filter for level = ERROR" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "level top values" })).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: "level = ERROR" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(new URL(window.location.href).searchParams.get("query")).toBe("`level` = 'ERROR'");
+    });
+  });
+
+  it("cancels in-flight top values requests", async () => {
+    const defaultFetch = window.fetch;
+    const fieldStatsSignals: AbortSignal[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const rawUrl = typeof input === "string" ? input : input.toString();
+        const url = new URL(rawUrl, "http://localhost");
+        const method = init?.method || "GET";
+
+        if (method === "POST" && url.pathname.endsWith("/api/v2/query/field-stats")) {
+          if (init?.signal) {
+            fieldStatsSignals.push(init.signal);
+          }
+          return createAbortableFetchResponse(init?.signal);
+        }
+
+        return defaultFetch(input, init);
+      })
+    );
+
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+    await waitFor(() => {
+      expect(screen.getAllByText("ERROR").length).toBeGreaterThan(0);
+    });
+
+    const levelHeader = getColumnHeaderByText("level");
+    fireEvent.click(getColumnHeaderMenuButton(levelHeader, "level"));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Top values" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "level top values" });
+    await waitFor(() => {
+      expect(fieldStatsSignals).toHaveLength(1);
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Cancel top values query" }));
+
+    await waitFor(() => {
+      expect(fieldStatsSignals[0].aborted).toBe(true);
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "level top values" })).not.toBeInTheDocument();
+    });
+  });
+
+  it("moves and hides result columns from the column header menu", async () => {
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText("ERROR").length).toBeGreaterThan(0);
+    });
+
+    const initialLabels = getColumnHeaderLabels();
+    expect(initialLabels.findIndex((item) => item.includes("time"))).toBeLessThan(
+      initialLabels.findIndex((item) => item.includes("level"))
+    );
+
+    const levelHeader = getColumnHeaderByText("level");
+    expect(within(levelHeader).queryByRole("button", { name: "Hide level column" })).not.toBeInTheDocument();
+    fireEvent.click(getColumnHeaderMenuButton(levelHeader, "level"));
+    expect(await screen.findByRole("menuitem", { name: "Hide column" })).toBeInTheDocument();
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move left" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("menuitem", { name: "Move left" })).not.toBeInTheDocument();
+    });
+
+    const movedLeftLabels = getColumnHeaderLabels();
+    expect(movedLeftLabels.findIndex((item) => item.includes("level"))).toBeLessThan(
+      movedLeftLabels.findIndex((item) => item.includes("time"))
+    );
+
+    const movedLevelHeader = getColumnHeaderByText("level");
+    fireEvent.click(getColumnHeaderMenuButton(movedLevelHeader, "level"));
+    expect(await screen.findByRole("menuitem", { name: "Move left" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Move right" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("menuitem", { name: "Move right" })).not.toBeInTheDocument();
+    });
+
+    const movedRightLabels = getColumnHeaderLabels();
+    expect(movedRightLabels.findIndex((item) => item.includes("time"))).toBeLessThan(
+      movedRightLabels.findIndex((item) => item.includes("level"))
+    );
+
+    const messageHeader = getColumnHeaderByText("msg");
+    const resizeHandle = within(messageHeader).getByRole("button", { name: "Resize msg column" });
+    fireEvent.mouseDown(resizeHandle, { button: 0, clientX: 320 });
+    fireEvent.mouseMove(window, { clientX: 440 });
+    fireEvent.mouseUp(window);
+    await waitFor(() => {
+      const storedWidths = JSON.parse(
+        window.localStorage.getItem("clickvisual-v2-query-result-columns:anonymous:1:default:logs:widths") ?? "{}"
+      ) as Record<string, number>;
+      expect(storedWidths.__message).toBe(480);
+    });
+    expect(document.body).not.toHaveClass("cv-query-resizing-column");
+    expect(
+      Array.from(document.querySelectorAll<HTMLTableColElement>("col.cv-query-result-col--message")).some(
+        (column) => column.style.width === "480px"
+      )
+    ).toBe(true);
+
+    fireEvent.click(getColumnHeaderMenuButton(messageHeader, "msg"));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Hide column" }));
+    expect(screen.getAllByRole("columnheader").some((header) => header.textContent?.includes("msg"))).toBe(false);
+  });
+
+  it("keeps the Auto interval label tied to the automatic bucket size", async () => {
+    const defaultFetch = window.fetch;
+    const rangeStart = 1784863980;
+    const rangeEnd = rangeStart + 6 * 60;
+    window.history.replaceState({}, "", `/v2/query?start=${rangeStart}&end=${rangeEnd}`);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const rawUrl = typeof input === "string" ? input : input.toString();
+        const url = new URL(rawUrl, "http://localhost");
+        const method = init?.method || "GET";
+
+        if (method === "GET" && url.pathname.endsWith("/api/v1/tables/9527/logs")) {
+          return {
+            ok: true,
+            text: async () =>
+              JSON.stringify({
+                code: 0,
+                msg: "succ",
+                data: {
+                  count: 1,
+                  cost: 2,
+                  query: "",
+                  keys: [],
+                  logs: [
+                    {
+                      _time: "2026-07-24 11:35:00",
+                      level: "INFO",
+                      message: "auto interval sample"
+                    }
+                  ]
+                }
+              })
+          };
+        }
+
+        if (method === "GET" && url.pathname.endsWith("/api/v1/tables/9527/charts")) {
+          return {
+            ok: true,
+            text: async () =>
+              JSON.stringify({
+                code: 0,
+                msg: "succ",
+                data: {
+                  histograms: Array.from({ length: 6 }, (_, index) => ({
+                    count: index === 0 ? 10 : 20,
+                    from: rangeStart + index * 60,
+                    to: rangeStart + (index + 1) * 60,
+                    progress: "100%"
+                  }))
+                }
+              })
+          };
+        }
+
+        return defaultFetch(input, init);
+      })
+    );
+
+    render(
+      <TimeRangeProvider>
+        <QueryPage />
+      </TimeRangeProvider>
+    );
+
+    await waitForQueryPageReady();
+    const histogramIntervalButton = await screen.findByLabelText("Histogram interval");
+    await waitFor(() => {
+      expect(histogramIntervalButton).toHaveTextContent("Auto (1m)");
+    });
+
+    fireEvent.click(histogramIntervalButton);
+    fireEvent.click(await screen.findByRole("option", { name: "10 minutes" }));
+    await waitFor(() => {
+      expect(histogramIntervalButton).toHaveTextContent("10 minutes");
+    });
+
+    fireEvent.click(histogramIntervalButton);
+    expect(await screen.findByRole("option", { name: "Auto (1m)" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "10 minutes" })).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.click(screen.getByRole("option", { name: "Auto (1m)" }));
+    await waitFor(() => {
+      expect(histogramIntervalButton).toHaveTextContent("Auto (1m)");
+    });
+  });
+
+  it("zooms and clears a selected histogram range from keyboard and click shortcuts", () => {
+    const onZoom = vi.fn();
+    const onCancel = vi.fn();
+    const range = {
+      startIndex: 0,
+      endIndex: 1,
+      from: 1784863980,
+      to: 1784864100,
+      count: 12
+    };
+
+    const { rerender } = render(
+      <HistogramSelectionOverlay
+        range={range}
+        style={{ left: "10%", width: "20%" }}
+        onZoom={onZoom}
+        onCancel={onCancel}
+      />
+    );
+
+    const selectedRange = screen.getByRole("button", { name: /Selected histogram range:/ });
+    fireEvent.keyDown(selectedRange, { key: "Enter" });
+    fireEvent.keyDown(selectedRange, { key: " " });
+    fireEvent.click(selectedRange);
+    fireEvent.keyDown(selectedRange, { key: "Escape" });
+
+    expect(onZoom).toHaveBeenCalledTimes(3);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <HistogramSelectionOverlay
+        range={range}
+        style={{ left: "10%", width: "20%" }}
+        disabled
+        onZoom={onZoom}
+        onCancel={onCancel}
+      />
+    );
+    const disabledRange = screen.getByRole("button", { name: /Selected histogram range:/ });
+    fireEvent.keyDown(disabledRange, { key: "Enter" });
+    fireEvent.click(disabledRange);
+    fireEvent.keyDown(disabledRange, { key: "Escape" });
+
+    expect(onZoom).toHaveBeenCalledTimes(3);
+    expect(onCancel).toHaveBeenCalledTimes(2);
   });
 
   it("parses raw log json and renders client time in query results", async () => {
@@ -681,16 +2057,90 @@ describe("query page", () => {
                     {
                       level: "[NULL]",
                       addr: "[NULL]",
+                      code: "[NULL]",
+                      method: "[NULL]",
+                      comp: "[NULL]",
+                      compName: "[NULL]",
+                      cost: "[NULL]",
+                      event: "[NULL]",
+                      ip: "[NULL]",
+                      name: "[NULL]",
+                      peerIp: "[NULL]",
+                      peerName: "[NULL]",
+                      type: "[NULL]",
+                      ucode: "[NULL]",
+                      blank: "   ",
                       "container.name": "svc-front-tracker",
                       _time_nanosecond_: "2026-06-02T13:57:52+08:00",
+                      _time_second_: "2026-06-02T13:57:52+08:00",
                       _raw_log_: JSON.stringify({
                         lv: "info",
                         ts: 1780312831.121323,
                         msg: "GetTableRepo",
                         "container.name": "svc-front-tracker",
+                        "container.image.name": "registry.example.com/svc-front-tracker:e2b8425",
+                        "host.ip": "172.17.9.83",
+                        "host.name": "master-1",
+                        "k8s.namespace.name": "default",
+                        "k8s.node.ip": "172.17.9.83",
+                        "k8s.node.name": "master-1",
+                        "k8s.pod.name": "svc-front-tracker-6f4c9b9c8d-abcde",
                         "k8s.pod.uid": "pod-uid-9527",
+                        lname: "default.log",
+                        "log.file.path": "/var/log/containers/app_stdout.log",
+                        time: 1780312831,
+                        path: "/host/proc/meminfo",
                         request_length: 74,
                         nested: { ok: true }
+                      })
+                    },
+                    {
+                      level: "WARN",
+                      addr: "[NULL]",
+                      "container.name": "svc-front-tracker",
+                      _time_nanosecond_: "2026-06-02T13:58:10+08:00",
+                      _raw_log_: JSON.stringify({
+                        lv: "warn",
+                        msg: "NoTimestampInRawLog",
+                        "container.name": "svc-front-tracker"
+                      })
+                    },
+                    {
+                      level: "ERROR",
+                      tid: "trace-ns",
+                      msg: "NanosecondStringTimestamp",
+                      "container.name": "svc-front-tracker",
+                      _time_nanosecond_: "1780379910000000000",
+                      _raw_log_: JSON.stringify({
+                        lv: "error",
+                        msg: "NanosecondStringTimestamp",
+                        "container.name": "svc-front-tracker"
+                      })
+                    },
+                    {
+                      "container.name": "drive-be-worker",
+                      _time_nanosecond_: "2026-06-02T13:58:40+08:00",
+                      _time_second_: "2026-06-02T13:58:40+08:00",
+                      _raw_log_: JSON.stringify({
+                        lv: "info",
+                        ts: 1780312920.9174867,
+                        msg: "access",
+                        lname: "ego.sys",
+                        comp: "component.eredis",
+                        compName: "redis.db",
+                        method: "del",
+                        cost: 0.217,
+                        req: ["del", "resync-group-lock"],
+                        tid: "0af62e9181187917950810e9cc9e67c2",
+                        event: "normal",
+                        addr: "redis-master:6379",
+                        code: 0,
+                        ip: "172.17.9.83",
+                        name: "drive-be",
+                        peerIp: "172.17.9.84",
+                        peerName: "redis-master",
+                        type: "redis",
+                        ucode: "OK"
                       })
                     }
                   ]
@@ -730,84 +2180,209 @@ describe("query page", () => {
       </TimeRangeProvider>
     );
 
-    await screen.findByRole("heading", { name: "日志查询" });
-    fireEvent.click(screen.getByRole("button", { name: "执行查询" }));
+    await screen.findByRole("heading", { name: "Log query" });
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
 
     await waitFor(() => {
       expect(screen.getAllByText("info").length).toBeGreaterThan(0);
     });
     expect(screen.getAllByText("GetTableRepo").length).toBeGreaterThan(0);
-    expect(screen.getByText("2026/6/1 19:20:31")).toBeInTheDocument();
-    expect(screen.getByText("06/01 19:20")).toBeInTheDocument();
-    expect(document.querySelector(".cv-query-histogram__bar--empty")).toBeInTheDocument();
+    expect(screen.getByText("2026-06-02 13:57:52")).toBeInTheDocument();
+    expect(screen.getByText("2026-06-02 13:58:10")).toBeInTheDocument();
+    expect(screen.getByText("2026-06-02 13:58:30")).toBeInTheDocument();
+    expect(screen.queryByText("1780379910000000000")).not.toBeInTheDocument();
+    const defaultResultHeaders = getColumnHeaderLabels();
+    expect(defaultResultHeaders.some((header) => header.includes("container.name"))).toBe(true);
+    expect(defaultResultHeaders.some((header) => header.includes("_container_name_"))).toBe(false);
+    expect(document.querySelector(".echChart")).toBeInTheDocument();
     expect(screen.queryByTitle(/：0 条$/)).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("日志详情")).not.toBeInTheDocument();
+    const zoomOutButton = screen.getByRole("button", { name: "Zoom out" });
+    expect(zoomOutButton).toHaveClass("cv-query-histogram-action--text");
+    expect(zoomOutButton).toHaveTextContent("Zoom out");
+    const hideChartButton = screen.getByRole("button", { name: "Hide chart" });
+    expect(hideChartButton).toHaveClass("cv-query-histogram-action--icon");
+    expect(hideChartButton).toHaveTextContent("");
+    fireEvent.click(hideChartButton);
+    expect(screen.queryByLabelText("Log time distribution")).not.toBeInTheDocument();
+    const showChartButton = screen.getByRole("button", { name: "Show chart" });
+    expect(showChartButton).toHaveClass("cv-query-histogram-action--icon");
+    expect(showChartButton).toHaveTextContent("");
+    fireEvent.click(showChartButton);
+    expect(document.querySelector(".echChart")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Log details")).not.toBeInTheDocument();
+    const bodyScroll = view.container.querySelector<HTMLDivElement>(".cv-query-result-table-scroll");
+    const headerScroll = view.container.querySelector<HTMLDivElement>(".cv-query-result-table-header");
+    expect(bodyScroll).toBeTruthy();
+    expect(headerScroll).toBeTruthy();
+    bodyScroll!.scrollLeft = 128;
+    headerScroll!.scrollLeft = 128;
     fireEvent.click(screen.getByText("GetTableRepo"));
-    expect(screen.getByLabelText("日志详情")).toBeInTheDocument();
-    expect(screen.getByText("_time_nanosecond_")).toBeInTheDocument();
-    expect(screen.getAllByText("k8s.pod.uid").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("pod-uid-9527").length).toBeGreaterThan(0);
+    const logDetails = screen.getByLabelText("Log details");
+    expect(logDetails).toBeInTheDocument();
+    expect(logDetails).toHaveClass("cv-query-detail--fields");
+    expect(within(logDetails).queryByText("2026-06-02 13:57:52")).not.toBeInTheDocument();
+    expect(bodyScroll!.scrollLeft).toBe(0);
+    expect(headerScroll!.scrollLeft).toBe(0);
+    expect(screen.getAllByRole("columnheader").some((header) => header.textContent?.includes("request_length"))).toBe(false);
+    const includeMsgButton = within(logDetails).getByRole("button", { name: "Filter for msg = GetTableRepo" });
+    expect(includeMsgButton).toHaveClass("cv-query-detail__icon-button--quick");
+    expect(includeMsgButton).not.toHaveClass("cv-query-detail__icon-button--secondary");
+    const addRequestLengthButton = screen.getByRole("button", { name: "Add request_length column" });
+    expect(addRequestLengthButton).toHaveClass("cv-query-detail__icon-button--secondary");
+    fireEvent.click(addRequestLengthButton);
+    expect(screen.getAllByRole("columnheader").some((header) => header.textContent?.includes("request_length"))).toBe(true);
+    fireEvent.click(screen.getByRole("button", { name: "Remove request_length column" }));
+    expect(screen.getAllByRole("columnheader").some((header) => header.textContent?.includes("request_length"))).toBe(false);
+    expect(within(logDetails).getByText("path")).toBeInTheDocument();
+    expect(within(logDetails).getByText("/host/proc/meminfo")).toBeInTheDocument();
+    expect(within(logDetails).queryByText("_raw_log_")).not.toBeInTheDocument();
+    expect(screen.queryByText("_time_nanosecond_")).not.toBeInTheDocument();
+    expect(within(logDetails).queryByText("_time_second_")).not.toBeInTheDocument();
+    expect(within(logDetails).queryByText("container.image.name")).not.toBeInTheDocument();
+    expect(within(logDetails).queryByText("host.ip")).not.toBeInTheDocument();
+    expect(within(logDetails).queryByText("host.name")).not.toBeInTheDocument();
+    expect(within(logDetails).queryByText("k8s.namespace.name")).not.toBeInTheDocument();
+    expect(within(logDetails).queryByText("k8s.node.ip")).not.toBeInTheDocument();
+    expect(within(logDetails).queryByText("k8s.node.name")).not.toBeInTheDocument();
+    expect(within(logDetails).queryByText("k8s.pod.name")).not.toBeInTheDocument();
+    expect(within(logDetails).queryByText("k8s.pod.uid")).not.toBeInTheDocument();
+    expect(within(logDetails).queryByText("lname")).not.toBeInTheDocument();
+    expect(within(logDetails).queryByText("log.file.path")).not.toBeInTheDocument();
+    expect(within(logDetails).queryByText("ts")).not.toBeInTheDocument();
+    expect(within(logDetails).queryByText("time")).not.toBeInTheDocument();
+    expect(within(logDetails).queryByText("pod-uid-9527")).not.toBeInTheDocument();
+    [
+      "addr",
+      "code",
+      "method",
+      "comp",
+      "compName",
+      "cost",
+      "event",
+      "ip",
+      "name",
+      "peerIp",
+      "peerName",
+      "type",
+      "ucode",
+      "blank"
+    ].forEach((field) => {
+      expect(within(logDetails).queryByText(field)).not.toBeInTheDocument();
+    });
     expect(screen.getByText("nested")).toBeInTheDocument();
     expect(screen.getByText("{\"ok\":true}")).toBeInTheDocument();
+    expect(screen.queryByText("ok")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "1 field" }));
+    expect(screen.getByText("ok")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Show 15 fields" }));
+    expect(within(logDetails).getByText("_raw_log_")).toBeInTheDocument();
+    expect(screen.getByText("_time_nanosecond_")).toBeInTheDocument();
+    expect(screen.getByText("_time_second_")).toBeInTheDocument();
+    expect(screen.getByText("container.image.name")).toBeInTheDocument();
+    expect(screen.getByText("host.ip")).toBeInTheDocument();
+    expect(screen.getByText("host.name")).toBeInTheDocument();
+    expect(screen.getByText("k8s.namespace.name")).toBeInTheDocument();
+    expect(screen.getByText("k8s.node.ip")).toBeInTheDocument();
+    expect(screen.getByText("k8s.node.name")).toBeInTheDocument();
+    expect(screen.getByText("k8s.pod.name")).toBeInTheDocument();
+    expect(screen.getAllByText("k8s.pod.uid").length).toBeGreaterThan(0);
+    expect(screen.getByText("lname")).toBeInTheDocument();
+    expect(screen.getByText("log.file.path")).toBeInTheDocument();
+    expect(screen.getByText("ts")).toBeInTheDocument();
+    expect(within(logDetails).getByText("time")).toBeInTheDocument();
+    expect(screen.getAllByText("pod-uid-9527").length).toBeGreaterThan(0);
     expect(screen.getAllByText("msg").length).toBeGreaterThan(0);
-    const podUidFieldButton = screen
-      .getAllByTitle("添加条件：k8s.pod.uid = pod-uid-9527")
-      .find((item) => !item.getAttribute("aria-label"));
-    expect(podUidFieldButton).toBeDefined();
-    fireEvent.click(podUidFieldButton!);
-    expect(screen.getByRole("button", { name: "k8s.pod.uid / = / pod-uid-9527" })).toBeInTheDocument();
-    await waitFor(() => {
-      expect(new URL(window.location.href).searchParams.get("query")).toBe("`k8s.pod.uid` = 'pod-uid-9527'");
-    });
-    fireEvent.click(podUidFieldButton!);
-    expect(screen.getAllByRole("button", { name: "k8s.pod.uid / = / pod-uid-9527" })).toHaveLength(1);
-    expect(screen.getByText("已存在条件 k8s.pod.uid = pod-uid-9527")).toBeInTheDocument();
-    expect(new URL(window.location.href).searchParams.get("query")).toBe("`k8s.pod.uid` = 'pod-uid-9527'");
-    fireEvent.click(screen.getByRole("button", { name: "从 JSON 添加条件 container.name = svc-front-tracker" }));
-    expect(screen.getByRole("button", { name: "container.name / = / svc-front-tracker" })).toBeInTheDocument();
-    expect(new URL(window.location.href).searchParams.get("query")).toBe(
-      "`k8s.pod.uid` = 'pod-uid-9527' AND `container.name` = 'svc-front-tracker'"
-    );
-    fireEvent.click(screen.getByRole("button", { name: "2026-06-02T13:57:52+08:00" }));
-    expect(
-      screen.getByRole("button", { name: "_time_nanosecond_ / >= / 2026-06-02 13:57:52" })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "_time_nanosecond_ / < / 2026-06-02 13:57:53" })
-    ).toBeInTheDocument();
-    expect(new URL(window.location.href).searchParams.get("query")).toBe(
-      "`k8s.pod.uid` = 'pod-uid-9527' AND `container.name` = 'svc-front-tracker' AND _time_nanosecond_ >= '2026-06-02 13:57:52' AND _time_nanosecond_ < '2026-06-02 13:57:53'"
-    );
-    expect(
-      screen.getByText(
-        "`k8s.pod.uid` = 'pod-uid-9527' AND `container.name` = 'svc-front-tracker' AND _time_nanosecond_ >= '2026-06-02 13:57:52' AND _time_nanosecond_ < '2026-06-02 13:57:53'"
-      )
-    ).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "从 JSON 添加条件 msg = GetTableRepo" }));
-    expect(screen.getByRole("button", { name: "msg / = / GetTableRepo" })).toBeInTheDocument();
-    expect(new URL(window.location.href).searchParams.get("query")).toBe(
-      "`k8s.pod.uid` = 'pod-uid-9527' AND `container.name` = 'svc-front-tracker' AND _time_nanosecond_ >= '2026-06-02 13:57:52' AND _time_nanosecond_ < '2026-06-02 13:57:53' AND msg = 'GetTableRepo'"
-    );
-    fireEvent.click(screen.getByRole("button", { name: "JSON" }));
+    fireEvent.click(screen.getByRole("tab", { name: "JSON" }));
+    expect(screen.getByLabelText("Log details")).toHaveClass("cv-query-detail--json");
     const inlineJson = screen.getByText(/"_raw_log_"/).closest("pre");
     expect(inlineJson).toHaveTextContent("\"lv\": \"info\"");
     expect(inlineJson).not.toHaveTextContent("\"parsed\"");
     expect(inlineJson).not.toHaveTextContent("\"original\"");
     expect(inlineJson).not.toHaveTextContent("[NULL]");
+    const clipboardWriteText = vi.mocked(navigator.clipboard.writeText);
+    fireEvent.click(within(logDetails).getByRole("button", { name: "Copy log" }));
+    await waitFor(() => {
+      expect(clipboardWriteText).toHaveBeenCalled();
+    });
+    const copiedLogJson = String(clipboardWriteText.mock.calls.at(-1)?.[0] ?? "");
+    expect(copiedLogJson).toContain("\"_raw_log_\"");
+    expect(copiedLogJson).toContain("\"GetTableRepo\"");
+    expect(copiedLogJson).not.toContain("\"parsed\"");
+    expect(copiedLogJson).not.toContain("\"original\"");
+    expect(copiedLogJson).not.toContain("[NULL]");
     expect(screen.queryByText("全部 JSON")).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "字段" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Fields" }));
+    expect(screen.getByLabelText("Log details")).toHaveClass("cv-query-detail--fields");
     expect(screen.getAllByText("k8s.pod.uid").length).toBeGreaterThan(0);
+    fireEvent.click(within(logDetails).getByRole("button", { name: "Copy k8s.pod.uid value" }));
+    await waitFor(() => {
+      expect(clipboardWriteText.mock.calls.at(-1)?.[0]).toBe("pod-uid-9527");
+    });
+    fireEvent.click(screen.getByText("access"));
+    const accessLogDetails = screen.getAllByLabelText("Log details").at(-1)!;
+    expect(accessLogDetails).toHaveClass("cv-query-detail--fields");
+    [
+      "tid",
+      "method",
+      "addr",
+      "comp",
+      "compName",
+      "cost",
+      "event",
+      "code",
+      "ip",
+      "name",
+      "peerIp",
+      "peerName",
+      "type",
+      "ucode"
+    ].forEach((field) => {
+      expect(within(accessLogDetails).getByText(field)).toBeInTheDocument();
+    });
+    expect(within(accessLogDetails).getByText("del")).toBeInTheDocument();
+    expect(within(accessLogDetails).getByText("component.eredis")).toBeInTheDocument();
+    expect(within(accessLogDetails).queryByText("lname")).not.toBeInTheDocument();
 
     expect(screen.queryByRole("columnheader", { name: "k8s.pod.uid" })).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "列配置" }));
-    fireEvent.click(screen.getByRole("checkbox", { name: /k8s\.pod\.uid/ }));
-    fireEvent.click(screen.getByRole("checkbox", { name: /^addr/ }));
-    expect(screen.getByRole("columnheader", { name: "k8s.pod.uid" })).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "addr" })).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "addr" }).closest("table")).not.toHaveTextContent("[NULL]");
+    fireEvent.click(screen.getByRole("button", { name: "Fields" }));
+    const fieldsDialog = screen.getByRole("dialog", { name: "Fields" });
+    await waitFor(() => {
+      expect(within(fieldsDialog).getByRole("searchbox", { name: "Search fields" })).toHaveFocus();
+    });
+    const fieldsSearch = within(fieldsDialog).getByRole("searchbox", { name: "Search fields" });
+    fireEvent.change(fieldsSearch, { target: { value: "k8s" } });
+    fireEvent.keyDown(fieldsSearch, { key: "Escape" });
+    expect(fieldsSearch).toHaveValue("");
+    expect(screen.getByRole("dialog", { name: "Fields" })).toBeInTheDocument();
+    fireEvent.change(fieldsSearch, { target: { value: "k8s.pod.uid" } });
+    fireEvent.click(within(fieldsDialog).getByRole("button", { name: "Add k8s.pod.uid column" }));
+    expect(screen.getByRole("dialog", { name: "Fields" })).toBeInTheDocument();
+    fireEvent.change(fieldsSearch, { target: { value: "addr" } });
+    fireEvent.click(within(fieldsDialog).getByRole("button", { name: "Add addr column" }));
+    const columnHeaders = screen.getAllByRole("columnheader");
+    expect(columnHeaders.some((header) => header.textContent?.includes("k8s.pod.uid"))).toBe(true);
+    const addrHeader = columnHeaders.find((header) => header.textContent?.includes("addr"));
+    expect(addrHeader).toBeTruthy();
+    expect(addrHeader?.closest("table")).not.toHaveTextContent("[NULL]");
     expect(
       window.localStorage.getItem("clickvisual-v2-query-result-columns:anonymous:1:default:logs")
     ).toContain("k8s.pod.uid");
+    fireEvent.pointerDown(document.body);
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Fields" })).not.toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fields" }));
+    expect(screen.getByRole("dialog", { name: "Fields" })).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Fields" })).not.toBeInTheDocument();
+    });
+    const podUidFieldButton = screen.getByRole("button", { name: "Filter for k8s.pod.uid = pod-uid-9527" });
+    fireEvent.click(podUidFieldButton);
+    expect(screen.getByRole("button", { name: "k8s.pod.uid = pod-uid-9527" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(new URL(window.location.href).searchParams.get("query")).toBe("`k8s.pod.uid` = 'pod-uid-9527'");
+    });
 
     view.unmount();
     window.history.replaceState({}, "", "/v2/query");
@@ -816,9 +2391,13 @@ describe("query page", () => {
         <QueryPage />
       </TimeRangeProvider>
     );
-    await screen.findByRole("heading", { name: "日志查询" });
-    fireEvent.click(screen.getByRole("button", { name: "执行查询" }));
-    expect(await screen.findByRole("columnheader", { name: "k8s.pod.uid" })).toBeInTheDocument();
+    await screen.findByRole("heading", { name: "Log query" });
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole("columnheader").some((header) => header.textContent?.includes("k8s.pod.uid"))
+      ).toBe(true);
+    });
   });
 
   it("parses level and message from _raw_log without trailing underscore", async () => {
@@ -928,8 +2507,8 @@ describe("query page", () => {
       </TimeRangeProvider>
     );
 
-    await screen.findByRole("heading", { name: "日志查询" });
-    fireEvent.click(screen.getByRole("button", { name: "执行查询" }));
+    await screen.findByRole("heading", { name: "Log query" });
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
 
     await waitFor(() => {
       expect(screen.getAllByText("info").length).toBeGreaterThan(0);
@@ -1059,10 +2638,10 @@ describe("query page", () => {
       </TimeRangeProvider>
     );
 
-    await screen.findByRole("heading", { name: "日志查询" });
-    fireEvent.click(screen.getByRole("button", { name: "执行查询" }));
+    await screen.findByRole("heading", { name: "Log query" });
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
 
-    expect(await screen.findByLabelText("Trace 链路")).toBeInTheDocument();
+    expect(await screen.findByLabelText("Trace links")).toBeInTheDocument();
     expect(screen.getByText("trace-1")).toBeInTheDocument();
     expect(screen.getByText(/2 spans/)).toBeInTheDocument();
     expect(screen.getByText("gateway")).toBeInTheDocument();
@@ -1207,19 +2786,20 @@ describe("query page", () => {
       </TimeRangeProvider>
     );
 
-    await screen.findByRole("heading", { name: "日志查询" });
-    fireEvent.click(screen.getByRole("button", { name: "执行查询" }));
+    await screen.findByRole("heading", { name: "Log query" });
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
     expect(await screen.findByText("GetTableRepo")).toBeInTheDocument();
 
     fireEvent.click(screen.getByText("GetTableRepo"));
-    expect(screen.getAllByTitle("用 msg 进行 AI 分析").length).toBeGreaterThan(0);
-    expect(screen.getAllByTitle("用 tid 进行 AI 分析").length).toBeGreaterThan(0);
-    fireEvent.click(screen.getAllByTitle("用 msg 进行 AI 分析")[0]);
+    expect(screen.getAllByRole("button", { name: "Correlate logs by msg" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: "Correlate logs by tid" }).length).toBeGreaterThan(0);
+    fireEvent.click(screen.getAllByRole("button", { name: "Correlate logs by msg" })[0]);
 
-    expect(await screen.findByRole("dialog", { name: "链路查询" })).toBeInTheDocument();
-    expect(screen.getByText("锚点字段")).toBeInTheDocument();
+    expect(await screen.findByRole("dialog", { name: "Correlate logs" })).toBeInTheDocument();
+    expect(screen.getByText("Field")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Time window: ±5 minutes" })).toBeInTheDocument();
     fireEvent.click(screen.getByLabelText("default.app_logs"));
-    fireEvent.click(screen.getByRole("button", { name: "打开链路查询" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open correlation" }));
 
     expect(openSpy).toHaveBeenCalledWith(expect.stringContaining("/clickvisual/v2/query/link?"), "_blank");
     const openedUrl = openSpy.mock.calls[0][0] as string;
@@ -1571,20 +3151,20 @@ describe("query page", () => {
       </TimeRangeProvider>
     );
 
-    expect(await screen.findByRole("heading", { name: "日志查询" })).toBeInTheDocument();
-    expect(await screen.findByRole("tree", { name: "实例、数据库与日志表" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Log query" })).toBeInTheDocument();
+    expect(await openDatasourcePanel()).toBeInTheDocument();
     expect(screen.getByRole("treeitem", { name: "生产 ClickHouse" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "数据库 default" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "数据库 archive" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Database default" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Database archive" })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "数据库 archive" }));
+    fireEvent.click(screen.getByRole("button", { name: "Database archive" }));
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "日志表 audit_logs" })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "日志表 daily_backup" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Table audit_logs" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Table daily_backup" })).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "日志表 daily_backup" }));
+    fireEvent.click(screen.getByRole("button", { name: "Table daily_backup" }));
     expect(screen.getAllByText("daily_backup").length).toBeGreaterThan(0);
 
     await waitFor(() => {
@@ -1851,21 +3431,21 @@ describe("query page", () => {
       </TimeRangeProvider>
     );
 
-    await screen.findByRole("tree", { name: "实例、数据库与日志表" });
+    await openDatasourcePanel();
     const instanceButton = screen.getByRole("button", { name: "生产 ClickHouse" });
 
     fireEvent.contextMenu(instanceButton, { clientX: 120, clientY: 80 });
-    await screen.findByRole("menu", { name: "实例操作" });
+    await screen.findByRole("menu", { name: "Instance actions" });
     await waitFor(() => {
-      expect(screen.getByRole("menu", { name: "实例操作" })).toBeInTheDocument();
+      expect(screen.getByRole("menu", { name: "Instance actions" })).toBeInTheDocument();
     });
     fireEvent.mouseDown(document.body);
     await waitFor(() => {
-      expect(screen.queryByRole("menu", { name: "实例操作" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("menu", { name: "Instance actions" })).not.toBeInTheDocument();
     });
 
     fireEvent.contextMenu(instanceButton, { clientX: 120, clientY: 80 });
-    fireEvent.click(await screen.findByRole("menuitem", { name: "新增数据库" }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "New database" }));
     await screen.findByRole("dialog", { name: "新增数据库" });
     fireEvent.change(screen.getByLabelText("数据库"), { target: { value: "analytics" } });
     fireEvent.change(screen.getByLabelText("Cluster"), { target: { value: "cluster-main" } });
@@ -1874,13 +3454,13 @@ describe("query page", () => {
 
     await waitFor(() => {
       expect(screen.queryByRole("dialog", { name: "新增数据库" })).not.toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "数据库 analytics" })).toBeInTheDocument();
-      expect(screen.getByText("已定位到 analytics")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Database analytics" })).toBeInTheDocument();
+      expect(screen.getByText("Focused analytics")).toBeInTheDocument();
     });
 
-    fireEvent.contextMenu(screen.getByRole("button", { name: "数据库 analytics" }), { clientX: 140, clientY: 120 });
-    expect(await screen.findByRole("menu", { name: "数据库操作" })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("menuitem", { name: "接入已有日志表" }));
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Database analytics" }), { clientX: 140, clientY: 120 });
+    expect(await screen.findByRole("menu", { name: "Database actions" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Add existing table" }));
 
     await screen.findByRole("dialog", { name: "接入已有日志表" });
     fireEvent.change(screen.getByLabelText("数据库"), { target: { value: "analytics" } });
@@ -1892,13 +3472,13 @@ describe("query page", () => {
 
     await waitFor(() => {
       expect(screen.queryByRole("dialog", { name: "接入已有日志表" })).not.toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "日志表 app_logs" })).toBeInTheDocument();
-      expect(screen.getByText("已接入 analytics.app_logs")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Table app_logs" })).toBeInTheDocument();
+      expect(screen.getByText("Added analytics.app_logs")).toBeInTheDocument();
     });
 
-    fireEvent.contextMenu(screen.getByRole("button", { name: "数据库 analytics" }), { clientX: 140, clientY: 120 });
-    expect(await screen.findByRole("menu", { name: "数据库操作" })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("menuitem", { name: "编辑数据库" }));
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Database analytics" }), { clientX: 140, clientY: 120 });
+    expect(await screen.findByRole("menu", { name: "Database actions" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Edit database" }));
 
     await screen.findByRole("dialog", { name: "编辑数据库" });
     fireEvent.change(screen.getByLabelText("描述"), { target: { value: "edited analytics db" } });
@@ -1906,33 +3486,33 @@ describe("query page", () => {
 
     await waitFor(() => {
       expect(screen.queryByRole("dialog", { name: "编辑数据库" })).not.toBeInTheDocument();
-      expect(screen.getByText("已定位到 analytics")).toBeInTheDocument();
+      expect(screen.getByText("Focused analytics")).toBeInTheDocument();
     });
 
-    fireEvent.contextMenu(screen.getByRole("button", { name: "日志表 app_logs" }), { clientX: 160, clientY: 180 });
-    expect(await screen.findByRole("menu", { name: "日志表操作" })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("menuitem", { name: "删除表" }));
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Table app_logs" }), { clientX: 160, clientY: 180 });
+    expect(await screen.findByRole("menu", { name: "Table actions" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete table" }));
 
-    await screen.findByRole("dialog", { name: "删除表" });
-    fireEvent.click(screen.getByRole("button", { name: "删除" }));
+    await screen.findByRole("dialog", { name: "Delete table" });
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
 
     await waitFor(() => {
-      expect(screen.queryByRole("dialog", { name: "删除表" })).not.toBeInTheDocument();
-      expect(screen.queryByRole("button", { name: "日志表 app_logs" })).not.toBeInTheDocument();
-      expect(screen.getByText("已删除 app_logs")).toBeInTheDocument();
+      expect(screen.queryByRole("dialog", { name: "Delete table" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Table app_logs" })).not.toBeInTheDocument();
+      expect(screen.getByText("Deleted app_logs")).toBeInTheDocument();
     });
 
-    fireEvent.contextMenu(screen.getByRole("button", { name: "数据库 analytics" }), { clientX: 140, clientY: 120 });
-    expect(await screen.findByRole("menu", { name: "数据库操作" })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("menuitem", { name: "删除数据库" }));
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Database analytics" }), { clientX: 140, clientY: 120 });
+    expect(await screen.findByRole("menu", { name: "Database actions" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete database" }));
 
-    await screen.findByRole("dialog", { name: "删除数据库" });
-    fireEvent.click(screen.getByRole("button", { name: "删除" }));
+    await screen.findByRole("dialog", { name: "Delete database" });
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
 
     await waitFor(() => {
-      expect(screen.queryByRole("dialog", { name: "删除数据库" })).not.toBeInTheDocument();
-      expect(screen.queryByRole("button", { name: "数据库 analytics" })).not.toBeInTheDocument();
-      expect(screen.getByText("已删除 analytics")).toBeInTheDocument();
+      expect(screen.queryByRole("dialog", { name: "Delete database" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Database analytics" })).not.toBeInTheDocument();
+      expect(screen.getByText("Deleted analytics")).toBeInTheDocument();
     });
 
     expect(
@@ -1956,7 +3536,7 @@ describe("query page", () => {
     expect(requests.some((item) => item.method === "DELETE" && item.path.endsWith("/api/v1/databases/13"))).toBe(true);
   });
 
-  it("runs the first table with the recent 15 minute range on page entry", async () => {
+  it("runs the first table with an absolute 15 minute window on page entry", async () => {
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(new Date("2026-04-21T09:30:00").getTime());
 
     const requestPaths: string[] = [];
@@ -2046,10 +3626,32 @@ describe("query page", () => {
         </TimeRangeProvider>
       );
 
-      await screen.findByRole("tree", { name: "实例、数据库与日志表" });
-      expect(screen.getByRole("button", { name: "时间范围 Last 15 minutes" })).toBeInTheDocument();
+      await waitForQueryPageReady();
+      expect(screen.getByRole("button", { name: "Time range: 04/21 09:15 - 09:30" })).toBeInTheDocument();
 
-      await screen.findByText("共 1 条结果");
+      expect((await screen.findAllByText("1 row")).length).toBeGreaterThan(0);
+      const resultSummary = document.querySelector(".cv-query-result-bar__summary");
+      expect(resultSummary).toHaveTextContent("1 row");
+      expect(resultSummary).not.toHaveTextContent("1 - 1");
+
+      act(() => {
+        fireEvent.click(screen.getByRole("button", { name: "Time range: 04/21 09:15 - 09:30" }));
+      });
+      expect(screen.queryByText(/Relative time/i)).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Last 15 minutes" })).not.toBeInTheDocument();
+      const presetRow = screen.getByLabelText("Absolute time shortcuts");
+      expect(presetRow).toContainElement(screen.getByRole("button", { name: "Today" }));
+      expect(presetRow).toContainElement(screen.getByRole("button", { name: "Apply 15 minute absolute span" }));
+      expect(document.querySelector(".cv-query-time-absolute-separator")).not.toBeInTheDocument();
+      act(() => {
+        fireEvent.click(screen.getByLabelText("Absolute start time"));
+      });
+      expect(screen.queryByRole("button", { name: "Start" })).not.toBeInTheDocument();
+      expect(screen.getByLabelText("Absolute start time field")).toHaveClass("cv-query-time-absolute-field--active");
+      act(() => {
+        fireEvent.click(screen.getByLabelText("Absolute end time field"));
+      });
+      expect(screen.getByLabelText("Absolute end time field")).toHaveClass("cv-query-time-absolute-field--active");
 
       expect(
         requestPaths.some(
@@ -2059,6 +3661,7 @@ describe("query page", () => {
             item.includes(`et=${expectedEnd}`)
         )
       ).toBe(true);
+      expect(window.location.search).not.toContain("tab=relative");
     } finally {
       nowSpy.mockRestore();
     }

--- a/ui-v2/tests/setup.ts
+++ b/ui-v2/tests/setup.ts
@@ -5,6 +5,19 @@ import {
   reportResultMockById
 } from "../src/domains/report/mocks/reportMockData";
 
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const originalElementQuerySelector = Element.prototype.querySelector;
+const originalElementQuerySelectorAll = Element.prototype.querySelectorAll;
+
+function isUnsupportedBrowserPseudoSelector(error: unknown, selector: string) {
+  return error instanceof DOMException && selector.includes(":autofill");
+}
+
 beforeEach(() => {
   const queryFilterProfiles: Array<Record<string, unknown>> = [];
 
@@ -21,6 +34,37 @@ beforeEach(() => {
       dispatchEvent: vi.fn()
     }))
   });
+  Object.defineProperty(window, "ResizeObserver", {
+    configurable: true,
+    writable: true,
+    value: TestResizeObserver
+  });
+  vi.stubGlobal("ResizeObserver", TestResizeObserver);
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn();
+  }
+  window.scroll = vi.fn();
+  window.scrollTo = vi.fn();
+  Element.prototype.querySelector = function querySelector(selector: string) {
+    try {
+      return originalElementQuerySelector.call(this, selector);
+    } catch (error) {
+      if (isUnsupportedBrowserPseudoSelector(error, selector)) {
+        return null;
+      }
+      throw error;
+    }
+  };
+  Element.prototype.querySelectorAll = function querySelectorAll(selector: string) {
+    try {
+      return originalElementQuerySelectorAll.call(this, selector);
+    } catch (error) {
+      if (isUnsupportedBrowserPseudoSelector(error, selector)) {
+        return document.createDocumentFragment().querySelectorAll("*");
+      }
+      throw error;
+    }
+  };
   Object.defineProperty(navigator, "clipboard", {
     configurable: true,
     value: {
@@ -481,6 +525,31 @@ beforeEach(() => {
                     request_id: "req-1001"
                   }
                 ]
+              }
+            })
+        };
+      }
+
+      if (method === "POST" && url.pathname.endsWith("/api/v2/query/field-stats")) {
+        return {
+          ok: true,
+          text: async () =>
+            JSON.stringify({
+              code: 0,
+              msg: "succ",
+              data: {
+                total: 10,
+                items: [
+                  { value: "ERROR", count: 6, percentage: 60 },
+                  { value: "INFO", count: 4, percentage: 40 }
+                ],
+                sql: "SELECT `level`, count() FROM `default`.`logs` GROUP BY `level`",
+                plan: {
+                  table: "`default`.`logs`",
+                  plannedConditions: [],
+                  warnings: [],
+                  orderBy: []
+                }
               }
             })
         };


### PR DESCRIPTION
Squash of Jack's latest 8 commits from the shimo clickvisual repo:
- feat(theme): 橙色主题
- fix(query): 修复 Top Values 查询取消与 lv 条件性能问题
- feat(query): 增加字段占比弹窗
- fix(query): 修复 top values 无法应用当前条件问题
- fix(query): 优化日志刷新与条件样式
- fix(query): 优化日志查询与分享链接体验
- feat(query): 优化日志查询页面交互体验
- fix(log): TECHNOLOGY-3820 修复 private-lite 无法精确查询 && 去掉 Google Fonts 依赖

Note: clickhouse.go retry logic was merged (kept the target's 10-retry loop, made it context-aware). ui-v2/package-lock.json omitted as it is gitignored in this repo.