### PR TITLE
feat(header): link Shimo icon to ShimoDocs

### DIFF
--- a/ui/src/components/RightContent/index.tsx
+++ b/ui/src/components/RightContent/index.tsx
@@ -40,12 +40,21 @@ const RightContent: React.FC = () => {
             前往 v2
         </Button>
         </Tooltip>
-        <Tooltip placement="bottom" title={"Shimo"}>
-        <Button type="link">
-            <a href="https://shimo.im/welcome" target="_blank">
+        <Tooltip
+          placement="bottom"
+          title={
+            "我们团队最新推出了石墨文档私有化版本5人永久免费版 @ShimoDocs，欢迎了解！"
+          }
+        >
+          <Button
+            type="link"
+            href="https://github.com/shimodocs/shimodocs"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="我们团队最新推出了石墨文档私有化版本5人永久免费版 @ShimoDocs，欢迎了解！"
+          >
             <IconFont type={"icon-shimo"} />
-            </a>
-        </Button>
+          </Button>
         </Tooltip>
         <Tooltip placement="bottom" title={"Github"}>
         <Button type="link">

--- a/ui/tests/shimodocs-header-link.test.mjs
+++ b/ui/tests/shimodocs-header-link.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(
+  new URL("../src/components/RightContent/index.tsx", import.meta.url),
+  "utf8"
+);
+
+const shimoDocsSubtree = source.match(
+  /<Tooltip\s+placement="bottom"\s+title=\{\s*"我们团队最新推出了石墨文档私有化版本5人永久免费版 @ShimoDocs，欢迎了解！"\s*\}\s*>[\s\S]*?<Button\b[\s\S]*?<\/Button>[\s\S]*?<\/Tooltip>/
+)?.[0];
+
+assert.ok(shimoDocsSubtree, "ShimoDocs Tooltip/Button subtree should exist");
+const shimoDocsButton = shimoDocsSubtree.match(/<Button\b[\s\S]*?>/)?.[0];
+
+assert.ok(shimoDocsButton, "ShimoDocs Button opening tag should exist");
+assert.match(
+  shimoDocsSubtree,
+  /title=\{\s*"我们团队最新推出了石墨文档私有化版本5人永久免费版 @ShimoDocs，欢迎了解！"\s*\}/
+);
+assert.match(
+  shimoDocsButton,
+  /href="https:\/\/github\.com\/shimodocs\/shimodocs"/
+);
+assert.match(shimoDocsButton, /target="_blank"/);
+assert.match(shimoDocsButton, /rel="noopener noreferrer"/);
+assert.match(
+  shimoDocsButton,
+  /aria-label="我们团队最新推出了石墨文档私有化版本5人永久免费版 @ShimoDocs，欢迎了解！"/
+);
+assert.match(shimoDocsSubtree, /icon-shimo/);
+assert.doesNotMatch(shimoDocsSubtree, /<a\b/);
+assert.ok(!source.includes("https://shimo.im/welcome"));
+
+console.log("ShimoDocs header link checks passed");


### PR DESCRIPTION
## Summary
- point the existing v1 Header Shimo icon to the ShimoDocs private-edition GitHub repository
- show the full private-edition introduction in the tooltip and accessible label
- keep the existing icon and layout while using a single secure external-link element
- add a contract test for the tooltip, URL, accessibility attributes, and removal of the legacy Shimo URL

## Verification
- `node --test ui/tests/shimodocs-header-link.test.mjs`
- `cd ui && npx prettier --check tests/shimodocs-header-link.test.mjs`
- `cd ui && yarn build`
- `git diff --check origin/master...HEAD`
- final spec, quality, and branch reviews: Critical 0 / Important 0 / Minor 0

## Known repository tooling baseline
- `npx eslint src/components/RightContent/index.tsx` cannot discover an ESLint configuration on clean `origin/master`
- `yarn tsc` reports existing cross-project TypeScript errors on clean `origin/master`; this change adds no new TypeScript diagnostics

## Manual smoke
- Pending: hover the existing Shimo icon in the v1 Header and click through to `https://github.com/shimodocs/shimodocs`