### PR TITLE
feat(header): add ShimoDocs link and simplify version switcher

### DIFF
--- a/ui-v2/src/shared/layout/AppShell.tsx
+++ b/ui-v2/src/shared/layout/AppShell.tsx
@@ -1,8 +1,13 @@
 import { NavLink, useLocation } from "react-router-dom";
+import { EuiToolTip } from "@elastic/eui";
 import type { ReactNode } from "react";
 import { TimeRangeProvider } from "../state/TimeRangeContext";
 import { isPrivateLiteEdition } from "../config/runtime";
 import VersionSwitcher from "./VersionSwitcher";
+
+const SHIMODOCS_URL = "https://github.com/shimodocs/shimodocs";
+const SHIMODOCS_TOOLTIP =
+  "我们团队最新推出的石墨文档私有化版本5人永久免费版 @ShimoDocs，欢迎了解！";
 
 const primaryNavigation = [
   { to: "/v2/overview", label: "总览大盘", icon: "◫" },
@@ -11,10 +16,12 @@ const primaryNavigation = [
   { to: "/v2/reports", label: "数据报表", icon: "◌" },
   { to: "/v2/alerts/rules", label: "告警中心", icon: "!" },
   { to: "/v2/settings/datasource", label: "配置中心", icon: "⋯" },
-  { to: "/v2/permission/users", label: "权限中心", icon: "⌥" }
+  { to: "/v2/permission/users", label: "权限中心", icon: "⌥" },
 ] as const;
 
-const privateLiteNavigation = primaryNavigation.filter((item) => item.to === "/v2/query");
+const privateLiteNavigation = primaryNavigation.filter(
+  (item) => item.to === "/v2/query",
+);
 
 function isNavigationActive(pathname: string, to: string) {
   if (to.startsWith("/v2/settings")) {
@@ -28,7 +35,9 @@ function isNavigationActive(pathname: string, to: string) {
 
 function ShellFrame({ children }: { children: ReactNode }) {
   const location = useLocation();
-  const navigation = isPrivateLiteEdition() ? privateLiteNavigation : primaryNavigation;
+  const navigation = isPrivateLiteEdition()
+    ? privateLiteNavigation
+    : primaryNavigation;
   return (
     <div className="cv-shell">
       <header className="cv-shell__topbar" data-testid="app-shell-topbar">
@@ -43,7 +52,11 @@ function ShellFrame({ children }: { children: ReactNode }) {
             </div>
           </div>
 
-          <nav aria-label="v2 主导航" className="cv-shell__nav" data-testid="app-shell-nav">
+          <nav
+            aria-label="v2 主导航"
+            className="cv-shell__nav"
+            data-testid="app-shell-nav"
+          >
             {navigation.map((item) => (
               <NavLink
                 key={item.to}
@@ -65,6 +78,20 @@ function ShellFrame({ children }: { children: ReactNode }) {
               <span className="cv-dot" aria-hidden="true" />
               v2
             </div>
+            <EuiToolTip content={SHIMODOCS_TOOLTIP} position="bottom">
+              <a
+                className="cv-shell__partner-link"
+                href={SHIMODOCS_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={SHIMODOCS_TOOLTIP}
+              >
+                <span className="cv-shell__partner-mark" aria-hidden="true">
+                  S
+                </span>
+                <span className="cv-shell__partner-label">ShimoDocs</span>
+              </a>
+            </EuiToolTip>
             <VersionSwitcher />
           </div>
         </div>

--- a/ui-v2/src/shared/layout/VersionSwitcher.tsx
+++ b/ui-v2/src/shared/layout/VersionSwitcher.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 export const VERSION_STORAGE_KEY = "clickvisual-preferred-ui-version";
 
@@ -31,15 +31,18 @@ export function normalizePublicPath(value?: string) {
 
 export function getConfiguredPublicPath() {
   return normalizePublicPath(
-    typeof __CLICKVISUAL_PUBLIC_PATH__ === "string" ? __CLICKVISUAL_PUBLIC_PATH__ : ""
+    typeof __CLICKVISUAL_PUBLIC_PATH__ === "string"
+      ? __CLICKVISUAL_PUBLIC_PATH__
+      : "",
   );
 }
 
 export function getPublicPathLoginRedirectHref(
   pathname?: string,
-  configuredPublicPath = getConfiguredPublicPath()
+  configuredPublicPath = getConfiguredPublicPath(),
 ) {
-  const normalizedConfiguredPublicPath = normalizePublicPath(configuredPublicPath);
+  const normalizedConfiguredPublicPath =
+    normalizePublicPath(configuredPublicPath);
   if (!normalizedConfiguredPublicPath || typeof window === "undefined") {
     return "";
   }
@@ -53,8 +56,12 @@ export function getPublicPathLoginRedirectHref(
   return `${normalizedConfiguredPublicPath}/v2/login`;
 }
 
-export function getV2BasePath(pathname?: string, configuredPublicPath = getConfiguredPublicPath()) {
-  const normalizedConfiguredPublicPath = normalizePublicPath(configuredPublicPath);
+export function getV2BasePath(
+  pathname?: string,
+  configuredPublicPath = getConfiguredPublicPath(),
+) {
+  const normalizedConfiguredPublicPath =
+    normalizePublicPath(configuredPublicPath);
   if (normalizedConfiguredPublicPath) {
     return normalizedConfiguredPublicPath;
   }
@@ -77,7 +84,10 @@ export function getV1Href(pathname?: string, configuredPublicPath?: string) {
 }
 
 export function getV2Href(pathname?: string, configuredPublicPath?: string) {
-  const basePath = getV2BasePath(pathname, configuredPublicPath) || pathname?.replace(/\/query\/?$/, "") || "";
+  const basePath =
+    getV2BasePath(pathname, configuredPublicPath) ||
+    pathname?.replace(/\/query\/?$/, "") ||
+    "";
   return `${basePath}/v2/query`;
 }
 
@@ -85,7 +95,7 @@ export function buildV2RouteHref(
   routePath: string,
   searchParams?: URLSearchParams,
   pathname?: string,
-  configuredPublicPath?: string
+  configuredPublicPath?: string,
 ) {
   const normalizedRoutePath = routePath.replace(/^\/+/, "");
   const query = searchParams?.toString();
@@ -95,15 +105,13 @@ export function buildV2RouteHref(
 export function buildShareRouteHref(
   searchParams?: URLSearchParams,
   pathname?: string,
-  configuredPublicPath?: string
+  configuredPublicPath?: string,
 ) {
   const query = searchParams?.toString();
   return `${getV2BasePath(pathname, configuredPublicPath)}/share${query ? `?${query}` : ""}`;
 }
 
 export default function VersionSwitcher() {
-  const [lastPreferredVersion] = useState(getPreferredUiVersion);
-
   useEffect(() => {
     setPreferredUiVersion("v2");
   }, []);
@@ -116,15 +124,17 @@ export default function VersionSwitcher() {
     }
   };
 
-  const switchLabel =
-    lastPreferredVersion === "v1" ? "返回上次使用的 v1" : "前往 v1";
-
   return (
     <div className="cv-version-switcher" data-testid="shell-version-switcher">
-      <span className="cv-version-switcher__label">当前版本：v2</span>
-      <a className="cv-version-switcher__link" href={getV1Href()} onClick={handleSwitch}>
+      <a
+        className="cv-version-switcher__link"
+        href={getV1Href()}
+        onClick={handleSwitch}
+        title="切换到 v1"
+        aria-label="切换到 v1"
+      >
         <span aria-hidden="true">↗</span>
-        {switchLabel}
+        v1
       </a>
     </div>
   );

--- a/ui-v2/src/styles.css
+++ b/ui-v2/src/styles.css
@@ -223,6 +223,38 @@ textarea {
   box-shadow: inset 0 0 0 1px var(--cv-border);
 }
 
+.cv-shell__partner-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 24px;
+  padding: 0 7px;
+  border-radius: 999px;
+  color: var(--cv-text-soft);
+  font-size: 11px;
+  font-weight: 700;
+  text-decoration: none;
+  transition: color 160ms ease, background-color 160ms ease;
+}
+
+.cv-shell__partner-link:hover {
+  color: var(--cv-primary-strong);
+  background: var(--cv-primary-soft);
+}
+
+.cv-shell__partner-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  color: #fff;
+  background: var(--cv-primary);
+  font-size: 10px;
+  line-height: 1;
+}
+
 .cv-shell__workspace {
   padding: 0;
 }

--- a/ui-v2/tests/app-shell-layout.test.tsx
+++ b/ui-v2/tests/app-shell-layout.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { RouterProvider, createMemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { routes } from "../src/app/router";
@@ -11,27 +11,67 @@ describe("v2 app shell", () => {
 
   it("renders real module navigation entries", async () => {
     const memoryRouter = createMemoryRouter(routes, {
-      initialEntries: ["/v2/overview"]
+      initialEntries: ["/v2/overview"],
     });
 
     render(<RouterProvider router={memoryRouter} />);
 
     expect(
-      screen.getByRole("navigation", { name: "v2 主导航" })
+      screen.getByRole("navigation", { name: "v2 主导航" }),
     ).toBeInTheDocument();
     expect(screen.getByTestId("app-shell-nav")).toHaveClass("cv-shell__nav");
-    expect(screen.getByTestId("app-shell-topbar")).toHaveClass("cv-shell__topbar");
+    expect(screen.getByTestId("app-shell-topbar")).toHaveClass(
+      "cv-shell__topbar",
+    );
     expect(screen.getByText("ClickVisual")).toBeInTheDocument();
     await screen.findByRole("heading", { name: "总览大盘" });
 
     const overviewLink = screen.getByRole("link", { name: "总览大盘" });
     expect(overviewLink).toHaveAttribute("aria-current", "page");
     expect(overviewLink.className).toContain("cv-shell__nav-link--active");
-    expect(screen.getByRole("link", { name: "日志查询" })).toHaveAttribute("href", "/v2/query");
-    expect(screen.getByRole("link", { name: "定时报表" })).toHaveAttribute("href", "/v2/reports");
-    expect(screen.getByRole("link", { name: "告警中心" })).toHaveAttribute("href", "/v2/alerts/rules");
-    expect(screen.getByRole("link", { name: "配置中心" })).toHaveAttribute("href", "/v2/settings/datasource");
-    expect(screen.getByRole("link", { name: "权限中心" })).toHaveAttribute("href", "/v2/permission/users");
+    expect(screen.getByRole("link", { name: "日志查询" })).toHaveAttribute(
+      "href",
+      "/v2/query",
+    );
+    expect(screen.getByRole("link", { name: "定时报表" })).toHaveAttribute(
+      "href",
+      "/v2/reports",
+    );
+    expect(screen.getByRole("link", { name: "告警中心" })).toHaveAttribute(
+      "href",
+      "/v2/alerts/rules",
+    );
+    expect(screen.getByRole("link", { name: "配置中心" })).toHaveAttribute(
+      "href",
+      "/v2/settings/datasource",
+    );
+    expect(screen.getByRole("link", { name: "权限中心" })).toHaveAttribute(
+      "href",
+      "/v2/permission/users",
+    );
     expect(screen.getByTestId("shell-version-switcher")).toBeInTheDocument();
+  });
+
+  it("shows the ShimoDocs tooltip on hover", async () => {
+    const memoryRouter = createMemoryRouter(routes, {
+      initialEntries: ["/v2/overview"],
+    });
+
+    render(<RouterProvider router={memoryRouter} />);
+
+    const shimoDocsLink = screen.getByRole("link", {
+      name: "我们团队最新推出的石墨文档私有化版本5人永久免费版 @ShimoDocs，欢迎了解！",
+    });
+    expect(shimoDocsLink).toHaveAttribute(
+      "href",
+      "https://github.com/shimodocs/shimodocs",
+    );
+    expect(shimoDocsLink).toHaveAttribute("target", "_blank");
+    expect(shimoDocsLink).toHaveAttribute("rel", "noopener noreferrer");
+
+    fireEvent.mouseOver(shimoDocsLink);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "我们团队最新推出的石墨文档私有化版本5人永久免费版 @ShimoDocs，欢迎了解！",
+    );
   });
 });

--- a/ui-v2/tests/version-switcher.test.tsx
+++ b/ui-v2/tests/version-switcher.test.tsx
@@ -11,7 +11,7 @@ import {
   getPreferredUiVersion,
   getPublicPathLoginRedirectHref,
   normalizePublicPath,
-  setPreferredUiVersion
+  setPreferredUiVersion,
 } from "../src/shared/layout/VersionSwitcher";
 
 const VERSION_STORAGE_KEY = "clickvisual-preferred-ui-version";
@@ -34,12 +34,18 @@ describe("v2 version switcher", () => {
     expect(getV1Href("/v2/reports")).toBe("/query?ui=v1");
     expect(getV2Href("/console/query")).toBe("/console/v2/query");
     expect(getV2Href("/query")).toBe("/v2/query");
-    expect(buildShareRouteHref(undefined, "/console/v2/query")).toBe("/console/share");
-    expect(buildShareRouteHref(undefined, "/console/share")).toBe("/console/share");
-    expect(buildShareRouteHref(new URLSearchParams("tid=1"), "/v2/query")).toBe("/share?tid=1");
+    expect(buildShareRouteHref(undefined, "/console/v2/query")).toBe(
+      "/console/share",
+    );
+    expect(buildShareRouteHref(undefined, "/console/share")).toBe(
+      "/console/share",
+    );
+    expect(buildShareRouteHref(new URLSearchParams("tid=1"), "/v2/query")).toBe(
+      "/share?tid=1",
+    );
     const params = new URLSearchParams({ field: "tid", value: "abc" });
     expect(buildV2RouteHref("query/link", params, "/console/v2/query")).toBe(
-      "/console/v2/query/link?field=tid&value=abc"
+      "/console/v2/query/link?field=tid&value=abc",
     );
   });
 
@@ -47,42 +53,52 @@ describe("v2 version switcher", () => {
     const params = new URLSearchParams({ field: "level", value: "30" });
 
     expect(normalizePublicPath("/mdp/clickvisual/")).toBe("/mdp/clickvisual");
-    expect(normalizePublicPath("https://mdp.shimodev.com/clickvisual/")).toBe("/clickvisual");
-    expect(getV2BasePath("/v2/query", "/mdp/clickvisual/")).toBe("/mdp/clickvisual");
-    expect(getV1Href("/v2/query", "/mdp/clickvisual/")).toBe("/mdp/clickvisual/query?ui=v1");
+    expect(normalizePublicPath("https://mdp.shimodev.com/clickvisual/")).toBe(
+      "/clickvisual",
+    );
+    expect(getV2BasePath("/v2/query", "/mdp/clickvisual/")).toBe(
+      "/mdp/clickvisual",
+    );
+    expect(getV1Href("/v2/query", "/mdp/clickvisual/")).toBe(
+      "/mdp/clickvisual/query?ui=v1",
+    );
     expect(buildShareRouteHref(params, "/v2/query", "/mdp/clickvisual/")).toBe(
-      "/mdp/clickvisual/share?field=level&value=30"
+      "/mdp/clickvisual/share?field=level&value=30",
     );
-    expect(buildV2RouteHref("query/link", params, "/v2/query", "/mdp/clickvisual/")).toBe(
-      "/mdp/clickvisual/v2/query/link?field=level&value=30"
-    );
+    expect(
+      buildV2RouteHref("query/link", params, "/v2/query", "/mdp/clickvisual/"),
+    ).toBe("/mdp/clickvisual/v2/query/link?field=level&value=30");
   });
 
   it("redirects into the configured public path before rendering", () => {
     expect(getPublicPathLoginRedirectHref("/v2", "/clickvisual/")).toBe(
-      "/clickvisual/v2/login"
+      "/clickvisual/v2/login",
     );
     expect(getPublicPathLoginRedirectHref("/v2/query", "/clickvisual/")).toBe(
-      "/clickvisual/v2/login"
+      "/clickvisual/v2/login",
     );
-    expect(getPublicPathLoginRedirectHref("/clickvisual/v2", "/clickvisual/")).toBe("");
-    expect(getPublicPathLoginRedirectHref("/clickvisual/v2/login", "/clickvisual/")).toBe("");
-    expect(getPublicPathLoginRedirectHref("/clickvisual-other/v2", "/clickvisual/")).toBe(
-      "/clickvisual/v2/login"
-    );
+    expect(
+      getPublicPathLoginRedirectHref("/clickvisual/v2", "/clickvisual/"),
+    ).toBe("");
+    expect(
+      getPublicPathLoginRedirectHref("/clickvisual/v2/login", "/clickvisual/"),
+    ).toBe("");
+    expect(
+      getPublicPathLoginRedirectHref("/clickvisual-other/v2", "/clickvisual/"),
+    ).toBe("/clickvisual/v2/login");
   });
 
   it("records v2 as preferred version on the report page", async () => {
     window.localStorage.clear();
 
     const memoryRouter = createMemoryRouter(routes, {
-      initialEntries: ["/v2/reports/1001"]
+      initialEntries: ["/v2/reports/1001"],
     });
 
     render(<RouterProvider router={memoryRouter} />);
 
     expect(
-      screen.getByRole("heading", { name: "定时报表" })
+      screen.getByRole("heading", { name: "定时报表" }),
     ).toBeInTheDocument();
     await screen.findByRole("list", { name: "报表任务列表" });
     expect(window.localStorage.getItem(VERSION_STORAGE_KEY)).toBe("v2");
@@ -92,7 +108,7 @@ describe("v2 version switcher", () => {
     window.localStorage.clear();
 
     const memoryRouter = createMemoryRouter(routes, {
-      initialEntries: ["/v2"]
+      initialEntries: ["/v2"],
     });
 
     render(<RouterProvider router={memoryRouter} />);
@@ -105,19 +121,16 @@ describe("v2 version switcher", () => {
     window.localStorage.setItem(VERSION_STORAGE_KEY, "v1");
 
     const memoryRouter = createMemoryRouter(routes, {
-      initialEntries: ["/v2/reports/1001"]
+      initialEntries: ["/v2/reports/1001"],
     });
 
     render(<RouterProvider router={memoryRouter} />);
 
     await screen.findByRole("list", { name: "报表任务列表" });
 
-    const link = screen.getByRole("link", { name: "返回上次使用的 v1" });
+    const link = screen.getByRole("link", { name: "切换到 v1" });
 
-    expect(link).toHaveAttribute(
-      "href",
-      "/query?ui=v1"
-    );
+    expect(link).toHaveAttribute("href", "/query?ui=v1");
     fireEvent.click(link);
     expect(window.localStorage.getItem(VERSION_STORAGE_KEY)).toBe("v1");
   });
@@ -127,14 +140,14 @@ describe("v2 version switcher", () => {
     window.history.pushState({}, "", "/console/v2/reports/1001");
 
     const memoryRouter = createMemoryRouter(routes, {
-      initialEntries: ["/v2/reports/1001"]
+      initialEntries: ["/v2/reports/1001"],
     });
 
     render(<RouterProvider router={memoryRouter} />);
 
     await screen.findByRole("list", { name: "报表任务列表" });
 
-    const link = screen.getByRole("link", { name: "返回上次使用的 v1" });
+    const link = screen.getByRole("link", { name: "切换到 v1" });
 
     expect(link).toHaveAttribute("href", "/console/query?ui=v1");
 
@@ -148,14 +161,14 @@ describe("v2 version switcher", () => {
     window.history.pushState({}, "", "/console/v2/query");
 
     const memoryRouter = createMemoryRouter(routes, {
-      initialEntries: ["/v2/query"]
+      initialEntries: ["/v2/query"],
     });
 
     render(<RouterProvider router={memoryRouter} />);
 
     await screen.findByRole("heading", { name: "日志查询" });
 
-    const link = screen.getByRole("link", { name: "返回上次使用的 v1" });
+    const link = screen.getByRole("link", { name: "切换到 v1" });
     expect(link).toHaveAttribute("href", "/console/query?ui=v1");
   });
 });

--- a/ui/src/components/RightContent/index.tsx
+++ b/ui/src/components/RightContent/index.tsx
@@ -1,6 +1,6 @@
-import {Button, Space, Tooltip} from "antd";
+import { Button, Space, Tooltip } from "antd";
 import React from "react";
-import {SelectLang, useModel} from "umi";
+import { SelectLang, useModel } from "umi";
 import Avatar from "./AvatarDropdown";
 import styles from "./index.less";
 import IconFont from "@/components/IconFont";
@@ -35,35 +35,35 @@ const RightContent: React.FC = () => {
   return (
     <Space className={className}>
       <Avatar />
-        <Tooltip placement="bottom" title={"V2"}>
+      <Tooltip placement="bottom" title={"切换到 v2"}>
         <Button type="link" href={getV2Href()} onClick={handleSwitchToV2}>
-            前往 v2
+          v2
         </Button>
-        </Tooltip>
-        <Tooltip
-          placement="bottom"
-          title={
-            "我们团队最新推出了石墨文档私有化版本5人永久免费版 @ShimoDocs，欢迎了解！"
-          }
+      </Tooltip>
+      <Tooltip
+        placement="bottom"
+        title={
+          "我们团队最新推出了石墨文档私有化版本5人永久免费版 @ShimoDocs，欢迎了解！"
+        }
+      >
+        <Button
+          type="link"
+          href="https://github.com/shimodocs/shimodocs"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="我们团队最新推出了石墨文档私有化版本5人永久免费版 @ShimoDocs，欢迎了解！"
         >
-          <Button
-            type="link"
-            href="https://github.com/shimodocs/shimodocs"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="我们团队最新推出了石墨文档私有化版本5人永久免费版 @ShimoDocs，欢迎了解！"
-          >
-            <IconFont type={"icon-shimo"} />
-          </Button>
-        </Tooltip>
-        <Tooltip placement="bottom" title={"Github"}>
-        <Button type="link">
-            <a href="https://github.com/clickvisual/clickvisual" target="_blank">
-            <IconFont type={"icon-github"} />
-            </a>
+          <IconFont type={"icon-shimo"} />
         </Button>
-        </Tooltip>
-        <SelectLang className={styles.action} reload={false} />
+      </Tooltip>
+      <Tooltip placement="bottom" title={"Github"}>
+        <Button type="link">
+          <a href="https://github.com/clickvisual/clickvisual" target="_blank">
+            <IconFont type={"icon-github"} />
+          </a>
+        </Button>
+      </Tooltip>
+      <SelectLang className={styles.action} reload={false} />
     </Space>
   );
 };


### PR DESCRIPTION
## 变更内容

- 在 v2 Header 增加 ShimoDocs 友链，点击后新窗口打开 GitHub。
- 使用 EUI Tooltip 修复 ShimoDocs 悬浮提示不显示的问题。
- 将 v1/v2 版本切换入口压缩为简短的 v1/v2 标识。
- 增加 Tooltip hover 回归测试。

## 验证

- `npm run build` 通过。
- staged-state build verification 通过。
- Tooltip Vitest 回归测试通过。
- Playwright 真实浏览器悬浮验证通过。
- 现有测试仍有与本次改动无关的基线断言失败：`定时报表` 文案和 `日志查询` heading。