### PR TITLE
ci(docker): publish master development images

### DIFF
--- a/.github/workflows/publish-docker-dev.yml
+++ b/.github/workflows/publish-docker-dev.yml
@@ -1,0 +1,54 @@
+name: publish-docker-dev
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: publish-docker-dev-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: clickvisual/clickvisual
+          tags: |
+            type=raw,value=master
+            type=raw,value=edge
+            type=sha,prefix=master-
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: clickvisual
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push development image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GOPROXY=proxy.golang.org


### PR DESCRIPTION
## Summary
- add a dedicated workflow for multi-architecture development images from master
- publish mutable `master` and `edge` tags plus an immutable `master-<sha>` tag
- keep stable image publishing and `latest` tags limited to release workflows

## Verification
- workflow YAML parsed successfully
- `git diff --check` passed
- based on origin/master including PR #1246 Docker lockfile fix