### PR TITLE
fix(docker): correct ui-v2 build output path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY go.mod go.sum ./
 RUN go mod download -x
 COPY . .
 COPY --from=js-builder /clickvisual/ui/dist ./api/internal/ui/dist
-COPY --from=js-builder /clickvisual/ui-v2/api/internal/ui/v2dist/dist ./api/internal/ui/v2dist/dist
+COPY --from=js-builder /clickvisual/api/internal/ui/v2dist/dist ./api/internal/ui/v2dist/dist
 RUN ls -rlt ./api/internal/ui/dist && make build.api
 
 


### PR DESCRIPTION
## Summary
- fix the Docker multi-stage copy path for the ui-v2 build output
- copy from `/clickvisual/api/internal/ui/v2dist/dist`, matching `vite.config.ts`

## Verification
- `npm ci --ignore-scripts` in ui-v2: passed
- `npm run build` in ui-v2: passed
- confirmed `api/internal/ui/v2dist/dist/index.html` is generated
- local Docker build reached base-image resolution but Docker Hub timed out

This fixes the `publish-docker-dev` failure in run 33583831583.