### PR TITLE
fix(ci): resolve obsutil path dynamically

### DIFF
--- a/.github/workflows/docs-apis.yml
+++ b/.github/workflows/docs-apis.yml
@@ -28,11 +28,19 @@ jobs:
           redoc-cli bundle ./api/docs/swagger.json ./api/docs/index.html
           mv redoc-static.html ./api/docs/index.html
       - name: install obsutil
-        run: wget https://obs-community.obs.cn-north-1.myhuaweicloud.com/obsutil/current/obsutil_linux_amd64.tar.gz && tar -zxvf obsutil_linux_amd64.tar.gz && chmod 755 ./obsutil_linux_amd64_5.7.9/obsutil
+        run: |
+          wget https://obs-community.obs.cn-north-1.myhuaweicloud.com/obsutil/current/obsutil_linux_amd64.tar.gz
+          tar -zxvf obsutil_linux_amd64.tar.gz
+          obsutil_bin="$(find "$PWD" -maxdepth 2 -type f -name obsutil -print -quit)"
+          test -n "$obsutil_bin"
+          chmod 755 "$obsutil_bin"
+          echo "OBSUTIL_BIN=$obsutil_bin" >> "$GITHUB_ENV"
       - name: config obsutil
-        run: ./obsutil_linux_amd64_5.7.9/obsutil config -i ${{ secrets.OBS_ACCESS_KEY_ID }} -k ${{ secrets.OBS_ACCESS_KEY_SECRET }} -e https://obs.cn-north-4.myhuaweicloud.com
+        run: |
+          "$OBSUTIL_BIN" config -i "${{ secrets.OBS_ACCESS_KEY_ID }}" -k "${{ secrets.OBS_ACCESS_KEY_SECRET }}" -e https://obs.cn-north-4.myhuaweicloud.com
       - name: upload docs by obsutil
-        run: ./obsutil_linux_amd64_5.7.9/obsutil cp ./api/docs/index.html obs://open-read/clickvisual/api/index.html -f -r
+        run: |
+          "$OBSUTIL_BIN" cp ./api/docs/index.html obs://open-read/clickvisual/api/index.html -f -r
       - name: create commit
         uses: peter-evans/create-pull-request@v6
         with:

--- a/.github/workflows/docs-cv.yml
+++ b/.github/workflows/docs-cv.yml
@@ -15,8 +15,19 @@ jobs:
       - name: Build docs
         run: cd docs && export NODE_OPTIONS=--openssl-legacy-provider && yarn install && yarn run docs:build
       - name: Install obsutil
-        run: cd docs && wget https://obs-community.obs.cn-north-1.myhuaweicloud.com/obsutil/current/obsutil_linux_amd64.tar.gz && tar -zxvf obsutil_linux_amd64.tar.gz && chmod 755 ./obsutil_linux_amd64_5.7.9/obsutil
+        run: |
+          cd docs
+          wget https://obs-community.obs.cn-north-1.myhuaweicloud.com/obsutil/current/obsutil_linux_amd64.tar.gz
+          tar -zxvf obsutil_linux_amd64.tar.gz
+          obsutil_bin="$(find "$PWD" -maxdepth 2 -type f -name obsutil -print -quit)"
+          test -n "$obsutil_bin"
+          chmod 755 "$obsutil_bin"
+          echo "OBSUTIL_BIN=$obsutil_bin" >> "$GITHUB_ENV"
       - name: Config obsutil
-        run: cd docs && ./obsutil_linux_amd64_5.7.9/obsutil config -i ${{ secrets.OBS_ACCESS_KEY_ID }} -k ${{ secrets.OBS_ACCESS_KEY_SECRET }} -e https://obs.cn-north-4.myhuaweicloud.com
+        run: |
+          cd docs
+          "$OBSUTIL_BIN" config -i "${{ secrets.OBS_ACCESS_KEY_ID }}" -k "${{ secrets.OBS_ACCESS_KEY_SECRET }}" -e https://obs.cn-north-4.myhuaweicloud.com
       - name: Upload docs by obsutil
-        run: cd docs && ./obsutil_linux_amd64_5.7.9/obsutil cp ./docs/.vuepress/dist obs://open-read/clickvisual/dist -f -r -flat
+        run: |
+          cd docs
+          "$OBSUTIL_BIN" cp ./docs/.vuepress/dist obs://open-read/clickvisual/dist -f -r -flat


### PR DESCRIPTION
修复 docs-apis 和 docs-cv 工作流因 obsutil 下载目录版本变化导致的构建失败。

- 解压后自动查找 obsutil 可执行文件，不再固定使用 5.7.9 目录；
- 通过 GITHUB_ENV 在配置和上传步骤复用动态路径；
- 已完成 YAML 解析、shell -n 和 git diff --check 验证。

关联失败运行：
- https://github.com/clickvisual/clickvisual/actions/runs/33585352202
- https://github.com/clickvisual/clickvisual/actions/runs/33585352216