### PR TITLE
fix: restore v2 share compatibility and API docs workflow

### DIFF
--- a/.github/workflows/docs-apis.yml
+++ b/.github/workflows/docs-apis.yml
@@ -5,12 +5,16 @@ on:
     branches:
       - 'master'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   updateAPI:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.21.1'
       - run: go version
@@ -42,9 +46,9 @@ jobs:
         run: |
           "$OBSUTIL_BIN" cp ./api/docs/index.html obs://open-read/clickvisual/api/index.html -f -r
       - name: create commit
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ github.token }}
           delete-branch: true
           commit-message: 'docs: eapi'
           title: eapi

--- a/ui-v2/src/domains/query/hooks/useQueryWorkspace.ts
+++ b/ui-v2/src/domains/query/hooks/useQueryWorkspace.ts
@@ -173,7 +173,7 @@ function createConditionFromQueryToken(token: string, index: number): QueryFilte
   if (!trimmed) {
     return null;
   }
-  const match = trimmed.match(/^(.+?)\s*(not\s+like|like|!=|=)\s*(.+)$/i);
+  const match = trimmed.match(/^(.+?)\s*(not\s+like|like|!=|>=|<=|=|>|<)\s*(.+)$/i);
   if (!match) {
     return null;
   }
@@ -205,27 +205,61 @@ function parseQueryTextConditions(query: string) {
     .filter((item): item is QueryFilterCondition => Boolean(item));
 }
 
+function parseCompleteQueryConditions(query: string) {
+  const tokens = query.split(/\s+AND\s+/i);
+  const conditions = tokens.map((item, index) => createConditionFromQueryToken(item, index));
+  return conditions.every((item): item is QueryFilterCondition => Boolean(item)) ? conditions : [];
+}
+
+function readLegacyV1ShareQuery() {
+  if (typeof window === "undefined") {
+    return "";
+  }
+  const pathname = window.location.pathname.replace(/\/+$/, "");
+  if (!pathname.endsWith("/share")) {
+    return "";
+  }
+  const params = new URLSearchParams(window.location.search);
+  const keyword = params.get("kw")?.trim() ?? "";
+  if (!keyword || parseCompleteQueryConditions(keyword).length === 0) {
+    return "";
+  }
+  const query = params.get("query")?.trim() ?? "";
+  if (query && query !== keyword) {
+    return keyword;
+  }
+  const legacyMarkers = ["index", "logState", "mode", "queryType", "tab"];
+  return legacyMarkers.some((marker) => params.has(marker)) ? keyword : "";
+}
+
 function readInitialQueryConditions() {
   if (typeof window === "undefined") {
     return [] as QueryFilterCondition[];
   }
   const params = new URLSearchParams(window.location.search);
   const query = params.get("query") ?? "";
-  if (!query.trim()) {
-    const keyword = params.get("kw")?.trim();
-    if (keyword) {
-      return [
-        {
-          id: "cond_url_kw",
-          field: GLOBAL_MATCH_FIELD,
-          operator: "like",
-          value: keyword,
-          valueType: "string"
-        }
-      ] as QueryFilterCondition[];
+  const keyword = params.get("kw")?.trim();
+  if (keyword) {
+    const legacyConditions = parseCompleteQueryConditions(keyword);
+    if (legacyConditions.length > 0) {
+      return legacyConditions;
     }
   }
-  return parseQueryTextConditions(query);
+  if (query.trim()) {
+    return parseQueryTextConditions(query);
+  }
+  if (!keyword) {
+    return [] as QueryFilterCondition[];
+  }
+  return [
+    {
+      id: "cond_url_kw",
+      field: GLOBAL_MATCH_FIELD,
+      operator: "like",
+      value: keyword,
+      valueType: "string"
+    }
+  ] as QueryFilterCondition[];
 }
 
 function writeQueryToURL(query: string) {
@@ -470,6 +504,7 @@ export function useQueryWorkspace(
   }
 ) {
   const initialConditions = useMemo(() => readInitialQueryConditions(), []);
+  const legacyV1ShareQuery = useMemo(() => readLegacyV1ShareQuery(), []);
   const [instances, setInstances] = useState<QuerySourceInstance[]>([]);
   const [databases, setDatabases] = useState<QuerySourceDatabase[]>([]);
   const [tables, setTables] = useState<QuerySourceTable[]>([]);
@@ -844,7 +879,8 @@ export function useQueryWorkspace(
       effectiveConditions,
       analysisFields
     );
-    const shouldUseStructuredRun = !effectiveQueryText.trim() && structuredConditions.length > 0;
+    const shouldUseStructuredRun =
+      !legacyV1ShareQuery && !effectiveQueryText.trim() && structuredConditions.length > 0;
     const effectivePageSize =
       overridePageSize && Number.isFinite(overridePageSize) && overridePageSize > 0
         ? Math.round(overridePageSize)
@@ -852,7 +888,7 @@ export function useQueryWorkspace(
 
     const params = {
       ...timeParams,
-      query: requestQuery,
+      query: legacyV1ShareQuery || requestQuery,
       page: nextPage,
       pageSize: effectivePageSize
     };

--- a/ui-v2/tests/query-page.test.tsx
+++ b/ui-v2/tests/query-page.test.tsx
@@ -761,6 +761,116 @@ describe("query page", () => {
     expect(runRequest).toContain('"value":"aud"');
   });
 
+  it("restores legacy v1 kw filter expressions as structured v2 conditions", async () => {
+    const defaultFetch = window.fetch;
+    const runPayloads: any[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const rawUrl = typeof input === "string" ? input : input.toString();
+        const url = new URL(rawUrl, "http://localhost");
+        if ((init?.method || "GET") === "POST" && url.pathname.endsWith("/api/v2/query/run")) {
+          runPayloads.push(JSON.parse(String(init?.body || "{}")));
+        }
+        return defaultFetch(input, init);
+      })
+    );
+    const params = new URLSearchParams({
+      tid: "9527",
+      start: "1788328607",
+      end: "1788328787",
+      kw: "`_container_name_`='svc-table' and `ucode` > '499' and `error` not like '%deadline exceeded%'"
+    });
+    window.history.replaceState({}, "", `/share?${params.toString()}`);
+
+    render(
+      <TimeRangeProvider>
+        <QueryPage shareMode />
+      </TimeRangeProvider>
+    );
+
+    await waitFor(() => {
+      expect(runPayloads.length).toBeGreaterThan(0);
+    });
+    expect(runPayloads[0].conditions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ operator: "=", value: "svc-table" }),
+        expect.objectContaining({ operator: ">", value: "499" }),
+        expect.objectContaining({ operator: "not_contains", value: "%deadline exceeded%" })
+      ])
+    );
+  });
+
+  it("uses legacy v1 logs for a share link when kw is the original filter", async () => {
+    const defaultFetch = window.fetch;
+    const requests: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const rawUrl = typeof input === "string" ? input : input.toString();
+        const url = new URL(rawUrl, "http://localhost");
+        requests.push(`${init?.method || "GET"} ${url.pathname}${url.search}`);
+        return defaultFetch(input, init);
+      })
+    );
+    const params = new URLSearchParams({
+      tid: "9527",
+      start: "1788328607",
+      end: "1788328787",
+      kw: "`_container_name_`='svc-table' and `ucode` > '499'",
+      query: "_raw_log_ like '%`_container_name_`=\\'svc-table\\'%' AND `addr` != '\\\\'/duplicateBase\\\\''"
+    });
+    window.history.replaceState({}, "", `/share?${params.toString()}`);
+
+    render(
+      <TimeRangeProvider>
+        <QueryPage shareMode />
+      </TimeRangeProvider>
+    );
+
+    await waitFor(() => {
+      expect(requests.some((item) => item.includes("GET /api/v1/tables/9527/logs"))).toBe(true);
+    });
+    expect(requests.some((item) => item.includes("POST /api/v2/query/run"))).toBe(false);
+    expect(requests.find((item) => item.includes("GET /api/v1/tables/9527/logs"))).toContain(
+      "query=%60_container_name_%60%3D%27svc-table%27+and+%60ucode%60+%3E+%27499%27"
+    );
+  });
+
+  it("recognizes the legacy v1 share shape when query is absent", async () => {
+    const defaultFetch = window.fetch;
+    const requests: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const rawUrl = typeof input === "string" ? input : input.toString();
+        const url = new URL(rawUrl, "http://localhost");
+        requests.push(`${init?.method || "GET"} ${url.pathname}${url.search}`);
+        return defaultFetch(input, init);
+      })
+    );
+    const params = new URLSearchParams({
+      tid: "9527",
+      start: "1788328607",
+      end: "1788328787",
+      kw: "`service`='gateway'",
+      queryType: "rawLog",
+      tab: "relative"
+    });
+    window.history.replaceState({}, "", `/share?${params.toString()}`);
+
+    render(
+      <TimeRangeProvider>
+        <QueryPage shareMode />
+      </TimeRangeProvider>
+    );
+
+    await waitFor(() => {
+      expect(requests.some((item) => item.includes("GET /api/v1/tables/9527/logs"))).toBe(true);
+    });
+    expect(requests.some((item) => item.includes("POST /api/v2/query/run"))).toBe(false);
+  });
+
   it("applies compact URL query conditions and last run time to top values", async () => {
     const defaultFetch = window.fetch;
     const runPayloads: any[] = [];


### PR DESCRIPTION
## Summary

- Restore legacy v1 Share filter parsing in the v2 query page.
- Route legacy Share result/detail requests through the v1 logs API while keeping normal v2 structured queries on `/api/v2/query/run`.
- Update the API docs workflow to current Node 24-compatible Actions and use explicit repository write permissions with the built-in GitHub token so automated PR creation can authenticate.

## Verification

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/docs-apis.yml`
- `npm test -- --run tests/query-page.test.tsx --testTimeout=10000` (53 passed)
- `npm run build`

The docs workflow is triggered on pushes to `master`, so its post-merge execution will validate the workflow change in GitHub Actions.
