### PR TITLE
fix(ci): allow docs workflow to create pull requests

### DIFF
--- a/.github/workflows/docs-apis.yml
+++ b/.github/workflows/docs-apis.yml
@@ -48,7 +48,7 @@ jobs:
       - name: create commit
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.RELEASE_TOKEN }}
           delete-branch: true
           commit-message: 'docs: eapi'
           title: eapi


### PR DESCRIPTION
## Summary

The `docs-apis` workflow successfully generated and pushed `create-pull-request/patch`, but failed when calling the GitHub pull request API because repository policy disallows the built-in `GITHUB_TOKEN` from creating pull requests.

Use the existing `RELEASE_TOKEN` PAT for `peter-evans/create-pull-request@v8`. The workflow keeps the explicit contents/pull-requests permissions and current Action versions.

## Verification

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/docs-apis.yml`
- `git diff --check`

This is a follow-up to #1250, which already merged the v2 Share compatibility and initial docs workflow updates.
