### PR TITLE
fix(release): build v2 assets and use workflow token

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,44 +6,71 @@ on:
       - "v**"
     branches:
       - 'fix/release'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing tag to build and publish, for example v1.1.1
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
           fetch-depth: 0
-      - name: Cache dependencies
-        uses: actions/cache@v4
+      - name: Verify release tag
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: git show-ref --verify --quiet "refs/tags/${RELEASE_TAG}"
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
         with:
-          path: ~/.yarn
-          key: yarn-${{ hashFiles('ui/yarn.lock') }}
-          restore-keys: yarn-
-      - name: yarn build dist
+          node-version: '20'
+      - name: Cache dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/yarn
+            ~/.npm
+          key: web-${{ runner.os }}-${{ hashFiles('ui/yarn.lock', 'ui-v2/package-lock.json') }}
+          restore-keys: web-${{ runner.os }}-
+      - name: Build v1 and v2 web assets
+        env:
+          NODE_OPTIONS: --max_old_space_size=8000
         run: |
           cd ui
           yarn install --frozen-lockfile
           yarn run build
           rm -rf ../api/internal/ui/dist
           cp -rf dist ../api/internal/ui
+          cd ../ui-v2
+          npm ci
+          npm run build
+          test -s ../api/internal/ui/dist/index.html
+          test -s ../api/internal/ui/v2dist/dist/index.html
+          test -n "$(find ../api/internal/ui/v2dist/dist/assets -type f -print -quit)"
       - name: Set up Go
-        uses: actions/setup-go@v5
-      - uses: actions/cache@v4
+        uses: actions/setup-go@v7
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version-file: go.mod
+          cache: true
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
-          # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
-          # 'latest', 'nightly', or a semver
-          version: '~> v2'
+          version: 'v2.18.0'
           args: release --clean --skip=validate
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- use the built-in GitHub Actions token with `contents: write` to fix the GoReleaser `401 Bad credentials` failure
- build and verify both v1 and v2 frontend assets before compiling release binaries
- add manual dispatch for rebuilding an existing tag such as `v1.1.1` and uploading assets to its existing empty Release
- update JavaScript/Go/release actions to Node 24-compatible major versions and pin GoReleaser 2.18.0

## Verification

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/publish-release.yml`
- `git diff --check`
- `npm run build -- --outDir /tmp/clickvisual-v1.1.1-v2-dist --emptyOutDir`
- verified all referenced action major tags exist

## Release follow-up

The existing `v1.1.1` GitHub Release has no assets. After this PR is merged, dispatch `publish-release` from `master` with `tag=v1.1.1` to rebuild and upload the release archives without moving the tag.